### PR TITLE
fix: do not add tokens to cost calculation in case of openai errors

### DIFF
--- a/langfuse/src/openai/traceMethod.ts
+++ b/langfuse/src/openai/traceMethod.ts
@@ -108,6 +108,11 @@ const wrapMethod = async <T extends GenericMethod>(
       endTime: new Date(),
       statusMessage: String(error),
       level: "ERROR",
+      usage: {
+        inputCost: 0,
+        outputCost: 0,
+        totalCost: 0,
+      },
     });
 
     throw error;


### PR DESCRIPTION
Contributes to: https://github.com/langfuse/langfuse/issues/1981