### PR TITLE
chore: remove unnecessary console.log

### DIFF
--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -298,8 +298,6 @@ abstract class LangfuseCoreStateless {
 
   async getPromptStateless(name: string, version?: number): Promise<GetLangfusePromptResponse> {
     const url = `${this.baseUrl}/api/public/prompts/?name=${name}` + (version ? `&version=${version}` : "");
-    console.log(url);
-
     return this.fetch(url, this.getFetchOptions({ method: "GET" })).then((res) => res.json());
   }
 


### PR DESCRIPTION
## Problem

API URL is logged to console every time when calling `getPrompt()`.

## Changes

Removed the unnecessary console.log call.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them
- [ ] langfuse
- [ ] langfuse-node

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Removed API URL logging when calling getPrompt()
