### PR TITLE
Name the trace with runName if it is set or use the default

### DIFF
--- a/langfuse-langchain/src/callback.ts
+++ b/langfuse-langchain/src/callback.ts
@@ -183,12 +183,13 @@ export class CallbackHandler extends BaseCallbackHandler {
     try {
       this._log(`Chain start with Id: ${runId}`);
 
-      this.generateTrace(chain, runId, parentRunId, tags, metadata, inputs);
+      let runName = name ?? chain.id.at(-1)?.toString();
+      this.generateTrace(runName, runId, parentRunId, tags, metadata, inputs);
       this.langfuse.span({
         id: runId,
         traceId: this.traceId,
         parentObservationId: parentRunId ?? this.rootObservationId,
-        name: name ?? chain.id.at(-1)?.toString(),
+        name: runName,
         metadata: this.joinTagsAndMetaData(tags, metadata),
         input: inputs,
         version: this.version,
@@ -251,7 +252,7 @@ export class CallbackHandler extends BaseCallbackHandler {
   }
 
   generateTrace(
-    serialized: Serialized,
+    runName: string,
     runId: string,
     parentRunId: string | undefined,
     tags?: string[] | undefined,
@@ -264,7 +265,7 @@ export class CallbackHandler extends BaseCallbackHandler {
     }
 
     const params = {
-      name: serialized.id.at(-1)?.toString(),
+      name: runName,
       metadata: this.joinTagsAndMetaData(tags, metadata, this.metadata),
       userId: this.userId,
       version: this.version,


### PR DESCRIPTION
## Problem

langfuse-js now just does not use the runName as trace name from user config.
And the default name is confusing. 
If user sets the name, it should be used instead of default.

## Changes

## Release info Sub-libraries affected

### Bump level

- [ ] Patch
issue  [#2334](https://github.com/langfuse/langfuse/issues/2334)

### Libraries affected

- [ ] langfuse-node

### Changelog notes
