### PR TITLE
chore: remove enabling local export mode via env

### DIFF
--- a/integration-test/langfuse-integration-langchain.spec.ts
+++ b/integration-test/langfuse-integration-langchain.spec.ts
@@ -694,130 +694,125 @@ describe("Langchain", () => {
     });
 
     it("should export events in admin mode", async () => {
-      process.env.LANGFUSE_JS_SDK_LOCAL_EVENT_EXPORT_ENABLED = "true";
+      const projectId = "test-project-id";
+      const handler = new CallbackHandler({
+        sessionId: "test-session",
+        userId: "test-user",
+        metadata: {
+          foo: "bar",
+          array: ["a", "b"],
+        },
+        tags: ["test-tag", "test-tag-2"],
+        _projectId: projectId,
+        _isLocalEventExportEnabled: true,
+        version: "1.0.0",
+      });
 
-      try {
-        const projectId = "test-project-id";
-        const handler = new CallbackHandler({
-          sessionId: "test-session",
-          userId: "test-user",
-          metadata: {
-            foo: "bar",
-            array: ["a", "b"],
-          },
-          tags: ["test-tag", "test-tag-2"],
-          _projectId: projectId,
-          version: "1.0.0",
-        });
+      handler.debug(true);
 
-        handler.debug(true);
+      const messages = [new SystemMessage("You are an excellent Comedian"), new HumanMessage("Tell me a joke")];
 
-        const messages = [new SystemMessage("You are an excellent Comedian"), new HumanMessage("Tell me a joke")];
+      const llm = new ChatOpenAI({ modelName: "gpt-4-turbo-preview" });
+      await llm.invoke(messages, { callbacks: [handler] });
 
-        const llm = new ChatOpenAI({ modelName: "gpt-4-turbo-preview" });
-        await llm.invoke(messages, { callbacks: [handler] });
-
-        await handler.flushAsync();
-        const shutdownResult = await handler.langfuse._shutdownAdmin(projectId);
-        if (!shutdownResult) {
-          throw new Error("No shutdown result");
-        }
-
-        console.log(JSON.stringify(shutdownResult, null, 2));
-
-        const events = shutdownResult;
-
-        expect(events.length).toBe(4);
-        const [traceCreate, generationCreate, generationUpdate, traceUpdate] = events;
-
-        // Check trace create event
-        expect(traceCreate.type).toBe("trace-create");
-        expect(traceCreate.body).toMatchObject({
-          name: "ChatOpenAI",
-          metadata: {
-            ls_provider: "openai",
-            ls_model_name: "gpt-4-turbo-preview",
-            ls_model_type: "chat",
-            ls_temperature: 1,
-            foo: "bar",
-            array: ["a", "b"],
-          },
-          userId: "test-user",
-          version: "1.0.0",
-          sessionId: "test-session",
-          input: [
-            {
-              content: "You are an excellent Comedian",
-              role: "system",
-            },
-            {
-              content: "Tell me a joke",
-              role: "user",
-            },
-          ],
-          tags: ["test-tag", "test-tag-2"],
-        });
-
-        // Check generation create event
-        expect(generationCreate.type).toBe("generation-create");
-        expect(generationCreate.body).toMatchObject({
-          name: "ChatOpenAI",
-          metadata: {
-            ls_provider: "openai",
-            ls_model_name: "gpt-4-turbo-preview",
-            ls_model_type: "chat",
-            ls_temperature: 1,
-          },
-          input: [
-            {
-              content: "You are an excellent Comedian",
-              role: "system",
-            },
-            {
-              content: "Tell me a joke",
-              role: "user",
-            },
-          ],
-          model: "gpt-4-turbo-preview",
-          modelParameters: {
-            temperature: 1,
-            top_p: 1,
-            frequency_penalty: 0,
-            presence_penalty: 0,
-          },
-          version: "1.0.0",
-        });
-
-        // Check generation update event
-        expect(generationUpdate.type).toBe("generation-update");
-        expect(generationUpdate.body).toMatchObject({
-          output: {
-            role: "assistant",
-          },
-          usage: {
-            completionTokens: expect.any(Number),
-            promptTokens: expect.any(Number),
-            totalTokens: expect.any(Number),
-          },
-          version: "1.0.0",
-        });
-
-        // Check trace update event
-        expect(traceUpdate.type).toBe("trace-create");
-        expect(traceUpdate.body).toMatchObject({
-          output: {
-            role: "assistant",
-          },
-        });
-
-        // Check IDs match between events
-        const traceId = (traceCreate.body as any).id;
-        expect((generationCreate.body as any).traceId).toBe(traceId);
-        expect((generationUpdate.body as any).traceId).toBe(traceId);
-        expect((traceUpdate.body as any).id).toBe(traceId);
-      } finally {
-        process.env.LANGFUSE_JS_SDK_LOCAL_EVENT_EXPORT_ENABLED = undefined;
+      await handler.flushAsync();
+      const shutdownResult = await handler.langfuse._exportLocalEvents(projectId);
+      if (!shutdownResult) {
+        throw new Error("No shutdown result");
       }
+
+      console.log(JSON.stringify(shutdownResult, null, 2));
+
+      const events = shutdownResult;
+
+      expect(events.length).toBe(4);
+      const [traceCreate, generationCreate, generationUpdate, traceUpdate] = events;
+
+      // Check trace create event
+      expect(traceCreate.type).toBe("trace-create");
+      expect(traceCreate.body).toMatchObject({
+        name: "ChatOpenAI",
+        metadata: {
+          ls_provider: "openai",
+          ls_model_name: "gpt-4-turbo-preview",
+          ls_model_type: "chat",
+          ls_temperature: 1,
+          foo: "bar",
+          array: ["a", "b"],
+        },
+        userId: "test-user",
+        version: "1.0.0",
+        sessionId: "test-session",
+        input: [
+          {
+            content: "You are an excellent Comedian",
+            role: "system",
+          },
+          {
+            content: "Tell me a joke",
+            role: "user",
+          },
+        ],
+        tags: ["test-tag", "test-tag-2"],
+      });
+
+      // Check generation create event
+      expect(generationCreate.type).toBe("generation-create");
+      expect(generationCreate.body).toMatchObject({
+        name: "ChatOpenAI",
+        metadata: {
+          ls_provider: "openai",
+          ls_model_name: "gpt-4-turbo-preview",
+          ls_model_type: "chat",
+          ls_temperature: 1,
+        },
+        input: [
+          {
+            content: "You are an excellent Comedian",
+            role: "system",
+          },
+          {
+            content: "Tell me a joke",
+            role: "user",
+          },
+        ],
+        model: "gpt-4-turbo-preview",
+        modelParameters: {
+          temperature: 1,
+          top_p: 1,
+          frequency_penalty: 0,
+          presence_penalty: 0,
+        },
+        version: "1.0.0",
+      });
+
+      // Check generation update event
+      expect(generationUpdate.type).toBe("generation-update");
+      expect(generationUpdate.body).toMatchObject({
+        output: {
+          role: "assistant",
+        },
+        usage: {
+          completionTokens: expect.any(Number),
+          promptTokens: expect.any(Number),
+          totalTokens: expect.any(Number),
+        },
+        version: "1.0.0",
+      });
+
+      // Check trace update event
+      expect(traceUpdate.type).toBe("trace-create");
+      expect(traceUpdate.body).toMatchObject({
+        output: {
+          role: "assistant",
+        },
+      });
+
+      // Check IDs match between events
+      const traceId = (traceCreate.body as any).id;
+      expect((generationCreate.body as any).traceId).toBe(traceId);
+      expect((generationUpdate.body as any).traceId).toBe(traceId);
+      expect((traceUpdate.body as any).id).toBe(traceId);
     });
   });
 });

--- a/langfuse-core/src/types.ts
+++ b/langfuse-core/src/types.ts
@@ -29,6 +29,8 @@ export type LangfuseCoreOptions = {
   mask?: MaskFunction;
   // Project ID to use for the SDK in admin mode. This should never be set by users.
   _projectId?: string;
+  // Whether to enable local event export. Defaults to false.
+  _isLocalEventExportEnabled?: boolean;
 };
 
 export enum LangfusePersistedProperty {

--- a/langfuse-core/test/langfuse.flush.spec.ts
+++ b/langfuse-core/test/langfuse.flush.spec.ts
@@ -241,28 +241,24 @@ describe("Langfuse Core", () => {
     });
 
     it("should not send events in admin mode", async () => {
-      process.env.LANGFUSE_JS_SDK_LOCAL_EVENT_EXPORT_ENABLED = "true";
-      try {
-        [langfuse, mocks] = createTestClient({
-          publicKey: "pk-lf-111",
-          secretKey: "sk-lf-111",
-          _projectId: "test-project-id",
-          flushAt: 5,
-          flushInterval: 200,
-        });
+      [langfuse, mocks] = createTestClient({
+        publicKey: "pk-lf-111",
+        secretKey: "sk-lf-111",
+        _projectId: "test-project-id",
+        _isLocalEventExportEnabled: true,
+        flushAt: 5,
+        flushInterval: 200,
+      });
 
-        // Create multiple traces
-        const traces = ["test-trace-1", "test-trace-2", "test-trace-3"];
-        traces.forEach((name) => langfuse.trace({ name }));
+      // Create multiple traces
+      const traces = ["test-trace-1", "test-trace-2", "test-trace-3"];
+      traces.forEach((name) => langfuse.trace({ name }));
 
-        expect(mocks.fetch).not.toHaveBeenCalled();
+      expect(mocks.fetch).not.toHaveBeenCalled();
 
-        await jest.runAllTimersAsync();
+      await jest.runAllTimersAsync();
 
-        expect(mocks.fetch).not.toHaveBeenCalled();
-      } finally {
-        process.env.LANGFUSE_JS_SDK_LOCAL_EVENT_EXPORT_ENABLED = undefined;
-      }
+      expect(mocks.fetch).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove local export mode activation via environment variable, replacing it with a constructor parameter in `LangfuseCoreStateless`.
> 
>   - **Behavior**:
>     - Remove enabling local export mode via `LANGFUSE_JS_SDK_LOCAL_EVENT_EXPORT_ENABLED` environment variable.
>     - Add `_isLocalEventExportEnabled` parameter to `LangfuseCoreOptions` in `types.ts`.
>     - Update `LangfuseCoreStateless` constructor to use `_isLocalEventExportEnabled` parameter.
>   - **Functions**:
>     - Rename `_shutdownAdmin()` to `_exportLocalEvents()` in `index.ts`.
>     - Replace `adminIngestionEvents` with `localEventExportMap` in `index.ts`.
>   - **Tests**:
>     - Update tests in `langfuse.flush.spec.ts` and `langfuse-integration-langchain.spec.ts` to use `_isLocalEventExportEnabled` parameter instead of environment variable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 4a0e37e0e9f5f40c1bf7f58f9497d0b2f0902d5f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->