### PR TITLE
Remove "No observability" warning when Langfuse is explicitly disabled

### DIFF
--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -908,9 +908,7 @@ export abstract class LangfuseWebStateless extends LangfuseCoreStateless {
     const { flushAt, flushInterval, publicKey, enabled, ...rest } = params;
     let isObservabilityEnabled = enabled === false ? false : true;
 
-    if (!isObservabilityEnabled) {
-      console.warn("Langfuse is disabled. No observability data will be sent to Langfuse.");
-    } else if (!publicKey) {
+    if (isObservabilityEnabled && !publicKey) {
       isObservabilityEnabled = false;
       console.warn(
         "Langfuse public key not passed to constructor and not set as 'LANGFUSE_PUBLIC_KEY' environment variable. No observability data will be sent to Langfuse."


### PR DESCRIPTION
## Problem

In the CI we are disabling Langfuse but we see in the logs hundreds of messages like this: "Langfuse is disabled. No observability data will be sent to Langfuse". I understand that if we explicitly disable Langfuse we should not see this warning.

Issue: https://github.com/langfuse/langfuse/issues/2475

## Changes

Removed console.warn when explicitly disabling Langfuse

## Release info Sub-libraries affected

### Bump level

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

- [ ] All of them
- [x] langfuse
- [ ] langfuse-node

### Changelog notes

- Remove "No observability" warning when Langfuse is explicitly disabled
