### PR TITLE
fix(core): integration as private, change langchain peer dependency, actually require dependencies (#47)

### DIFF
--- a/integration-test/modules/package.json
+++ b/integration-test/modules/package.json
@@ -1,6 +1,7 @@
 {
   "name": "langfuse-integration-test-modules",
   "version": "2.0.0-alpha.0",
+  "private": true,
   "description": "",
   "main": "dist/main.js",
   "scripts": {

--- a/langfuse-langchain/package.json
+++ b/langfuse-langchain/package.json
@@ -33,6 +33,10 @@
     "Readme.md"
   ],
   "gitHead": "1b8f422c3d4b0de925cabd2e5901a8c388738887",
+  "dependencies": {
+    "langfuse-core": "^2.0.0-alpha.0",
+    "langfuse": "^2.0.0-alpha.0"
+  },
   "peerDependencies": {
     "langchain": ">=0.0.157"
   },

--- a/langfuse-langchain/package.json
+++ b/langfuse-langchain/package.json
@@ -38,7 +38,7 @@
     "langfuse": "^2.0.0-alpha.0"
   },
   "peerDependencies": {
-    "langchain": ">=0.0.157"
+    "langchain": ">=0.0.157 <0.1.0"
   },
   "devDependencies": {
     "cheerio": "^1.0.0-rc.12"

--- a/langfuse-langchain/package.json
+++ b/langfuse-langchain/package.json
@@ -34,7 +34,7 @@
   ],
   "gitHead": "1b8f422c3d4b0de925cabd2e5901a8c388738887",
   "peerDependencies": {
-    "langchain": "^0.0.157"
+    "langchain": ">=0.0.157"
   },
   "devDependencies": {
     "cheerio": "^1.0.0-rc.12"

--- a/langfuse-node/package.json
+++ b/langfuse-node/package.json
@@ -27,7 +27,8 @@
     }
   },
   "dependencies": {
-    "axios": "^1.4.0"
+    "axios": "^1.4.0",
+    "langfuse-core": "^2.0.0-alpha.0"
   },
   "devDependencies": {
     "@types/node": "^20.4.10",

--- a/langfuse/package.json
+++ b/langfuse/package.json
@@ -31,5 +31,8 @@
     "lib",
     "Readme.md"
   ],
+  "dependencies": {
+    "langfuse-core": "^2.0.0-alpha.0"
+  },
   "gitHead": "1b8f422c3d4b0de925cabd2e5901a8c388738887"
 }


### PR DESCRIPTION
## Problem

Currently the integration test package isn't marked as private and would be uploaded.

We also need to change the langchain peer dependency from ^ to >=.
The caret (^) in the version number ^0.0.186 in the package.json file means that npm can update to any minor or patch versions greater than 0.0.186. However, for versions below 1.0.0, the caret (^) only allows patch-level changes, changing to >= will fix that. 
We also limit to <0.1.0 to re-adjust strategy when a more stable langchain version releases.

Additionally we 'actually' need to require the dependencies now.

### Bump level

- [ ] Major
- [ ] Minor
- [x] Patch
