### PR TITLE
feat(core): allow masking event input and output

### DIFF
--- a/integration-test/langfuse-integration-fetch.spec.ts
+++ b/integration-test/langfuse-integration-fetch.spec.ts
@@ -619,7 +619,7 @@ describe("Langfuse (fetch)", () => {
 
       await langfuse.flushAsync();
 
-      const fetchedTrace = await await axios.get(`${LANGFUSE_BASEURL}/api/public/traces/${traceId}`, {
+      const fetchedTrace = await axios.get(`${LANGFUSE_BASEURL}/api/public/traces/${traceId}`, {
         headers: getHeaders(),
       });
 

--- a/langfuse-core/src/types.ts
+++ b/langfuse-core/src/types.ts
@@ -25,6 +25,8 @@ export type LangfuseCoreOptions = {
   sdkIntegration?: string; // DEFAULT, LANGCHAIN, or any other custom value
   // Enabled switch for the SDK. If disabled, no observability data will be sent to Langfuse. Defaults to true.
   enabled?: boolean;
+  // Mask function to mask data in the event body
+  mask?: MaskFunction;
 };
 
 export enum LangfusePersistedProperty {
@@ -230,3 +232,5 @@ export type LinkDatasetItem = (
   }
 ) => Promise<{ id: string }>;
 export type DatasetItem = DatasetItemData & { link: LinkDatasetItem };
+
+export type MaskFunction = (params: { data: any }) => any;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds masking functionality for event input and output in Langfuse SDK, with a test case to verify the feature.
> 
>   - **Behavior**:
>     - Introduces a `mask` option in `LangfuseCoreOptions` in `types.ts` to allow masking of event input and output.
>     - Implements `maskEventBodyInPlace()` in `index.ts` to apply the mask function to `input` and `output` fields of `EventBody`.
>     - Updates `enqueue()` in `index.ts` to call `maskEventBodyInPlace()` before processing events.
>   - **Tests**:
>     - Adds test case in `langfuse-integration-fetch.spec.ts` to verify masking of confidential data in event bodies using a custom mask function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for b0bd7ff9fca3584e5b4b543c081988ea5eb70b4f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->