### PR TITLE
feat(prompts): return stale prompt version and fetch refreshed prompt in the background, instead of waiting for the updated prompt

### DIFF
--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -1067,6 +1067,8 @@ export abstract class LangfuseCore extends LangfuseCoreStateless {
           cacheTtlSeconds: options?.cacheTtlSeconds,
           maxRetries: options?.maxRetries,
           fetchTimeout: options?.fetchTimeoutMs,
+        }).catch(() => {
+          console.warn(`Failed to refresh prompt cache '${cacheKey}'`);
         });
         this._promptCache.addRefreshingPromise(cacheKey, refreshPromptPromise);
       }

--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -1068,7 +1068,9 @@ export abstract class LangfuseCore extends LangfuseCoreStateless {
           maxRetries: options?.maxRetries,
           fetchTimeout: options?.fetchTimeoutMs,
         }).catch(() => {
-          console.warn(`Failed to refresh prompt cache '${cacheKey}'`);
+          console.warn(
+            `Failed to refresh prompt cache '${cacheKey}', stale cache will be used until next refresh succeeds.`
+          );
         });
         this._promptCache.addRefreshingPromise(cacheKey, refreshPromptPromise);
       }

--- a/langfuse-core/src/prompts/promptCache.ts
+++ b/langfuse-core/src/prompts/promptCache.ts
@@ -38,7 +38,13 @@ export class LangfusePromptCache {
 
   public addRefreshingPromise(key: string, promise: Promise<any>): void {
     this._refreshingKeys.set(key, promise);
-    promise.then(() => this._refreshingKeys.delete(key)).catch(() => this._refreshingKeys.delete(key));
+    promise
+      .then(() => {
+        this._refreshingKeys.delete(key);
+      })
+      .catch(() => {
+        this._refreshingKeys.delete(key);
+      });
   }
 
   public isRefreshing(key: string): boolean {


### PR DESCRIPTION
Docs for this change: https://github.com/langfuse/langfuse-docs/pull/787