### PR TITLE
Treat node_modules as external for resulting build and move langchain to peerDependencies

### DIFF
--- a/langfuse-langchain/package.json
+++ b/langfuse-langchain/package.json
@@ -20,7 +20,7 @@
     "Readme.md"
   ],
   "gitHead": "1b8f422c3d4b0de925cabd2e5901a8c388738887",
-  "dependencies": {
+  "peerDependencies": {
     "langchain": "^0.0.157"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,18 +5,10 @@ import json from "@rollup/plugin-json";
 import typescript from "rollup-plugin-typescript2";
 import dts from "rollup-plugin-dts";
 
-import pkg from "./package.json";
-
 const extensions = [".js", ".jsx", ".ts", ".tsx"];
-
-let globalExternal = Object.keys(pkg.dependencies || {}).concat(Object.keys(pkg.peerDependencies || {}));
 
 const configs = ["langfuse", "langfuse-node", "langfuse-langchain"].reduce((acc, x) => {
   const localPkg = require(`./${x}/package.json`);
-  let external = [...globalExternal]
-    .concat(Object.keys(localPkg.dependencies || {}))
-    .concat(Object.keys(localPkg.peerDependencies || {}))
-    .concat(Object.keys(localPkg.devDependencies || {}));
 
   return [
     ...acc,
@@ -35,7 +27,7 @@ const configs = ["langfuse", "langfuse-node", "langfuse-langchain"].reduce((acc,
           format: `es`,
         },
       ],
-      external,
+      external: [/node_modules/],
       plugins: [
         // Allows node_modules resolution
         resolve({ extensions }),


### PR DESCRIPTION
## Problem

Currently langfuse(-langchain) does not correctly treat dependencies as external. See https://www.npmjs.com/package/langfuse-langchain?activeTab=code for the included files in node_modules and check the content of index.(cjs|esm).js.
This results in some issues:
* langchain upstream code is inlined. This will cause (hidden) issues when the bundled code diverges from the langchain version the including package is using. Additionally some checks won't work, like the instanceof AIMessage check in langfuse-langchain/src/callback.ts. As the passed down AIMessage from langchain will be an instance of their AIMessage class, whereas the comparision will be against the bundled in class.
* When upstream langchain types change, the langfuse-langchain callback handler won't be passable into chains anymore, as the returned handler will confirm to the bundled in types and version and not correctly inherit from the latest BaseCallbackHandler provided by langchain.

Additionally langchain should be a peerDependency so downstream can correctly use their version.

## Changes

Don't use the package.json files for defining externals in rollup, instead just treat everything in node_modules as external.
Change to peerDependency.
This will also shrink the bundled size by around 100kb.

## Caveat
I didn't test this further in my local setup/downstream package as I didn't setup project linking (yet).

## Release info Sub-libraries affected

### Bump level

- [ ] Major
- [X] Minor
- [ ] Patch

### Libraries affected


- [X] All of them
- [ ] langfuse
- [ ] langfuse-node

### Changelog notes

- Treat node_modules as external for rollup
- Move langchain to peerDependencies for langfuse-langchain
