### PR TITLE
update broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Modular mono repo for the Langfuse JS/TS client libraries.
 
 | Package                                     | NPM                                                                                                                                   | Environments          |
 | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
-| [langfuse](./langfuse)                      | [![npm package](https://img.shields.io/npm/v/langfuse?style=flat-square)](https://www.npmjs.com/package/langfuse)                     | Node >= 18, Web, Edge |
-| [langfuse-node](./langfuse-node)            | [![npm package](https://img.shields.io/npm/v/langfuse-node?style=flat-square)](https://www.npmjs.com/package/langfuse-node)           | Node < 18             |
-| [langfuse-langchain](./langfuse-langchain)  | [![npm package](https://img.shields.io/npm/v/langfuse-langchain?style=flat-square)](https://www.npmjs.com/package/langfuse-langchain) | Node >= 20, Web, Edge |
-| [langfuse-vercel (beta)](./langfuse-vercel) | [![npm package](https://img.shields.io/npm/v/langfuse-vercel?style=flat-square)](https://www.npmjs.com/package/langfuse-vercel)       | Node >= 20, Web, Edge |
+| [langfuse](https://github.com/langfuse/langfuse-js/tree/main/langfuse)                      | [![npm package](https://img.shields.io/npm/v/langfuse?style=flat-square)](https://www.npmjs.com/package/langfuse)                     | Node >= 18, Web, Edge |
+| [langfuse-node](https://github.com/langfuse/langfuse-js/tree/main/langfuse-node)            | [![npm package](https://img.shields.io/npm/v/langfuse-node?style=flat-square)](https://www.npmjs.com/package/langfuse-node)           | Node < 18             |
+| [langfuse-langchain](https://github.com/langfuse/langfuse-js/tree/main/langfuse-langchain)  | [![npm package](https://img.shields.io/npm/v/langfuse-langchain?style=flat-square)](https://www.npmjs.com/package/langfuse-langchain) | Node >= 20, Web, Edge |
+| [langfuse-vercel (beta)](https://github.com/langfuse/langfuse-js/tree/main/langfuse-vercel) | [![npm package](https://img.shields.io/npm/v/langfuse-vercel?style=flat-square)](https://www.npmjs.com/package/langfuse-vercel)       | Node >= 20, Web, Edge |
 
 ## Documentation
 


### PR DESCRIPTION
Added absolute links since relative links are broken if the page is rendered on: https://js.reference.langfuse.com/


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update broken relative links to absolute links in `README.md`.
> 
>   - **Links**:
>     - Updated relative links to absolute links in `README.md` for `langfuse`, `langfuse-node`, `langfuse-langchain`, and `langfuse-vercel` packages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 046baa035700401f6f954ff8dc17f468aecc2cdd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->