### PR TITLE
fix direct process access in getCommonReleaseEnvs

### DIFF
--- a/langfuse-core/src/release-env.ts
+++ b/langfuse-core/src/release-env.ts
@@ -1,3 +1,5 @@
+import { getEnv } from "./utils";
+
 const common_release_envs = [
   // Vercel
   "VERCEL_GIT_COMMIT_SHA",
@@ -19,9 +21,10 @@ const common_release_envs = [
 ] as const;
 
 export function getCommonReleaseEnvs(): string | undefined {
-  for (const env of common_release_envs) {
-    if (process.env[env]) {
-      return process.env[env];
+  for (const key of common_release_envs) {
+    const value = getEnv(key);
+    if (value) {
+      return value;
     }
   }
   return undefined;


### PR DESCRIPTION
## Problem

process.env is directly accessed which is an issue on edge workers.

## Changes

Instead use the getEnv utility function.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them
- [ ] langfuse
- [ ] langfuse-node

### Changelog notes

Don't access process.env anymore on edge workers.
