### PR TITLE
Added tags to returned prompt

### DIFF
--- a/langfuse-core/src/prompts/promptClients.ts
+++ b/langfuse-core/src/prompts/promptClients.ts
@@ -18,6 +18,7 @@ abstract class BasePromptClient {
     this.version = prompt.version;
     this.config = prompt.config;
     this.labels = prompt.labels;
+    this.tags = prompt.tags;
     this.isFallback = isFallback;
   }
 


### PR DESCRIPTION
## Problem

GetPrompt doesn't include tags which prevents their usage for filtering on client side

## Changes

Added tags to the prompt object return after parsing API response

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ X] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ X] langfuse
- [ ] langfuse-node

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for returning tags
