### PR TITLE
feat: add support for usage_metadata in langfuse-langchain callback

### DIFF
--- a/langfuse-langchain/src/callback.ts
+++ b/langfuse-langchain/src/callback.ts
@@ -2,12 +2,13 @@ import { Langfuse, type LangfuseOptions } from "langfuse";
 
 import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
 import {
-  BaseMessage,
-  HumanMessage,
-  ChatMessage,
   AIMessage,
-  SystemMessage,
+  AIMessageChunk,
+  BaseMessage,
+  ChatMessage,
   FunctionMessage,
+  HumanMessage,
+  SystemMessage,
   ToolMessage,
   type BaseMessageFields,
   type MessageContent,
@@ -16,10 +17,10 @@ import {
 import type { Serialized } from "@langchain/core/load/serializable";
 import type { AgentAction, AgentFinish } from "@langchain/core/agents";
 import type { ChainValues } from "@langchain/core/utils/types";
-import type { LLMResult } from "@langchain/core/outputs";
+import type { Generation, LLMResult } from "@langchain/core/outputs";
 import type { Document } from "@langchain/core/documents";
 
-import type { LangfuseTraceClient, LangfuseSpanClient } from "langfuse-core";
+import type { components, LangfuseSpanClient, LangfuseTraceClient } from "langfuse-core";
 
 export type LlmMessage = {
   role: string;
@@ -524,7 +525,7 @@ export class CallbackHandler extends BaseCallbackHandler {
       const lastResponse =
         output.generations[output.generations.length - 1][output.generations[output.generations.length - 1].length - 1];
 
-      const llmUsage = output.llmOutput?.["tokenUsage"];
+      const llmUsage = output.llmOutput?.["tokenUsage"] ?? this.extractUsageMetadata(lastResponse);
 
       const extractedOutput =
         "message" in lastResponse && lastResponse["message"] instanceof BaseMessage
@@ -549,6 +550,25 @@ export class CallbackHandler extends BaseCallbackHandler {
     } catch (e) {
       this._log(e);
     }
+  }
+
+  /** Not all models supports tokenUsage in llmOutput, can use AIMessage.usage_metadata instead */
+  private extractUsageMetadata(generation: Generation): components["schemas"]["IngestionUsage"] | undefined {
+    const usageMetadata =
+      "message" in generation &&
+      (generation["message"] instanceof AIMessage || generation["message"] instanceof AIMessageChunk)
+        ? generation["message"].usage_metadata
+        : undefined;
+
+    if (!usageMetadata) {
+      return undefined;
+    }
+
+    return {
+      promptTokens: usageMetadata.input_tokens,
+      completionTokens: usageMetadata.output_tokens,
+      totalTokens: usageMetadata.total_tokens,
+    };
   }
 
   private extractChatMessageContent(message: BaseMessage): LlmMessage | AnonymousLlmMessage | MessageContent {


### PR DESCRIPTION
## Problem

`@langchain/google-vertexai` does not have any `tokenUsage` in the its `llmOutput` (`response_metadata`), so the traces from ChatVertexAI does not update its usage at the moment, but it does have the `usage_metadata` defined in the `AIMessage` and `AIMessageChunk` types in `@langchain/core/messages`. 

The `usage_metadata` field is also returned from the OpenAI client in addition to the `tokenUsage` that is currently used in the callback.

## Changes
Created a new private method `extractUsageMetadata` in `callback.ts` which extracts and maps `usage_metadata` to the supported `usage` param in `langfuse._updateGeneration`. Only used if `tokenUsage` is not defined.

Example output of ChatOpenAI:
``` 
AIMessage {
  "id": "chatcmpl-9qiNsoWFg00ySZ7Hp3Kc6zgksb3Ml",
  "content": "As an artificial intelligence, I don't have personal likes or dislikes. However, I can provide information and engage in discussions about \"The Lord of the Rings\" series.",
  "additional_kwargs": {},
  "response_metadata": {
    "tokenUsage": {
      "completionTokens": 34,
      "promptTokens": 13,
      "totalTokens": 47
    },
    "finish_reason": "stop"
  },
  "tool_calls": [],
  "invalid_tool_calls": [],
  "usage_metadata": {
    "input_tokens": 13,
    "output_tokens": 34,
    "total_tokens": 47
  }
}
```

Example output from ChatVertexAI:
```
AIMessageChunk {
  "content": "As a large language model, I don't have personal preferences or feelings like \"liking\" something. I can't enjoy a book or movie the way a human can. \n\nHowever, I can tell you that *The Lord of the Rings* is a massively popular and critically acclaimed series that has had a huge cultural impact. \n\nIs there anything specific you'd like to know about *The Lord of the Rings*? For example:\n\n* **Information about the books or movies:** I can tell you about the plot, characters, setting, etc.\n* **Analysis of themes and symbolism:** I can discuss topics like good vs. evil, friendship, sacrifice, and more.\n* **Comparisons to other works:** I can compare *The Lord of the Rings* to other fantasy series or explore its influences. \n\nLet me know what you're interested in, and I'll do my best to help! \n",
  "additional_kwargs": {},
  "response_metadata": {},
  "tool_calls": [],
  "tool_call_chunks": [],
  "invalid_tool_calls": [],
  "usage_metadata": {
    "input_tokens": 6,
    "output_tokens": 193,
    "total_tokens": 199
  }
}
```

Usage now updates in traces in Langfuse for ChatVertexAI. Total Cost still not calculated correctly though, but that might be due missing unit config for `gemini-1.5-pro`

<img width="1019" alt="Screenshot 2024-07-30 at 20 26 12" src="https://github.com/user-attachments/assets/0bed1281-723d-41fa-b31b-4bdbff503680">

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

- [ ] All of them
- [ ] langfuse
- [ ] langfuse-node
- [x] langfuse-langchain

### Changelog notes

- Added support for usage_metadata in langfuse-langchain callback
