### PR TITLE
feat(langfuse-core): add traces forwarding for Defer integration

### DIFF
--- a/langfuse-core/src/globalThis.d.ts
+++ b/langfuse-core/src/globalThis.d.ts
@@ -1,0 +1,16 @@
+export {};
+
+declare interface DeferLangFuseTrace {
+  id: string;
+  name: string;
+  url: string;
+}
+
+declare global {
+  namespace globalThis {
+    // eslint-disable-next-line no-var
+    var __deferRuntime: {
+      langfuseTraces: (traces: DeferLangFuseTrace[]) => void;
+    };
+  }
+}

--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -452,7 +452,21 @@ export abstract class LangfuseCore extends LangfuseCoreStateless {
 
   trace(body?: CreateLangfuseTraceBody): LangfuseTraceClient {
     const id = this.traceStateless(body ?? {});
-    return new LangfuseTraceClient(this, id);
+    const t = new LangfuseTraceClient(this, id);
+    if (process.env.DEFER && body) {
+      try {
+        if (globalThis.__deferRuntime) {
+          __deferRuntime.langfuseTraces([
+            {
+              id: id,
+              name: body.name || "",
+              url: t.getTraceUrl(),
+            },
+          ]);
+        }
+      } catch {}
+    }
+    return t;
   }
 
   span(body: CreateLangfuseSpanBody): LangfuseSpanClient {


### PR DESCRIPTION
This PR introduces `traces` forwarding to the Defer Runtime as part of the Defer <> Langfuse integration:

![image](https://github.com/langfuse/langfuse-js/assets/1252066/c58ef31d-0d61-4114-aa91-907cb5c853cd)
