### PR TITLE
`langfuse-langchain`: use run names as trace names

### DIFF
--- a/langfuse-langchain/src/callback.ts
+++ b/langfuse-langchain/src/callback.ts
@@ -114,7 +114,9 @@ export class CallbackHandler extends BaseCallbackHandler {
     runId: string,
     parentRunId?: string | undefined,
     tags?: string[] | undefined,
-    metadata?: Record<string, unknown> | undefined
+    metadata?: Record<string, unknown> | undefined,
+    runType?: string
+    name?: string
   ): Promise<void> {
     try {
       this._log(`Chain start with Id: ${runId}`);
@@ -124,7 +126,7 @@ export class CallbackHandler extends BaseCallbackHandler {
         id: runId,
         traceId: this.traceId,
         parentObservationId: parentRunId ?? this.rootObservationId,
-        name: chain.id.at(-1)?.toString(),
+        name: name ?? chain.id.at(-1)?.toString(),
         metadata: this.joinTagsAndMetaData(tags, metadata),
         input: inputs,
         version: this.version,
@@ -221,7 +223,8 @@ export class CallbackHandler extends BaseCallbackHandler {
     parentRunId?: string | undefined,
     extraParams?: Record<string, unknown> | undefined,
     tags?: string[] | undefined,
-    metadata?: Record<string, unknown> | undefined
+    metadata?: Record<string, unknown> | undefined,
+    name?: string
   ): Promise<void> {
     this._log(`Generation start with ID: ${runId}`);
 
@@ -259,7 +262,7 @@ export class CallbackHandler extends BaseCallbackHandler {
     this.langfuse.generation({
       id: runId,
       traceId: this.traceId,
-      name: llm.id.at(-1)?.toString(),
+      name: name ?? llm.id.at(-1)?.toString(),
       metadata: this.joinTagsAndMetaData(tags, metadata),
       parentObservationId: parentRunId ?? this.rootObservationId,
       input: messages,
@@ -276,12 +279,13 @@ export class CallbackHandler extends BaseCallbackHandler {
     parentRunId?: string | undefined,
     extraParams?: Record<string, unknown> | undefined,
     tags?: string[] | undefined,
-    metadata?: Record<string, unknown> | undefined
+    metadata?: Record<string, unknown> | undefined,
+    name?: string
   ): Promise<void> {
     try {
       this._log(`Chat model start with ID: ${runId}`);
 
-      this.handleGenerationStart(llm, messages, runId, parentRunId, extraParams, tags, metadata);
+      this.handleGenerationStart(llm, messages, runId, parentRunId, extraParams, tags, metadata, name);
     } catch (e) {
       this._log(e);
     }
@@ -311,12 +315,13 @@ export class CallbackHandler extends BaseCallbackHandler {
     parentRunId?: string | undefined,
     extraParams?: Record<string, unknown> | undefined,
     tags?: string[] | undefined,
-    metadata?: Record<string, unknown> | undefined
+    metadata?: Record<string, unknown> | undefined,
+    name?: string
   ): Promise<void> {
     try {
       this._log(`LLM start with ID: ${runId}`);
 
-      this.handleGenerationStart(llm, prompts, runId, parentRunId, extraParams, tags, metadata);
+      this.handleGenerationStart(llm, prompts, runId, parentRunId, extraParams, tags, metadata, name);
     } catch (e) {
       this._log(e);
     }
@@ -328,7 +333,8 @@ export class CallbackHandler extends BaseCallbackHandler {
     runId: string,
     parentRunId?: string | undefined,
     tags?: string[] | undefined,
-    metadata?: Record<string, unknown> | undefined
+    metadata?: Record<string, unknown> | undefined,
+    name?: string
   ): Promise<void> {
     try {
       this._log(`Tool start with ID: ${runId}`);
@@ -337,7 +343,7 @@ export class CallbackHandler extends BaseCallbackHandler {
         id: runId,
         parentObservationId: parentRunId,
         traceId: this.traceId,
-        name: tool.id.at(-1)?.toString(),
+        name: name ?? tool.id.at(-1)?.toString(),
         input: input,
         metadata: this.joinTagsAndMetaData(tags, metadata),
         version: this.version,


### PR DESCRIPTION
## Problem
I want to have better names in my trace on Langfuse. My Langchain runnables have nice names. This already is the case in Langsmith. Changes basically copied from https://github.com/langchain-ai/langchainjs/blob/6e5d02188bd29c7fe51ff1440a097150f88c547d/langchain-core/src/tracers/base.ts

<img width="274" alt="image" src="https://github.com/langfuse/langfuse-js/assets/17096641/8891ce44-3870-4f38-90f1-262a3b986cb2">

## Changes
Langfuse-langsmith callback handler

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] langfuse
- [ ] langfuse-node
- [x] langfuse-langchain

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Use Langchain run names in traces
