### PR TITLE
fix(media): remove type import fs/crypto

### DIFF
--- a/langfuse-core/src/media/LangfuseMedia.ts
+++ b/langfuse-core/src/media/LangfuseMedia.ts
@@ -1,11 +1,13 @@
-let fs: typeof import("fs") | undefined;
-let crypto: typeof import("crypto") | undefined;
+let fs: any;
+let crypto: any;
 
+// Fail gracefully in environments without fs/crypto support
 try {
   fs = require("fs");
+  crypto = require("crypto");
 } catch {
-  // Fail gracefully in environments without fs/crypto support
   fs = undefined;
+  crypto = undefined;
 }
 
 try {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `fs` and `crypto` types to `any` in `LangfuseMedia.ts` for better environment compatibility.
> 
>   - **Type Changes**:
>     - Change `fs` and `crypto` types from `typeof import("fs")` and `typeof import("crypto")` to `any` in `LangfuseMedia.ts`.
>   - **Error Handling**:
>     - Maintain graceful failure in environments without `fs` or `crypto` support by setting them to `undefined` if `require` fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 3137f27701f633d2c9edd239deed61913bf1c783. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->