### PR TITLE
refactor(test): remove redundancy while mentioning keys

### DIFF
--- a/integration-test/integration-utils.ts
+++ b/integration-test/integration-utils.ts
@@ -6,6 +6,12 @@ export const LF_HOST = process.env.LF_HOST ?? "http://localhost:3000";
 export const LF_PUBLIC_KEY = process.env.LF_PUBLIC_KEY ?? "pk-lf-1234567890";
 export const LF_SECRET_KEY = process.env.LF_SECRET_KEY ?? "sk-lf-1234567890";
 
+export const getKeys = {
+  publicKey: LF_PUBLIC_KEY,
+  secretKey: LF_SECRET_KEY,
+  baseUrl: LF_HOST,
+};
+
 export const getHeaders = {
   Authorization: "Basic " + Buffer.from(`${LF_PUBLIC_KEY}:${LF_SECRET_KEY}`).toString("base64"),
 };

--- a/integration-test/integration-utils.ts
+++ b/integration-test/integration-utils.ts
@@ -6,11 +6,11 @@ export const LF_HOST = process.env.LF_HOST ?? "http://localhost:3000";
 export const LF_PUBLIC_KEY = process.env.LF_PUBLIC_KEY ?? "pk-lf-1234567890";
 export const LF_SECRET_KEY = process.env.LF_SECRET_KEY ?? "sk-lf-1234567890";
 
-export const getKeys = {
+export const getKeys = (): { publicKey: string; secretKey: string; baseUrl: string } => ({
   publicKey: LF_PUBLIC_KEY,
   secretKey: LF_SECRET_KEY,
   baseUrl: LF_HOST,
-};
+});
 
 export const getHeaders = {
   Authorization: "Basic " + Buffer.from(`${LF_PUBLIC_KEY}:${LF_SECRET_KEY}`).toString("base64"),

--- a/integration-test/langfuse-integration-datasets.spec.ts
+++ b/integration-test/langfuse-integration-datasets.spec.ts
@@ -9,7 +9,8 @@ describe("Langfuse Node.js", () => {
   jest.useRealTimers();
 
   beforeEach(() => {
-    langfuse = new Langfuse(getKeys);
+    const keys = getKeys();
+    langfuse = new Langfuse(keys);
     langfuse.debug(true);
   });
 

--- a/integration-test/langfuse-integration-datasets.spec.ts
+++ b/integration-test/langfuse-integration-datasets.spec.ts
@@ -1,9 +1,7 @@
 // uses the compiled node.js version, run yarn build after making changes to the SDKs
 import Langfuse from "../langfuse-node";
 
-const LF_HOST = process.env.LF_HOST ?? "http://localhost:3000";
-const LF_PUBLIC_KEY = process.env.LF_PUBLIC_KEY ?? "pk-lf-1234567890";
-const LF_SECRET_KEY = process.env.LF_SECRET_KEY ?? "sk-lf-1234567890";
+import { getKeys } from "./integration-utils";
 
 describe("Langfuse Node.js", () => {
   let langfuse: Langfuse;
@@ -11,11 +9,7 @@ describe("Langfuse Node.js", () => {
   jest.useRealTimers();
 
   beforeEach(() => {
-    langfuse = new Langfuse({
-      publicKey: LF_PUBLIC_KEY,
-      secretKey: LF_SECRET_KEY,
-      baseUrl: LF_HOST,
-    });
+    langfuse = new Langfuse(getKeys);
     langfuse.debug(true);
   });
 

--- a/integration-test/langfuse-integration-fetch.spec.ts
+++ b/integration-test/langfuse-integration-fetch.spec.ts
@@ -11,7 +11,7 @@ describe("Langfuse (fetch)", () => {
 
   beforeEach(() => {
     langfuse = new Langfuse({
-      ...getKeys,
+      ...getKeys(),
       flushAt: 100,
       fetchRetryDelay: 100,
       fetchRetryCount: 3,
@@ -27,7 +27,7 @@ describe("Langfuse (fetch)", () => {
   describe("core methods", () => {
     it("check health of langfuse server", async () => {
       const res = await axios
-        .get(getKeys.baseUrl + "/api/public/health", { headers: getHeaders })
+        .get(getKeys().baseUrl + "/api/public/health", { headers: getHeaders })
         .then((res) => res.data)
         .catch((err) => console.log(err));
       expect(res).toMatchObject({ status: "OK" });
@@ -42,7 +42,7 @@ describe("Langfuse (fetch)", () => {
       });
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/traces/${trace.id}`, {
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/traces/${trace.id}`, {
         headers: getHeaders,
       });
       expect(res.data).toMatchObject({
@@ -63,7 +63,7 @@ describe("Langfuse (fetch)", () => {
       });
       await langfuse.flushAsync();
 
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/traces/${trace.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/traces/${trace.id}`, { headers: getHeaders });
 
       expect(res.data).toMatchObject({
         id: trace.id,
@@ -80,7 +80,7 @@ describe("Langfuse (fetch)", () => {
       });
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${span.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/observations/${span.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: span.id,
         name: "span-name",
@@ -119,7 +119,7 @@ describe("Langfuse (fetch)", () => {
       span.end();
       await langfuse.flushAsync();
 
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${span.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/observations/${span.id}`, { headers: getHeaders });
 
       expect(res.data).toMatchObject({
         id: span.id,
@@ -138,7 +138,7 @@ describe("Langfuse (fetch)", () => {
       const generation = trace.generation({ name: "generation-name-new" });
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: generation.id,
         name: "generation-name-new",
@@ -160,7 +160,7 @@ describe("Langfuse (fetch)", () => {
 
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: generation.id,
         name: "generation-name-new",
@@ -191,7 +191,7 @@ describe("Langfuse (fetch)", () => {
       });
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: generation.id,
         name: "generation-name-new",
@@ -218,7 +218,7 @@ describe("Langfuse (fetch)", () => {
       });
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: generation.id,
         name: "generation-name-new",
@@ -246,7 +246,7 @@ describe("Langfuse (fetch)", () => {
 
       await langfuse.flushAsync();
 
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
 
       expect(res.data).toMatchObject({
         id: generation.id,
@@ -266,7 +266,7 @@ describe("Langfuse (fetch)", () => {
       await langfuse.flushAsync();
 
       // check from get api if trace is created
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${event.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/observations/${event.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: event.id,
         name: "event-name",
@@ -279,7 +279,7 @@ describe("Langfuse (fetch)", () => {
       await langfuse.flushAsync();
 
       // check from get api if trace is created
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${event.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/observations/${event.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: event.id,
         name: "event-name",

--- a/integration-test/langfuse-integration-fetch.spec.ts
+++ b/integration-test/langfuse-integration-fetch.spec.ts
@@ -2,7 +2,7 @@
 import Langfuse from "../langfuse";
 
 import axios from "axios";
-import { LF_HOST, LF_PUBLIC_KEY, LF_SECRET_KEY, getHeaders } from "./integration-utils";
+import { getKeys, getHeaders } from "./integration-utils";
 
 describe("Langfuse (fetch)", () => {
   let langfuse: Langfuse;
@@ -11,9 +11,7 @@ describe("Langfuse (fetch)", () => {
 
   beforeEach(() => {
     langfuse = new Langfuse({
-      publicKey: LF_PUBLIC_KEY,
-      secretKey: LF_SECRET_KEY,
-      baseUrl: LF_HOST,
+      ...getKeys,
       flushAt: 100,
       fetchRetryDelay: 100,
       fetchRetryCount: 3,
@@ -29,7 +27,7 @@ describe("Langfuse (fetch)", () => {
   describe("core methods", () => {
     it("check health of langfuse server", async () => {
       const res = await axios
-        .get(LF_HOST + "/api/public/health", { headers: getHeaders })
+        .get(getKeys.baseUrl + "/api/public/health", { headers: getHeaders })
         .then((res) => res.data)
         .catch((err) => console.log(err));
       expect(res).toMatchObject({ status: "OK" });
@@ -44,7 +42,7 @@ describe("Langfuse (fetch)", () => {
       });
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${LF_HOST}/api/public/traces/${trace.id}`, {
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/traces/${trace.id}`, {
         headers: getHeaders,
       });
       expect(res.data).toMatchObject({
@@ -65,7 +63,7 @@ describe("Langfuse (fetch)", () => {
       });
       await langfuse.flushAsync();
 
-      const res = await axios.get(`${LF_HOST}/api/public/traces/${trace.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/traces/${trace.id}`, { headers: getHeaders });
 
       expect(res.data).toMatchObject({
         id: trace.id,
@@ -82,7 +80,7 @@ describe("Langfuse (fetch)", () => {
       });
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${LF_HOST}/api/public/observations/${span.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${span.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: span.id,
         name: "span-name",
@@ -121,7 +119,7 @@ describe("Langfuse (fetch)", () => {
       span.end();
       await langfuse.flushAsync();
 
-      const res = await axios.get(`${LF_HOST}/api/public/observations/${span.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${span.id}`, { headers: getHeaders });
 
       expect(res.data).toMatchObject({
         id: span.id,
@@ -140,7 +138,7 @@ describe("Langfuse (fetch)", () => {
       const generation = trace.generation({ name: "generation-name-new" });
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${LF_HOST}/api/public/observations/${generation.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: generation.id,
         name: "generation-name-new",
@@ -162,7 +160,7 @@ describe("Langfuse (fetch)", () => {
 
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${LF_HOST}/api/public/observations/${generation.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: generation.id,
         name: "generation-name-new",
@@ -193,7 +191,7 @@ describe("Langfuse (fetch)", () => {
       });
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${LF_HOST}/api/public/observations/${generation.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: generation.id,
         name: "generation-name-new",
@@ -220,7 +218,7 @@ describe("Langfuse (fetch)", () => {
       });
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${LF_HOST}/api/public/observations/${generation.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: generation.id,
         name: "generation-name-new",
@@ -248,7 +246,7 @@ describe("Langfuse (fetch)", () => {
 
       await langfuse.flushAsync();
 
-      const res = await axios.get(`${LF_HOST}/api/public/observations/${generation.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
 
       expect(res.data).toMatchObject({
         id: generation.id,
@@ -268,7 +266,7 @@ describe("Langfuse (fetch)", () => {
       await langfuse.flushAsync();
 
       // check from get api if trace is created
-      const res = await axios.get(`${LF_HOST}/api/public/observations/${event.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${event.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: event.id,
         name: "event-name",
@@ -281,7 +279,7 @@ describe("Langfuse (fetch)", () => {
       await langfuse.flushAsync();
 
       // check from get api if trace is created
-      const res = await axios.get(`${LF_HOST}/api/public/observations/${event.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${event.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: event.id,
         name: "event-name",

--- a/integration-test/langfuse-integration-langchain.spec.ts
+++ b/integration-test/langfuse-integration-langchain.spec.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 
 import { Langfuse, CallbackHandler } from "../langfuse-langchain";
 
-import { LF_HOST, LF_PUBLIC_KEY, LF_SECRET_KEY, getTraces } from "./integration-utils";
+import { getKeys, getTraces } from "./integration-utils";
 
 describe("simple chains", () => {
   jest.setTimeout(30_000);
@@ -18,9 +18,7 @@ describe("simple chains", () => {
 
   it("should execute simple llm call", async () => {
     const handler = new CallbackHandler({
-      publicKey: LF_PUBLIC_KEY,
-      secretKey: LF_SECRET_KEY,
-      baseUrl: LF_HOST,
+      ...getKeys,
       sessionId: "test-session",
     });
     const llm = new OpenAI({ streaming: true });
@@ -51,9 +49,7 @@ describe("simple chains", () => {
 
   it("should execute simple llm call (debug)", async () => {
     const handler = new CallbackHandler({
-      publicKey: LF_PUBLIC_KEY,
-      secretKey: LF_SECRET_KEY,
-      baseUrl: LF_HOST,
+      ...getKeys,
       sessionId: "test-session",
     });
     handler.debug(true);
@@ -85,9 +81,7 @@ describe("simple chains", () => {
 
   it("should execute simple llm call twice on two different traces", async () => {
     const handler = new CallbackHandler({
-      publicKey: LF_PUBLIC_KEY,
-      secretKey: LF_SECRET_KEY,
-      baseUrl: LF_HOST,
+      ...getKeys,
       sessionId: "test-session",
     });
     const llm = new OpenAI({ streaming: true });
@@ -112,11 +106,7 @@ describe("simple chains", () => {
   });
 
   it.each([["OpenAI"], ["ChatOpenAI"]])("should execute llm chain with '%s' ", async (llm: string) => {
-    const handler = new CallbackHandler({
-      publicKey: LF_PUBLIC_KEY,
-      secretKey: LF_SECRET_KEY,
-      baseUrl: LF_HOST,
-    });
+    const handler = new CallbackHandler(getKeys);
     const model = (): OpenAI | ChatOpenAI | ChatAnthropic => {
       if (llm === "OpenAI") {
         return new OpenAI({ temperature: 0 });
@@ -187,9 +177,7 @@ describe("simple chains", () => {
 
   it("conversation chain should pass", async () => {
     const handler = new CallbackHandler({
-      publicKey: LF_PUBLIC_KEY,
-      secretKey: LF_SECRET_KEY,
-      baseUrl: LF_HOST,
+      ...getKeys,
       sessionId: "test-session",
     });
     const model = new OpenAI({});
@@ -210,11 +198,7 @@ describe("simple chains", () => {
   });
 
   it("should trace agents", async () => {
-    const handler = new CallbackHandler({
-      publicKey: LF_PUBLIC_KEY,
-      secretKey: LF_SECRET_KEY,
-      baseUrl: LF_HOST,
-    });
+    const handler = new CallbackHandler(getKeys);
 
     const model = new OpenAI({ temperature: 0 });
     // A tool is a function that performs a specific duty
@@ -236,7 +220,7 @@ describe("simple chains", () => {
   });
 
   it("function calls", async () => {
-    const callback = new CallbackHandler({ publicKey: LF_PUBLIC_KEY, secretKey: LF_SECRET_KEY, baseUrl: LF_HOST });
+    const callback = new CallbackHandler(getKeys);
 
     const zodSchema = z.object({
       "person-name": z.string().optional(),
@@ -268,7 +252,7 @@ describe("simple chains", () => {
   });
 
   it("create trace for callback", async () => {
-    const langfuse = new Langfuse({ publicKey: LF_PUBLIC_KEY, secretKey: LF_SECRET_KEY, baseUrl: LF_HOST });
+    const langfuse = new Langfuse(getKeys);
 
     const trace = langfuse.trace({ name: "test-123" });
 
@@ -291,7 +275,7 @@ describe("simple chains", () => {
   });
 
   it("create span for callback", async () => {
-    const langfuse = new Langfuse({ publicKey: LF_PUBLIC_KEY, secretKey: LF_SECRET_KEY, baseUrl: LF_HOST });
+    const langfuse = new Langfuse(getKeys);
 
     const trace = langfuse.trace({ name: "test-trace" });
     const span = trace.span({ name: "test-span" });

--- a/integration-test/langfuse-integration-langchain.spec.ts
+++ b/integration-test/langfuse-integration-langchain.spec.ts
@@ -18,7 +18,7 @@ describe("simple chains", () => {
 
   it("should execute simple llm call", async () => {
     const handler = new CallbackHandler({
-      ...getKeys,
+      ...getKeys(),
       sessionId: "test-session",
     });
     const llm = new OpenAI({ streaming: true });
@@ -49,7 +49,7 @@ describe("simple chains", () => {
 
   it("should execute simple llm call (debug)", async () => {
     const handler = new CallbackHandler({
-      ...getKeys,
+      ...getKeys(),
       sessionId: "test-session",
     });
     handler.debug(true);
@@ -81,7 +81,7 @@ describe("simple chains", () => {
 
   it("should execute simple llm call twice on two different traces", async () => {
     const handler = new CallbackHandler({
-      ...getKeys,
+      ...getKeys(),
       sessionId: "test-session",
     });
     const llm = new OpenAI({ streaming: true });
@@ -106,7 +106,7 @@ describe("simple chains", () => {
   });
 
   it.each([["OpenAI"], ["ChatOpenAI"]])("should execute llm chain with '%s' ", async (llm: string) => {
-    const handler = new CallbackHandler(getKeys);
+    const handler = new CallbackHandler(getKeys());
     const model = (): OpenAI | ChatOpenAI | ChatAnthropic => {
       if (llm === "OpenAI") {
         return new OpenAI({ temperature: 0 });
@@ -177,7 +177,7 @@ describe("simple chains", () => {
 
   it("conversation chain should pass", async () => {
     const handler = new CallbackHandler({
-      ...getKeys,
+      ...getKeys(),
       sessionId: "test-session",
     });
     const model = new OpenAI({});
@@ -198,7 +198,7 @@ describe("simple chains", () => {
   });
 
   it("should trace agents", async () => {
-    const handler = new CallbackHandler(getKeys);
+    const handler = new CallbackHandler(getKeys());
 
     const model = new OpenAI({ temperature: 0 });
     // A tool is a function that performs a specific duty
@@ -220,7 +220,7 @@ describe("simple chains", () => {
   });
 
   it("function calls", async () => {
-    const callback = new CallbackHandler(getKeys);
+    const callback = new CallbackHandler(getKeys());
 
     const zodSchema = z.object({
       "person-name": z.string().optional(),
@@ -252,7 +252,7 @@ describe("simple chains", () => {
   });
 
   it("create trace for callback", async () => {
-    const langfuse = new Langfuse(getKeys);
+    const langfuse = new Langfuse(getKeys());
 
     const trace = langfuse.trace({ name: "test-123" });
 
@@ -275,7 +275,7 @@ describe("simple chains", () => {
   });
 
   it("create span for callback", async () => {
-    const langfuse = new Langfuse(getKeys);
+    const langfuse = new Langfuse(getKeys());
 
     const trace = langfuse.trace({ name: "test-trace" });
     const span = trace.span({ name: "test-span" });

--- a/integration-test/langfuse-integration-langfuse.spec.ts
+++ b/integration-test/langfuse-integration-langfuse.spec.ts
@@ -7,7 +7,7 @@ import { getKeys } from "./integration-utils";
 describe("Langfuse Langchain", () => {
   describe("core", () => {
     it("exports the Langfuse SDK", () => {
-      const langfuse = new Langfuse(getKeys);
+      const langfuse = new Langfuse(getKeys());
       expect(langfuse).toBeInstanceOf(Langfuse);
     });
   });

--- a/integration-test/langfuse-integration-langfuse.spec.ts
+++ b/integration-test/langfuse-integration-langfuse.spec.ts
@@ -2,18 +2,12 @@
 
 import { Langfuse } from "../langfuse-langchain";
 
-const LF_HOST = process.env.LF_HOST ?? "http://localhost:3000";
-const LF_PUBLIC_KEY = process.env.LF_PUBLIC_KEY ?? "pk-lf-1234567890";
-const LF_SECRET_KEY = process.env.LF_SECRET_KEY ?? "sk-lf-1234567890";
+import { getKeys } from "./integration-utils";
 
 describe("Langfuse Langchain", () => {
   describe("core", () => {
     it("exports the Langfuse SDK", () => {
-      const langfuse = new Langfuse({
-        publicKey: LF_PUBLIC_KEY,
-        secretKey: LF_SECRET_KEY,
-        baseUrl: LF_HOST,
-      });
+      const langfuse = new Langfuse(getKeys);
       expect(langfuse).toBeInstanceOf(Langfuse);
     });
   });

--- a/integration-test/langfuse-integration-node.spec.ts
+++ b/integration-test/langfuse-integration-node.spec.ts
@@ -4,12 +4,10 @@ import Langfuse from "../langfuse-node";
 // import { wait } from '../langfuse-core/test/test-utils/test-utils'
 import axios from "axios";
 
-const LF_HOST = process.env.LF_HOST ?? "http://localhost:3000";
-const LF_PUBLIC_KEY = process.env.LF_PUBLIC_KEY ?? "pk-lf-1234567890";
-const LF_SECRET_KEY = process.env.LF_SECRET_KEY ?? "sk-lf-1234567890";
+import { getKeys } from "./integration-utils";
 
 const getHeaders = {
-  Authorization: "Basic " + Buffer.from(`${LF_PUBLIC_KEY}:${LF_SECRET_KEY}`).toString("base64"),
+  Authorization: "Basic " + Buffer.from(`${getKeys.publicKey}:${getKeys.secretKey}`).toString("base64"),
 };
 
 describe("Langfuse Node.js", () => {
@@ -19,9 +17,7 @@ describe("Langfuse Node.js", () => {
 
   beforeEach(() => {
     langfuse = new Langfuse({
-      publicKey: LF_PUBLIC_KEY,
-      secretKey: LF_SECRET_KEY,
-      baseUrl: LF_HOST,
+      ...getKeys,
       flushAt: 100,
       fetchRetryDelay: 100,
       fetchRetryCount: 3,
@@ -37,7 +33,7 @@ describe("Langfuse Node.js", () => {
   describe("core methods", () => {
     it("check health of langfuse server", async () => {
       const res = await axios
-        .get(LF_HOST + "/api/public/health", { headers: getHeaders })
+        .get(getKeys.baseUrl + "/api/public/health", { headers: getHeaders })
         .then((res) => res.data)
         .catch((err) => console.log(err));
       expect(res).toMatchObject({ status: "OK" });
@@ -47,7 +43,7 @@ describe("Langfuse Node.js", () => {
       const trace = langfuse.trace({ name: "trace-name", tags: ["tag1", "tag2"] });
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${LF_HOST}/api/public/traces/${trace.id}`, {
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/traces/${trace.id}`, {
         headers: getHeaders,
       });
       expect(res.data).toMatchObject({ id: trace.id, name: "trace-name", tags: ["tag1", "tag2"] });
@@ -62,7 +58,7 @@ describe("Langfuse Node.js", () => {
       });
       await langfuse.flushAsync();
 
-      const res = await axios.get(`${LF_HOST}/api/public/traces/${trace.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/traces/${trace.id}`, { headers: getHeaders });
 
       expect(res.data).toMatchObject({
         id: trace.id,
@@ -79,7 +75,7 @@ describe("Langfuse Node.js", () => {
       });
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${LF_HOST}/api/public/observations/${span.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${span.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: span.id,
         name: "span-name",
@@ -116,7 +112,7 @@ describe("Langfuse Node.js", () => {
       span.end();
       await langfuse.flushAsync();
 
-      const res = await axios.get(`${LF_HOST}/api/public/observations/${span.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${span.id}`, { headers: getHeaders });
 
       expect(res.data).toMatchObject({
         id: span.id,
@@ -143,7 +139,7 @@ describe("Langfuse Node.js", () => {
 
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${LF_HOST}/api/public/observations/${generation.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: generation.id,
         name: "generation-name-new",
@@ -174,7 +170,7 @@ describe("Langfuse Node.js", () => {
       });
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${LF_HOST}/api/public/observations/${generation.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: generation.id,
         name: "generation-name-new",
@@ -201,7 +197,7 @@ describe("Langfuse Node.js", () => {
       });
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${LF_HOST}/api/public/observations/${generation.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: generation.id,
         name: "generation-name-new",
@@ -231,7 +227,7 @@ describe("Langfuse Node.js", () => {
 
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const returnedGeneration = await axios.get(`${LF_HOST}/api/public/observations/${generation.id}`, {
+      const returnedGeneration = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, {
         headers: getHeaders,
       });
       expect(returnedGeneration.data).toMatchObject({
@@ -247,7 +243,7 @@ describe("Langfuse Node.js", () => {
         },
       });
 
-      const returnedSpan = await axios.get(`${LF_HOST}/api/public/observations/${span.id}`, {
+      const returnedSpan = await axios.get(`${getKeys.baseUrl}/api/public/observations/${span.id}`, {
         headers: getHeaders,
       });
       expect(returnedSpan.data).toMatchObject({
@@ -281,7 +277,7 @@ describe("Langfuse Node.js", () => {
 
       await langfuse.flushAsync();
 
-      const res = await axios.get(`${LF_HOST}/api/public/observations/${generation.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
 
       expect(res.data).toMatchObject({
         id: generation.id,
@@ -302,7 +298,7 @@ describe("Langfuse Node.js", () => {
       await langfuse.flushAsync();
 
       // check from get api if trace is created
-      const res = await axios.get(`${LF_HOST}/api/public/observations/${event.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${event.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: event.id,
         name: "event-name",
@@ -315,7 +311,7 @@ describe("Langfuse Node.js", () => {
       await langfuse.flushAsync();
 
       // check from get api if trace is created
-      const res = await axios.get(`${LF_HOST}/api/public/observations/${event.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${event.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: event.id,
         name: "event-name",
@@ -340,7 +336,7 @@ describe("Langfuse Node.js", () => {
       expect(prompt.prompt).toEqual("This is a prompt with a {{variable}}");
       expect(prompt.version).toEqual(1);
 
-      const res = await axios.get(`${LF_HOST}/api/public/prompts/?name=test-prompt`, {
+      const res = await axios.get(`${getKeys.baseUrl}/api/public/prompts/?name=test-prompt`, {
         headers: getHeaders,
       });
 
@@ -372,7 +368,7 @@ describe("Langfuse Node.js", () => {
 
     await langfuse.flushAsync();
 
-    const res = await axios.get(`${LF_HOST}/api/public/prompts/?name=test-prompt`, {
+    const res = await axios.get(`${getKeys.baseUrl}/api/public/prompts/?name=test-prompt`, {
       headers: getHeaders,
     });
 
@@ -384,7 +380,7 @@ describe("Langfuse Node.js", () => {
     });
     console.log("post prompt", generation.id);
 
-    const observation = await axios.get(`${LF_HOST}/api/public/observations/${generation.id}`, {
+    const observation = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, {
       headers: getHeaders,
     });
 
@@ -413,7 +409,7 @@ describe("Langfuse Node.js", () => {
 
     expect(filledPrompt).toEqual("This is a prompt with a 1.0.0");
 
-    const res = await axios.get(`${LF_HOST}/api/public/prompts/?name=test-prompt`, {
+    const res = await axios.get(`${getKeys.baseUrl}/api/public/prompts/?name=test-prompt`, {
       headers: getHeaders,
     });
     expect(res.data).toMatchObject({});

--- a/integration-test/langfuse-integration-node.spec.ts
+++ b/integration-test/langfuse-integration-node.spec.ts
@@ -7,7 +7,7 @@ import axios from "axios";
 import { getKeys } from "./integration-utils";
 
 const getHeaders = {
-  Authorization: "Basic " + Buffer.from(`${getKeys.publicKey}:${getKeys.secretKey}`).toString("base64"),
+  Authorization: "Basic " + Buffer.from(`${getKeys().publicKey}:${getKeys().secretKey}`).toString("base64"),
 };
 
 describe("Langfuse Node.js", () => {
@@ -17,7 +17,7 @@ describe("Langfuse Node.js", () => {
 
   beforeEach(() => {
     langfuse = new Langfuse({
-      ...getKeys,
+      ...getKeys(),
       flushAt: 100,
       fetchRetryDelay: 100,
       fetchRetryCount: 3,
@@ -33,7 +33,7 @@ describe("Langfuse Node.js", () => {
   describe("core methods", () => {
     it("check health of langfuse server", async () => {
       const res = await axios
-        .get(getKeys.baseUrl + "/api/public/health", { headers: getHeaders })
+        .get(getKeys().baseUrl + "/api/public/health", { headers: getHeaders })
         .then((res) => res.data)
         .catch((err) => console.log(err));
       expect(res).toMatchObject({ status: "OK" });
@@ -43,7 +43,7 @@ describe("Langfuse Node.js", () => {
       const trace = langfuse.trace({ name: "trace-name", tags: ["tag1", "tag2"] });
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/traces/${trace.id}`, {
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/traces/${trace.id}`, {
         headers: getHeaders,
       });
       expect(res.data).toMatchObject({ id: trace.id, name: "trace-name", tags: ["tag1", "tag2"] });
@@ -58,7 +58,7 @@ describe("Langfuse Node.js", () => {
       });
       await langfuse.flushAsync();
 
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/traces/${trace.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/traces/${trace.id}`, { headers: getHeaders });
 
       expect(res.data).toMatchObject({
         id: trace.id,
@@ -75,7 +75,7 @@ describe("Langfuse Node.js", () => {
       });
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${span.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/observations/${span.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: span.id,
         name: "span-name",
@@ -112,7 +112,7 @@ describe("Langfuse Node.js", () => {
       span.end();
       await langfuse.flushAsync();
 
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${span.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/observations/${span.id}`, { headers: getHeaders });
 
       expect(res.data).toMatchObject({
         id: span.id,
@@ -139,7 +139,7 @@ describe("Langfuse Node.js", () => {
 
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: generation.id,
         name: "generation-name-new",
@@ -170,7 +170,7 @@ describe("Langfuse Node.js", () => {
       });
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: generation.id,
         name: "generation-name-new",
@@ -197,7 +197,7 @@ describe("Langfuse Node.js", () => {
       });
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: generation.id,
         name: "generation-name-new",
@@ -227,7 +227,7 @@ describe("Langfuse Node.js", () => {
 
       await langfuse.flushAsync();
       // check from get api if trace is created
-      const returnedGeneration = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, {
+      const returnedGeneration = await axios.get(`${getKeys().baseUrl}/api/public/observations/${generation.id}`, {
         headers: getHeaders,
       });
       expect(returnedGeneration.data).toMatchObject({
@@ -243,7 +243,7 @@ describe("Langfuse Node.js", () => {
         },
       });
 
-      const returnedSpan = await axios.get(`${getKeys.baseUrl}/api/public/observations/${span.id}`, {
+      const returnedSpan = await axios.get(`${getKeys().baseUrl}/api/public/observations/${span.id}`, {
         headers: getHeaders,
       });
       expect(returnedSpan.data).toMatchObject({
@@ -277,7 +277,7 @@ describe("Langfuse Node.js", () => {
 
       await langfuse.flushAsync();
 
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/observations/${generation.id}`, { headers: getHeaders });
 
       expect(res.data).toMatchObject({
         id: generation.id,
@@ -298,7 +298,7 @@ describe("Langfuse Node.js", () => {
       await langfuse.flushAsync();
 
       // check from get api if trace is created
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${event.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/observations/${event.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: event.id,
         name: "event-name",
@@ -311,7 +311,7 @@ describe("Langfuse Node.js", () => {
       await langfuse.flushAsync();
 
       // check from get api if trace is created
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/observations/${event.id}`, { headers: getHeaders });
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/observations/${event.id}`, { headers: getHeaders });
       expect(res.data).toMatchObject({
         id: event.id,
         name: "event-name",
@@ -336,7 +336,7 @@ describe("Langfuse Node.js", () => {
       expect(prompt.prompt).toEqual("This is a prompt with a {{variable}}");
       expect(prompt.version).toEqual(1);
 
-      const res = await axios.get(`${getKeys.baseUrl}/api/public/prompts/?name=test-prompt`, {
+      const res = await axios.get(`${getKeys().baseUrl}/api/public/prompts/?name=test-prompt`, {
         headers: getHeaders,
       });
 
@@ -368,7 +368,7 @@ describe("Langfuse Node.js", () => {
 
     await langfuse.flushAsync();
 
-    const res = await axios.get(`${getKeys.baseUrl}/api/public/prompts/?name=test-prompt`, {
+    const res = await axios.get(`${getKeys().baseUrl}/api/public/prompts/?name=test-prompt`, {
       headers: getHeaders,
     });
 
@@ -380,7 +380,7 @@ describe("Langfuse Node.js", () => {
     });
     console.log("post prompt", generation.id);
 
-    const observation = await axios.get(`${getKeys.baseUrl}/api/public/observations/${generation.id}`, {
+    const observation = await axios.get(`${getKeys().baseUrl}/api/public/observations/${generation.id}`, {
       headers: getHeaders,
     });
 
@@ -409,7 +409,7 @@ describe("Langfuse Node.js", () => {
 
     expect(filledPrompt).toEqual("This is a prompt with a 1.0.0");
 
-    const res = await axios.get(`${getKeys.baseUrl}/api/public/prompts/?name=test-prompt`, {
+    const res = await axios.get(`${getKeys().baseUrl}/api/public/prompts/?name=test-prompt`, {
       headers: getHeaders,
     });
     expect(res.data).toMatchObject({});


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Not a breaking change, Lots of redundant code in integration-tests

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->
Removed redundant calling of public, secret keys and host URL by creating a single block of data to mention these keys

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them
- [ ] langfuse
- [ ] langfuse-node

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- NA
