### PR TITLE
Add prompt caching to JS SDK (#77)

### DIFF
--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -49,6 +49,8 @@ export { LangfuseMemoryStorage } from "./storage-memory";
 
 export type IngestionBody = SingleIngestionEvent["body"];
 
+export const DEFAULT_PROMPT_CACHE_TTL_SECONDS = 60;
+
 class LangfuseFetchHttpError extends Error {
   name = "LangfuseFetchHttpError";
   body: string | undefined;
@@ -302,7 +304,11 @@ abstract class LangfuseCoreStateless {
 
   async getPromptStateless(name: string, version?: number): Promise<GetLangfusePromptResponse> {
     const url = `${this.baseUrl}/api/public/prompts/?name=${name}` + (version ? `&version=${version}` : "");
-    return this.fetch(url, this.getFetchOptions({ method: "GET" })).then((res) => res.json());
+    return this.fetch(url, this.getFetchOptions({ method: "GET" })).then(async (res) => {
+      const data = await res.json();
+
+      return { fetchResult: res.status === 200 ? "success" : "failure", data };
+    });
   }
 
   /***
@@ -529,10 +535,13 @@ export abstract class LangfuseWebStateless extends LangfuseCoreStateless {
 }
 
 export abstract class LangfuseCore extends LangfuseCoreStateless {
+  private _promptCache: LangfusePromptCache;
+
   constructor(params: { publicKey: string; secretKey: string } & LangfuseCoreOptions) {
     assert(params.publicKey, "You must pass your Langfuse project's api public key.");
     assert(params.secretKey, "You must pass your Langfuse project's api secret key.");
     super(params);
+    this._promptCache = new LangfusePromptCache();
   }
 
   trace(body?: CreateLangfuseTraceBody): LangfuseTraceClient {
@@ -618,9 +627,53 @@ export abstract class LangfuseCore extends LangfuseCoreStateless {
     return new LangfusePromptClient(prompt);
   }
 
-  async getPrompt(name: string, version?: number): Promise<LangfusePromptClient> {
-    const prompt = await this.getPromptStateless(name, version);
-    return new LangfusePromptClient(prompt);
+  async getPrompt(
+    name: string,
+    version?: number,
+    options?: { cacheTtlSeconds?: number }
+  ): Promise<LangfusePromptClient> {
+    const cacheKey = this._getPromptCacheKey(name, version);
+    const cachedPrompt = this._promptCache.getIncludingExpired(cacheKey);
+
+    if (!cachedPrompt) {
+      return await this._fetchPromptAndUpdateCache(name, version, options?.cacheTtlSeconds);
+    }
+
+    if (cachedPrompt.isExpired) {
+      return await this._fetchPromptAndUpdateCache(name, version, options?.cacheTtlSeconds).catch(() => {
+        console.warn(`Returning expired prompt cache for '${name}-${version ?? "latest"}' due to fetch error`);
+
+        return cachedPrompt.value;
+      });
+    }
+
+    return cachedPrompt.value;
+  }
+
+  private _getPromptCacheKey(name: string, version?: number): string {
+    return `${name}-${version ?? "latest"}`;
+  }
+
+  private async _fetchPromptAndUpdateCache(
+    name: string,
+    version?: number,
+    cacheTtlSeconds?: number
+  ): Promise<LangfusePromptClient> {
+    try {
+      const { data, fetchResult } = await this.getPromptStateless(name, version);
+      if (fetchResult === "failure") {
+        throw Error(data.message ?? "Internal error while fetching prompt");
+      }
+
+      const prompt = new LangfusePromptClient(data);
+      this._promptCache.set(this._getPromptCacheKey(name, version), prompt, cacheTtlSeconds);
+
+      return prompt;
+    } catch (error) {
+      console.error(`Error while fetching prompt '${name}-${version ?? "latest"}':`, error);
+
+      throw error;
+    }
   }
 
   _updateSpan(body: UpdateLangfuseSpanBody): this {
@@ -794,6 +847,40 @@ export class LangfusePromptClient {
 
   compile(variables?: { [key: string]: string }): string {
     return mustache.render(this.promptResponse.prompt, variables ?? {});
+  }
+}
+
+class LangfusePromptCacheItem {
+  private _expiry: number;
+
+  constructor(
+    public value: LangfusePromptClient,
+    ttlSeconds: number
+  ) {
+    this._expiry = Date.now() + ttlSeconds * 1000;
+  }
+
+  get isExpired(): boolean {
+    return Date.now() > this._expiry;
+  }
+}
+
+class LangfusePromptCache {
+  private _cache: Map<string, LangfusePromptCacheItem>;
+  private _defaultTtlSeconds: number;
+
+  constructor() {
+    this._cache = new Map<string, LangfusePromptCacheItem>();
+    this._defaultTtlSeconds = DEFAULT_PROMPT_CACHE_TTL_SECONDS;
+  }
+
+  public getIncludingExpired(key: string): LangfusePromptCacheItem | null {
+    return this._cache.get(key) ?? null;
+  }
+
+  public set(key: string, value: LangfusePromptClient, ttlSeconds?: number): void {
+    const effectiveTtlSeconds = ttlSeconds ?? this._defaultTtlSeconds;
+    this._cache.set(key, new LangfusePromptCacheItem(value, effectiveTtlSeconds));
   }
 }
 

--- a/langfuse-core/src/types.ts
+++ b/langfuse-core/src/types.ts
@@ -110,9 +110,16 @@ export type CreateLangfusePromptBody = FixTypes<
 export type CreateLangfusePromptResponse = FixTypes<
   paths["/api/public/prompts"]["post"]["responses"]["200"]["content"]["application/json"]
 >;
-export type GetLangfusePromptResponse = FixTypes<
+export type GetLangfusePromptSuccessData = FixTypes<
   paths["/api/public/prompts"]["get"]["responses"]["200"]["content"]["application/json"]
 >;
+export type GetLangfusePromptFailureData = { message?: string };
+export type GetLangfusePromptResponse =
+  | {
+      fetchResult: "success";
+      data: GetLangfusePromptSuccessData;
+    }
+  | { fetchResult: "failure"; data: GetLangfusePromptFailureData };
 
 export type PromptInput = {
   prompt?: LangfusePromptClient;

--- a/langfuse-core/test/langfuse.prompts.spec.ts
+++ b/langfuse-core/test/langfuse.prompts.spec.ts
@@ -4,10 +4,28 @@ import {
   type LangfuseCoreTestClient,
   type LangfuseCoreTestClientMocks,
 } from "./test-utils/LangfuseCoreTestClient";
+import { LangfusePromptClient, DEFAULT_PROMPT_CACHE_TTL_SECONDS, type GetLangfusePromptResponse } from "../src";
 
 describe("Langfuse Core", () => {
   let langfuse: LangfuseCoreTestClient;
   let mocks: LangfuseCoreTestClientMocks;
+
+  const getPromptStatelessSuccess: GetLangfusePromptResponse = {
+    fetchResult: "success",
+    data: {
+      name: "test-prompt",
+      prompt: "This is a prompt with a {{variable}}",
+      version: 1,
+    },
+  };
+
+  // Currently the fetch API doesn't throw on client or server errors, but resolves with a response object
+  const getPromptStatelessFailure: GetLangfusePromptResponse = {
+    fetchResult: "failure",
+    data: {
+      message: "Prompt not found",
+    },
+  };
 
   jest.useFakeTimers();
 
@@ -18,12 +36,16 @@ describe("Langfuse Core", () => {
       secretKey: "sk-lf-111",
       flushAt: 1,
     });
+
+    jest.setSystemTime(new Date("2022-01-01"));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   describe("prompts", () => {
     it("should create a prompt", async () => {
-      jest.setSystemTime(new Date("2022-01-01"));
-
       langfuse.createPromptStateless({
         name: "test-prompt",
         prompt: "This is a prompt with a {{variable}}",
@@ -44,8 +66,6 @@ describe("Langfuse Core", () => {
     });
 
     it("should get a prompt name only", async () => {
-      jest.setSystemTime(new Date("2022-01-01"));
-
       langfuse.getPromptStateless("test-prompt");
 
       expect(mocks.fetch).toHaveBeenCalledTimes(1);
@@ -55,14 +75,148 @@ describe("Langfuse Core", () => {
     });
 
     it("should get a prompt with name and version", async () => {
-      jest.setSystemTime(new Date("2022-01-01"));
-
       langfuse.getPromptStateless("test-prompt", 2);
 
       expect(mocks.fetch).toHaveBeenCalledTimes(1);
       const [url, options] = mocks.fetch.mock.calls[0];
       expect(url).toEqual("https://cloud.langfuse.com/api/public/prompts/?name=test-prompt&version=2");
       expect(options.method).toBe("GET");
+    });
+
+    it("should fetch and cache a prompt when not in cache", async () => {
+      const mockGetPromptStateless = jest
+        .spyOn(langfuse, "getPromptStateless")
+        .mockResolvedValueOnce(getPromptStatelessSuccess);
+      const result = await langfuse.getPrompt("test-prompt");
+
+      expect(mockGetPromptStateless).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(new LangfusePromptClient(getPromptStatelessSuccess.data));
+    });
+
+    it("should throw an error if nothing in cache and fetch fails", async () => {
+      const mockGetPromptStateless = jest
+        .spyOn(langfuse, "getPromptStateless")
+        .mockResolvedValueOnce(getPromptStatelessFailure);
+
+      expect(async () => await langfuse.getPrompt("test-prompt")).rejects.toThrow();
+      expect(mockGetPromptStateless).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return cached prompt if not expired", async () => {
+      const mockGetPromptStateless = jest
+        .spyOn(langfuse, "getPromptStateless")
+        .mockResolvedValueOnce(getPromptStatelessSuccess);
+
+      await langfuse.getPrompt("test-prompt");
+      expect(mockGetPromptStateless).toHaveBeenCalledTimes(1);
+
+      const result = await langfuse.getPrompt("test-prompt");
+      expect(mockGetPromptStateless).toHaveBeenCalledTimes(1);
+
+      expect(result).toEqual(new LangfusePromptClient(getPromptStatelessSuccess.data));
+    });
+
+    it("should refetch and return new prompt if cached one is expired according to custom TTL", async () => {
+      const cacheTtlSeconds = Math.max(DEFAULT_PROMPT_CACHE_TTL_SECONDS - 20, 10);
+      const mockGetPromptStateless = jest
+        .spyOn(langfuse, "getPromptStateless")
+        .mockResolvedValue(getPromptStatelessSuccess);
+
+      await langfuse.getPrompt("test-prompt", undefined, { cacheTtlSeconds });
+      expect(mockGetPromptStateless).toHaveBeenCalledTimes(1);
+      jest.advanceTimersByTime(cacheTtlSeconds * 1000 + 1);
+
+      const result = await langfuse.getPrompt("test-prompt", undefined, { cacheTtlSeconds });
+      expect(mockGetPromptStateless).toHaveBeenCalledTimes(2);
+
+      expect(result).toEqual(new LangfusePromptClient(getPromptStatelessSuccess.data));
+    });
+
+    it("should refetch and return new prompt if cached one is expired according to default TTL", async () => {
+      const mockGetPromptStateless = jest
+        .spyOn(langfuse, "getPromptStateless")
+        .mockResolvedValue(getPromptStatelessSuccess);
+
+      await langfuse.getPrompt("test-prompt", undefined);
+      expect(mockGetPromptStateless).toHaveBeenCalledTimes(1);
+      jest.advanceTimersByTime(DEFAULT_PROMPT_CACHE_TTL_SECONDS * 1000 + 1);
+
+      const result = await langfuse.getPrompt("test-prompt", undefined);
+      expect(mockGetPromptStateless).toHaveBeenCalledTimes(2);
+
+      expect(result).toEqual(new LangfusePromptClient(getPromptStatelessSuccess.data));
+    });
+
+    it("should return expired prompt if refetch fails", async () => {
+      const cacheTtlSeconds = Math.max(DEFAULT_PROMPT_CACHE_TTL_SECONDS - 20, 10);
+      const mockGetPromptStateless = jest
+        .spyOn(langfuse, "getPromptStateless")
+        .mockResolvedValueOnce(getPromptStatelessSuccess);
+
+      await langfuse.getPrompt("test-prompt", undefined, { cacheTtlSeconds });
+      expect(mockGetPromptStateless).toHaveBeenCalledTimes(1);
+      jest.advanceTimersByTime(cacheTtlSeconds * 1000 + 1);
+
+      mockGetPromptStateless.mockResolvedValueOnce(getPromptStatelessFailure);
+      const result = await langfuse.getPrompt("test-prompt", undefined, { cacheTtlSeconds });
+      expect(mockGetPromptStateless).toHaveBeenCalledTimes(2);
+
+      expect(result).toEqual(new LangfusePromptClient(getPromptStatelessSuccess.data));
+    });
+
+    it("should return expired prompt if refetch fails", async () => {
+      const cacheTtlSeconds = Math.max(DEFAULT_PROMPT_CACHE_TTL_SECONDS - 20, 10);
+      const mockGetPromptStateless = jest
+        .spyOn(langfuse, "getPromptStateless")
+        .mockResolvedValueOnce(getPromptStatelessSuccess);
+
+      await langfuse.getPrompt("test-prompt", undefined, { cacheTtlSeconds });
+      expect(mockGetPromptStateless).toHaveBeenCalledTimes(1);
+      jest.advanceTimersByTime(cacheTtlSeconds * 1000 + 1);
+
+      mockGetPromptStateless.mockResolvedValueOnce(getPromptStatelessFailure);
+      const result = await langfuse.getPrompt("test-prompt", undefined, { cacheTtlSeconds });
+      expect(mockGetPromptStateless).toHaveBeenCalledTimes(2);
+
+      expect(result).toEqual(new LangfusePromptClient(getPromptStatelessSuccess.data));
+    });
+
+    it("should fetch new prompt if version changes", async () => {
+      const newPromptVersion = getPromptStatelessSuccess.data.version - 1;
+      const versionChangedPrompt = {
+        ...getPromptStatelessSuccess,
+        data: {
+          ...getPromptStatelessSuccess.data,
+          version: getPromptStatelessSuccess.data.version - 1,
+        },
+      };
+      const mockGetPromptStateless = jest
+        .spyOn(langfuse, "getPromptStateless")
+        .mockResolvedValueOnce(getPromptStatelessSuccess);
+
+      await langfuse.getPrompt("test-prompt", undefined);
+      expect(mockGetPromptStateless).toHaveBeenCalledTimes(1);
+
+      mockGetPromptStateless.mockResolvedValue(versionChangedPrompt);
+      const result1 = await langfuse.getPrompt("test-prompt", newPromptVersion);
+      expect(mockGetPromptStateless).toHaveBeenCalledTimes(2);
+
+      expect(result1).toEqual(new LangfusePromptClient(versionChangedPrompt.data));
+
+      // Return cached value on subsequent calls
+      mockGetPromptStateless.mockResolvedValue(versionChangedPrompt);
+      const result2 = await langfuse.getPrompt("test-prompt", newPromptVersion);
+      expect(mockGetPromptStateless).toHaveBeenCalledTimes(2);
+
+      expect(result2).toEqual(new LangfusePromptClient(versionChangedPrompt.data));
+
+      // Refetch if cache has expired
+      jest.advanceTimersByTime(DEFAULT_PROMPT_CACHE_TTL_SECONDS * 1000 + 1);
+      mockGetPromptStateless.mockResolvedValue(versionChangedPrompt);
+      const result3 = await langfuse.getPrompt("test-prompt", newPromptVersion);
+      expect(mockGetPromptStateless).toHaveBeenCalledTimes(3);
+
+      expect(result3).toEqual(new LangfusePromptClient(versionChangedPrompt.data));
     });
   });
 });


### PR DESCRIPTION
## Problem

Currently, on every call to `langfuse.getPrompt(*)` a GET request is initiated to the `/prompts` endpoint. This PR implements SDK-level caching of prompts. Cache TTL can be set via `cacheTtlSeconds` property in an optional third options param in `langfuse.getPrompt`. If not specified, a default cache TTL is used (currently 60 seconds).

In case there is an expired prompt cache but fetching the fresh prompt fails, the stale prompt will be returned from `langfuse.getPrompt` to enable failover.

## Changes

- Introduces prompt caching to the JS SDK
- Default cache TTL set to 60 seconds
- Enables failover to stale prompt cache when fetching the fresh prompt fails
- Optional third param added to `langfuse.getPrompt(*)` to customize cache TTL through the `cacheTtlSeconds` property

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [X] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [X] langfuse
- [ ] langfuse-node

### Changelog notes

- Added support for SDK-level caching of prompts
