### PR TITLE
chore: adds admin mode

### DIFF
--- a/integration-test/langfuse-integration-langchain.spec.ts
+++ b/integration-test/langfuse-integration-langchain.spec.ts
@@ -697,7 +697,6 @@ describe("Langchain", () => {
       process.env.LANGFUSE_SDK_ADMIN_ENABLED = "true";
 
       try {
-        const projectId = randomUUID();
         const handler = new CallbackHandler({
           sessionId: "test-session",
           userId: "test-user",
@@ -707,7 +706,6 @@ describe("Langchain", () => {
           },
           tags: ["test-tag", "test-tag-2"],
           version: "1.0.0",
-          _projectId: projectId,
         });
 
         handler.debug(true);
@@ -725,9 +723,8 @@ describe("Langchain", () => {
 
         console.log(JSON.stringify(shutdownResult, null, 2));
 
-        const { events, projectId: eventsProjectId } = shutdownResult;
+        const events = shutdownResult;
 
-        expect(projectId).toBe(eventsProjectId);
         expect(events.length).toBe(4);
         const [traceCreate, generationCreate, generationUpdate, traceUpdate] = events;
 

--- a/integration-test/langfuse-integration-langchain.spec.ts
+++ b/integration-test/langfuse-integration-langchain.spec.ts
@@ -692,6 +692,134 @@ describe("Langchain", () => {
       expect((explainGeneration as any)["promptName"]).toBe(langfuseExplainPrompt.name);
       expect((explainGeneration as any)["promptVersion"]).toBe(langfuseExplainPrompt.version);
     });
+
+    it("should export events in admin mode", async () => {
+      process.env.LANGFUSE_SDK_ADMIN_ENABLED = "true";
+
+      try {
+        const projectId = randomUUID();
+        const handler = new CallbackHandler({
+          sessionId: "test-session",
+          userId: "test-user",
+          metadata: {
+            foo: "bar",
+            array: ["a", "b"],
+          },
+          tags: ["test-tag", "test-tag-2"],
+          version: "1.0.0",
+          _projectId: projectId,
+        });
+
+        handler.debug(true);
+
+        const messages = [new SystemMessage("You are an excellent Comedian"), new HumanMessage("Tell me a joke")];
+
+        const llm = new ChatOpenAI({ modelName: "gpt-4-turbo-preview" });
+        await llm.invoke(messages, { callbacks: [handler] });
+
+        await handler.flushAsync();
+        const shutdownResult = await handler.langfuse._shutdownAdmin();
+        if (!shutdownResult) {
+          throw new Error("No shutdown result");
+        }
+
+        console.log(JSON.stringify(shutdownResult, null, 2));
+
+        const { events, projectId: eventsProjectId } = shutdownResult;
+
+        expect(projectId).toBe(eventsProjectId);
+        expect(events.length).toBe(4);
+        const [traceCreate, generationCreate, generationUpdate, traceUpdate] = events;
+
+        // Check trace create event
+        expect(traceCreate.type).toBe("trace-create");
+        expect(traceCreate.body).toMatchObject({
+          name: "ChatOpenAI",
+          metadata: {
+            ls_provider: "openai",
+            ls_model_name: "gpt-4-turbo-preview",
+            ls_model_type: "chat",
+            ls_temperature: 1,
+            foo: "bar",
+            array: ["a", "b"],
+          },
+          userId: "test-user",
+          version: "1.0.0",
+          sessionId: "test-session",
+          input: [
+            {
+              content: "You are an excellent Comedian",
+              role: "system",
+            },
+            {
+              content: "Tell me a joke",
+              role: "user",
+            },
+          ],
+          tags: ["test-tag", "test-tag-2"],
+        });
+
+        // Check generation create event
+        expect(generationCreate.type).toBe("generation-create");
+        expect(generationCreate.body).toMatchObject({
+          name: "ChatOpenAI",
+          metadata: {
+            ls_provider: "openai",
+            ls_model_name: "gpt-4-turbo-preview",
+            ls_model_type: "chat",
+            ls_temperature: 1,
+          },
+          input: [
+            {
+              content: "You are an excellent Comedian",
+              role: "system",
+            },
+            {
+              content: "Tell me a joke",
+              role: "user",
+            },
+          ],
+          model: "gpt-4-turbo-preview",
+          modelParameters: {
+            temperature: 1,
+            top_p: 1,
+            frequency_penalty: 0,
+            presence_penalty: 0,
+          },
+          version: "1.0.0",
+        });
+
+        // Check generation update event
+        expect(generationUpdate.type).toBe("generation-update");
+        expect(generationUpdate.body).toMatchObject({
+          output: {
+            role: "assistant",
+          },
+          usage: {
+            completionTokens: expect.any(Number),
+            promptTokens: expect.any(Number),
+            totalTokens: expect.any(Number),
+          },
+          version: "1.0.0",
+        });
+
+        // Check trace update event
+        expect(traceUpdate.type).toBe("trace-create");
+        expect(traceUpdate.body).toMatchObject({
+          output: {
+            role: "assistant",
+          },
+        });
+
+        // Check IDs match between events
+        const traceId = (traceCreate.body as any).id;
+        expect((generationCreate.body as any).traceId).toBe(traceId);
+        expect((generationUpdate.body as any).traceId).toBe(traceId);
+        expect((traceUpdate.body as any).id).toBe(traceId);
+      } finally {
+        process.env.LANGFUSE_SDK_ADMIN_ENABLED = undefined;
+      }
+    });
   });
 });
 

--- a/integration-test/langfuse-integration-langchain.spec.ts
+++ b/integration-test/langfuse-integration-langchain.spec.ts
@@ -697,6 +697,7 @@ describe("Langchain", () => {
       process.env.LANGFUSE_SDK_ADMIN_ENABLED = "true";
 
       try {
+        const projectId = "test-project-id";
         const handler = new CallbackHandler({
           sessionId: "test-session",
           userId: "test-user",
@@ -705,6 +706,7 @@ describe("Langchain", () => {
             array: ["a", "b"],
           },
           tags: ["test-tag", "test-tag-2"],
+          _projectId: projectId,
           version: "1.0.0",
         });
 
@@ -716,7 +718,7 @@ describe("Langchain", () => {
         await llm.invoke(messages, { callbacks: [handler] });
 
         await handler.flushAsync();
-        const shutdownResult = await handler.langfuse._shutdownAdmin();
+        const shutdownResult = await handler.langfuse._shutdownAdmin(projectId);
         if (!shutdownResult) {
           throw new Error("No shutdown result");
         }

--- a/integration-test/langfuse-integration-langchain.spec.ts
+++ b/integration-test/langfuse-integration-langchain.spec.ts
@@ -694,7 +694,7 @@ describe("Langchain", () => {
     });
 
     it("should export events in admin mode", async () => {
-      process.env.LANGFUSE_SDK_ADMIN_ENABLED = "true";
+      process.env.LANGFUSE_JS_SDK_LOCAL_EVENT_EXPORT_ENABLED = "true";
 
       try {
         const projectId = "test-project-id";
@@ -816,7 +816,7 @@ describe("Langchain", () => {
         expect((generationUpdate.body as any).traceId).toBe(traceId);
         expect((traceUpdate.body as any).id).toBe(traceId);
       } finally {
-        process.env.LANGFUSE_SDK_ADMIN_ENABLED = undefined;
+        process.env.LANGFUSE_JS_SDK_LOCAL_EVENT_EXPORT_ENABLED = undefined;
       }
     });
   });

--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -1134,7 +1134,7 @@ abstract class LangfuseCoreStateless {
     }
   }
 
-  async _shutdownAdmin(): Promise<SingleIngestionEvent[] | undefined> {
+  async _shutdownAdmin(): Promise<SingleIngestionEvent[]> {
     if (this.adminEnabled) {
       clearTimeout(this._flushTimer);
       await this.flushAsync();
@@ -1145,7 +1145,7 @@ abstract class LangfuseCoreStateless {
       return events;
     } else {
       this._events.emit("error", "LANGFUSE_SDK_ADMIN_ENABLED is false, but _shutdownAdmin() was called.");
-      return undefined;
+      return [];
     }
   }
 

--- a/langfuse-core/src/types.ts
+++ b/langfuse-core/src/types.ts
@@ -27,6 +27,8 @@ export type LangfuseCoreOptions = {
   enabled?: boolean;
   // Mask function to mask data in the event body
   mask?: MaskFunction;
+  // Project ID to use for the SDK in admin mode. This should never be set by users.
+  _projectId?: string;
 };
 
 export enum LangfusePersistedProperty {

--- a/langfuse-core/src/types.ts
+++ b/langfuse-core/src/types.ts
@@ -27,8 +27,6 @@ export type LangfuseCoreOptions = {
   enabled?: boolean;
   // Mask function to mask data in the event body
   mask?: MaskFunction;
-  // Project ID to use for the SDK in admin mode. This should never be set by users.
-  _projectId?: string;
 };
 
 export enum LangfusePersistedProperty {

--- a/langfuse-core/test/langfuse.flush.spec.ts
+++ b/langfuse-core/test/langfuse.flush.spec.ts
@@ -241,7 +241,7 @@ describe("Langfuse Core", () => {
     });
 
     it("should not send events in admin mode", async () => {
-      process.env.LANGFUSE_SDK_ADMIN_ENABLED = "true";
+      process.env.LANGFUSE_JS_SDK_LOCAL_EVENT_EXPORT_ENABLED = "true";
       try {
         [langfuse, mocks] = createTestClient({
           publicKey: "pk-lf-111",
@@ -261,7 +261,7 @@ describe("Langfuse Core", () => {
 
         expect(mocks.fetch).not.toHaveBeenCalled();
       } finally {
-        process.env.LANGFUSE_SDK_ADMIN_ENABLED = undefined;
+        process.env.LANGFUSE_JS_SDK_LOCAL_EVENT_EXPORT_ENABLED = undefined;
       }
     });
   });

--- a/langfuse-core/test/langfuse.flush.spec.ts
+++ b/langfuse-core/test/langfuse.flush.spec.ts
@@ -246,6 +246,7 @@ describe("Langfuse Core", () => {
         [langfuse, mocks] = createTestClient({
           publicKey: "pk-lf-111",
           secretKey: "sk-lf-111",
+          _projectId: "test-project-id",
           flushAt: 5,
           flushInterval: 200,
         });

--- a/langfuse-core/test/langfuse.flush.spec.ts
+++ b/langfuse-core/test/langfuse.flush.spec.ts
@@ -239,5 +239,29 @@ describe("Langfuse Core", () => {
 
       expect(mocks.fetch).toHaveBeenCalledTimes(1);
     });
+
+    it("should not send events in admin mode", async () => {
+      process.env.LANGFUSE_SDK_ADMIN_ENABLED = "true";
+      try {
+        [langfuse, mocks] = createTestClient({
+          publicKey: "pk-lf-111",
+          secretKey: "sk-lf-111",
+          flushAt: 5,
+          flushInterval: 200,
+        });
+
+        // Create multiple traces
+        const traces = ["test-trace-1", "test-trace-2", "test-trace-3"];
+        traces.forEach((name) => langfuse.trace({ name }));
+
+        expect(mocks.fetch).not.toHaveBeenCalled();
+
+        await jest.runAllTimersAsync();
+
+        expect(mocks.fetch).not.toHaveBeenCalled();
+      } finally {
+        process.env.LANGFUSE_SDK_ADMIN_ENABLED = undefined;
+      }
+    });
   });
 });


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] langfuse
- [ ] langfuse-node

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds admin mode to Langfuse SDK to store events locally, with tests verifying no network requests in this mode.
> 
>   - **Behavior**:
>     - Introduces admin mode in `LangfuseCoreStateless` to store events locally instead of sending to server when `LANGFUSE_SDK_ADMIN_ENABLED` is true.
>     - Adds `_shutdownAdmin()` to retrieve stored events in admin mode.
>   - **Tests**:
>     - Adds test `should export events in admin mode` in `langfuse-integration-langchain.spec.ts` to verify event storage and retrieval.
>     - Adds test `should not send events in admin mode` in `langfuse.flush.spec.ts` to ensure no network requests are made in admin mode.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 7c8e88b7dc2a4ffb66431bb18d5e19118b087e3b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->