### PR TITLE
feat(vercel): prompt management interop

### DIFF
--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -66,7 +66,7 @@ import { getCommonReleaseEnvs } from "./release-env";
 import { ChatPromptClient, TextPromptClient, type LangfusePromptClient } from "./prompts/promptClients";
 import { LangfusePromptCache } from "./prompts/promptCache";
 export { LangfuseMemoryStorage } from "./storage-memory";
-
+export type { LangfusePromptRecord } from "./types";
 export type IngestionBody = SingleIngestionEvent["body"];
 export * from "./prompts/promptClients";
 

--- a/langfuse-core/src/prompts/promptClients.ts
+++ b/langfuse-core/src/prompts/promptClients.ts
@@ -13,14 +13,18 @@ abstract class BasePromptClient {
   public readonly labels: string[];
   public readonly tags: string[];
   public readonly isFallback: boolean;
+  public readonly type: "text" | "chat";
+  public readonly prompt: string | ChatMessage[];
 
-  constructor(prompt: CreateLangfusePromptResponse, isFallback = false) {
+  constructor(prompt: CreateLangfusePromptResponse, isFallback = false, type: "text" | "chat") {
     this.name = prompt.name;
     this.version = prompt.version;
     this.config = prompt.config;
     this.labels = prompt.labels;
     this.tags = prompt.tags;
     this.isFallback = isFallback;
+    this.type = type;
+    this.prompt = prompt.prompt;
   }
 
   abstract compile(variables?: Record<string, string>): string | ChatMessage[];
@@ -30,6 +34,19 @@ abstract class BasePromptClient {
   protected _transformToLangchainVariables(content: string): string {
     return content.replace(/\{\{(.*?)\}\}/g, "{$1}");
   }
+
+  public toJSON(): string {
+    return JSON.stringify({
+      name: this.name,
+      prompt: this.prompt,
+      version: this.version,
+      isFallback: this.isFallback,
+      tags: this.tags,
+      labels: this.labels,
+      type: this.type,
+      config: this.config,
+    });
+  }
 }
 
 export class TextPromptClient extends BasePromptClient {
@@ -37,7 +54,7 @@ export class TextPromptClient extends BasePromptClient {
   public readonly prompt: string;
 
   constructor(prompt: TextPrompt, isFallback = false) {
-    super(prompt, isFallback);
+    super(prompt, isFallback, "text");
     this.promptResponse = prompt;
     this.prompt = prompt.prompt;
   }
@@ -64,7 +81,7 @@ export class ChatPromptClient extends BasePromptClient {
   public readonly prompt: ChatMessage[];
 
   constructor(prompt: ChatPrompt, isFallback = false) {
-    super(prompt, isFallback);
+    super(prompt, isFallback, "chat");
     this.promptResponse = prompt;
     this.prompt = prompt.prompt;
   }

--- a/langfuse-core/src/types.ts
+++ b/langfuse-core/src/types.ts
@@ -1,5 +1,4 @@
 import { type LangfuseObjectClient } from "./index";
-import { type LangfusePromptClient } from "./prompts/promptClients";
 import { type components, type paths } from "./openapi/server";
 
 export type LangfuseCoreOptions = {
@@ -179,7 +178,7 @@ export type CreateChatPromptBody = { type: "chat" } & Omit<CreateChatPromptReque
 export type CreatePromptBody = CreateTextPromptBody | CreateChatPromptBody;
 
 export type PromptInput = {
-  prompt?: LangfusePromptClient;
+  prompt?: LangfusePromptRecord;
 };
 
 export type JsonType = string | number | boolean | null | { [key: string]: JsonType } | Array<JsonType>;
@@ -234,3 +233,5 @@ export type LinkDatasetItem = (
 export type DatasetItem = DatasetItemData & { link: LinkDatasetItem };
 
 export type MaskFunction = (params: { data: any }) => any;
+
+export type LangfusePromptRecord = (TextPrompt | ChatPrompt) & { isFallback: boolean };

--- a/langfuse-core/src/types.ts
+++ b/langfuse-core/src/types.ts
@@ -1,5 +1,5 @@
-import { LangfusePromptClient } from "langfuse-core/lib";
 import { type LangfuseObjectClient } from "./index";
+import { type LangfusePromptClient } from "./prompts/promptClients";
 import { type components, type paths } from "./openapi/server";
 
 export type LangfuseCoreOptions = {

--- a/langfuse-core/src/types.ts
+++ b/langfuse-core/src/types.ts
@@ -1,3 +1,4 @@
+import { LangfusePromptClient } from "langfuse-core/lib";
 import { type LangfuseObjectClient } from "./index";
 import { type components, type paths } from "./openapi/server";
 
@@ -178,7 +179,7 @@ export type CreateChatPromptBody = { type: "chat" } & Omit<CreateChatPromptReque
 export type CreatePromptBody = CreateTextPromptBody | CreateChatPromptBody;
 
 export type PromptInput = {
-  prompt?: LangfusePromptRecord;
+  prompt?: LangfusePromptRecord | LangfusePromptClient;
 };
 
 export type JsonType = string | number | boolean | null | { [key: string]: JsonType } | Array<JsonType>;

--- a/langfuse-vercel/src/LangfuseExporter.ts
+++ b/langfuse-vercel/src/LangfuseExporter.ts
@@ -263,8 +263,18 @@ export class LangfuseExporter implements SpanExporter {
     const attributes = span.attributes;
     const tools = "ai.prompt.tools" in attributes ? attributes["ai.prompt.tools"] : [];
 
+    let chatMessages: any[] = [];
+    if ("ai.prompt.messages" in attributes) {
+      chatMessages = [attributes["ai.prompt.messages"]];
+      try {
+        chatMessages = JSON.parse(attributes["ai.prompt.messages"] as string);
+      } catch (e) {
+        console.error("Error parsing ai.prompt.messages", e);
+      }
+    }
+
     return "ai.prompt.messages" in attributes
-      ? [...JSON.parse(attributes["ai.prompt.messages"] as string), ...(Array.isArray(tools) ? tools : [])]
+      ? [...chatMessages, ...(Array.isArray(tools) ? tools : [])]
       : "ai.prompt" in attributes
         ? attributes["ai.prompt"]
         : "ai.toolCall.args" in attributes

--- a/langfuse-vercel/src/LangfuseExporter.ts
+++ b/langfuse-vercel/src/LangfuseExporter.ts
@@ -350,7 +350,7 @@ export class LangfuseExporter implements SpanExporter {
 
         if (
           typeof parsedPrompt !== "object" ||
-          !(parsedPrompt["name"] && parsedPrompt["version"] && parsedPrompt["isFallback"])
+          !(parsedPrompt["name"] && parsedPrompt["version"] && typeof parsedPrompt["isFallback"] === "boolean")
         ) {
           throw Error("Invalid langfusePrompt");
         }

--- a/langfuse-vercel/src/LangfuseExporter.ts
+++ b/langfuse-vercel/src/LangfuseExporter.ts
@@ -349,7 +349,7 @@ export class LangfuseExporter implements SpanExporter {
         const parsedPrompt = JSON.parse(jsonPrompt.toString());
 
         if (
-          typeof parsedPrompt !== "object" &&
+          typeof parsedPrompt !== "object" ||
           !(parsedPrompt["name"] && parsedPrompt["version"] && parsedPrompt["isFallback"])
         ) {
           throw Error("Invalid langfusePrompt");

--- a/langfuse/src/langfuse.ts
+++ b/langfuse/src/langfuse.ts
@@ -10,7 +10,7 @@ import { type LangfuseStorage, getStorage } from "./storage";
 import { version } from "../package.json";
 import { type LangfuseOptions } from "./types";
 
-export type { LangfusePromptClient, ChatPromptClient, TextPromptClient } from "langfuse-core";
+export type { LangfusePromptClient, ChatPromptClient, TextPromptClient, LangfusePromptRecord } from "langfuse-core";
 
 // Required when users pass these as typed arguments
 export {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances Vercel integration by adding prompt management interoperability, including tracing and serialization of prompt data.
> 
>   - **Behavior**:
>     - Adds tracing for `streamText` calls with linked prompts in `langfuse-integration-vercel.spec.ts`.
>     - Updates `LangfuseExporter` to process spans with `LangfusePromptRecord`.
>   - **Types and Models**:
>     - Introduces `LangfusePromptRecord` type in `types.ts`.
>     - Updates `BasePromptClient` to include `toJSON()` method for serialization.
>   - **Functions**:
>     - Adds `parseLangfusePromptTraceAttribute()` in `LangfuseExporter.ts` to parse prompt data from spans.
>     - Modifies `processSpanAsLangfuseGeneration()` in `LangfuseExporter.ts` to include prompt data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 0f9e20e0971e5986b3c04cf71129a4e932119685. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->