### PR TITLE
Allow posibility to add span name through vercel integration

### DIFF
--- a/langfuse-vercel/src/LangfuseExporter.ts
+++ b/langfuse-vercel/src/LangfuseExporter.ts
@@ -305,7 +305,7 @@ export class LangfuseExporter implements SpanExporter {
 
   private parseTraceName(spans: ReadableSpan[]): string | undefined {
     return spans
-      .map((span) => span.attributes["resource.name"])
+      .map((span) => this.parseSpanMetadata(span)["langfuseSpanName"] || span.attributes["resource.name"])
       .find((name) => Boolean(name))
       ?.toString();
   }
@@ -376,7 +376,7 @@ export class LangfuseExporter implements SpanExporter {
   }
 
   private filterTraceAttributes(obj: Record<string, any>): Record<string, any> {
-    const langfuseTraceAttributes = ["userId", "sessionId", "tags", "langfuseTraceId", "langfusePrompt"];
+    const langfuseTraceAttributes = ["userId", "sessionId", "tags", "langfuseTraceId", "langfusePrompt", "langfuseSpanName"];
 
     return Object.entries(obj).reduce(
       (acc, [key, value]) => {


### PR DESCRIPTION
## Problem

Ther was no way to add the span name and have better trazability of the traces:
![image](https://github.com/user-attachments/assets/8fa0e565-f852-4a71-a42f-d46d51b7d8bf)

## Changes

Adds the posibility to define the `langFuseSpanName` through open telemetry metadata.

### Changelog notes

- Added support to declare span name in vercel integration

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Allow custom span names in `LangfuseExporter` via `langfuseSpanName` attribute for better traceability.
> 
>   - **Behavior**:
>     - Allow custom span name via `langfuseSpanName` in `LangfuseExporter`.
>     - `parseTraceName()` now checks for `langfuseSpanName` before defaulting to `resource.name`.
>   - **Attributes**:
>     - Add `langfuseSpanName` to `filterTraceAttributes()` to exclude it from metadata filtering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for ba6658521692f0f8ccb982a820434b568ccc9ae2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->