### PR TITLE
CI: run langfuse server dockerized in integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           git clone https://github.com/langfuse/langfuse.git ./langfuse-server
 
-      - name: Cache langfuse server packages
+      - name: Cache langfuse server dependencies
         uses: actions/cache@v3
         with:
           path: ./langfuse-server/node_modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,14 @@ jobs:
         run: |
           git clone https://github.com/langfuse/langfuse.git ./langfuse-server
 
+      - name: Cache langfuse server packages
+        uses: actions/cache@v3
+        with:
+          path: ./langfuse-server/node_modules
+          key: |
+            langfuse-server-${{ hashFiles('./langfuse-server/package-lock.json') }}
+            langfuse-server-
+
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,31 @@ jobs:
       LF_PUBLIC_KEY: ${{ secrets.LF_PUBLIC_KEY }}
     steps:
       - uses: actions/checkout@v3
+
+      - name: Clone langfuse server
+        run: |
+          git clone https://github.com/langfuse/langfuse.git ./langfuse-server
+
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+
+      - name: Run langfuse server
+        run: |
+          cd ./langfuse-server
+
+          echo "::group::Run langfuse server"
+          docker-compose up -d
+          echo "::endgroup::"
+
+          echo "::group::Install dependencies (necessary to run seeder)"
+          npm install
+          echo "::endgroup::"
+
+          echo "::group::Apply migrations and seed db"
+          cp .env.dev.example .env
+          npx --yes prisma migrate reset --force --skip-generate
+          echo "::endgroup::"
 
       - run: yarn install
       - run: yarn compile
@@ -58,7 +80,7 @@ jobs:
       - run: yarn lint
       - run: yarn prettier:check
   all-tests-passed:
-      # This allows us to have a branch protection rule for tests and deploys with matrix
+    # This allows us to have a branch protection rule for tests and deploys with matrix
     runs-on: ubuntu-latest
     needs: [tests, integration-test, lint]
     if: always()
@@ -69,4 +91,3 @@ jobs:
       - name: Failing deploy
         if: ${{ contains(needs.*.result, 'failure') }}
         run: exit 1
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
     timeout-minutes: 3
     runs-on: ubuntu-latest
     env:
-      LF_HOST: ${{ secrets.LF_HOST }}
-      LF_SECRET_KEY: ${{ secrets.LF_SECRET_KEY }}
-      LF_PUBLIC_KEY: ${{ secrets.LF_PUBLIC_KEY }}
+      LF_HOST: "http://localhost:3000"
+      LF_SECRET_KEY: "sk-lf-1234567890"
+      LF_PUBLIC_KEY: "pk-lf-1234567890"
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
**Context**
Currently tests depend on instance of langfuse server and require HOST, LF_PK and LF_SK environment secrets.

**Goal**
tests of the SDK should not require any secrets to enable safely running them on forks of this project (except for E2E test that use external APIs, e.g. OpenAI, Huggingface Hub)

**Potential solution**
Run dockerized langfuse (langfuse/langfuse) in CI, acc to instructions here: https://langfuse.com/docs/deployment/local