### PR TITLE
fix(vercel-ai-sdk): do not throw on missing root span

### DIFF
--- a/langfuse-vercel/src/LangfuseExporter.ts
+++ b/langfuse-vercel/src/LangfuseExporter.ts
@@ -68,7 +68,9 @@ export class LangfuseExporter implements SpanExporter {
   private processTraceSpans(traceId: string, spans: ReadableSpan[]): void {
     const rootSpan = spans.find((span) => this.isRootAiSdkSpan(span, spans));
     if (!rootSpan) {
-      throw Error("Root span not found");
+      this.logDebug("No root span found with AI SDK spans, skipping trace");
+
+      return;
     }
 
     const rootSpanAttributes = rootSpan.attributes;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `LangfuseExporter.ts`, `processTraceSpans()` now logs a debug message and skips the trace instead of throwing an error when a root span is missing.
> 
>   - **Behavior**:
>     - In `LangfuseExporter.ts`, `processTraceSpans()` no longer throws an error when a root span is missing. Instead, it logs a debug message and skips the trace.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for b01c032132ee5b2bdfd2152fc697154b568c6630. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->