### PR TITLE
docs: fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Modular mono repo for the Langfuse JS/TS client libraries.
 | [langfuse](./langfuse)                      | [![npm package](https://img.shields.io/npm/v/langfuse?style=flat-square)](https://www.npmjs.com/package/langfuse)                     | Node >= 18, Web, Edge |
 | [langfuse-node](./langfuse-node)            | [![npm package](https://img.shields.io/npm/v/langfuse-node?style=flat-square)](https://www.npmjs.com/package/langfuse-node)           | Node < 18             |
 | [langfuse-langchain](./langfuse-langchain)  | [![npm package](https://img.shields.io/npm/v/langfuse-langchain?style=flat-square)](https://www.npmjs.com/package/langfuse-langchain) | Node >= 20, Web, Edge |
-| [langfuse-vercel (beta)](./langfuse-vercel) | [![npm package](https://img.shields.io/npm/v/langfuse-vercel?style=flat-square)](https://www.npmjs.com/package/langfuse-vercel)       | Node >= 20, Web, Edge |
+| [langfuse-vercel (beta)](/modules/langfuse_vercel.html) | [![npm package](https://img.shields.io/npm/v/langfuse-vercel?style=flat-square)](https://www.npmjs.com/package/langfuse-vercel)       | Node >= 20, Web, Edge |
 
 ## Documentation
 


### PR DESCRIPTION
Hi @hassiebp, this link was broken. Not quite sure why because it looked right. This change should work - lgfy?
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix broken link for `langfuse-vercel` package in `README.md`.
> 
>   - **Documentation**:
>     - Fix broken link for `langfuse-vercel` package in `README.md` from `./langfuse-vercel` to `/modules/langfuse_vercel.html`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 8c8ba002721bf3eecfdca1c1dbbb19a788f10127. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->