### PR TITLE
feat: Add support to provide additional HTTP headers on fetch requests

### DIFF
--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -171,6 +171,7 @@ abstract class LangfuseCoreStateless {
   private secretKey: string | undefined;
   private publicKey: string;
   baseUrl: string;
+  additionalHeaders: Record<string, string> = {};
   private flushAt: number;
   private flushInterval: number;
   private requestTimeout: number;
@@ -207,6 +208,7 @@ abstract class LangfuseCoreStateless {
     this.publicKey = publicKey ?? "";
     this.secretKey = secretKey;
     this.baseUrl = removeTrailingSlash(options?.baseUrl || "https://cloud.langfuse.com");
+    this.additionalHeaders = options?.additionalHeaders || {};
     this.flushAt = options?.flushAt ? Math.max(options?.flushAt, 1) : 15;
     this.flushInterval = options?.flushInterval ?? 10000;
     this.release = options?.release ?? getEnv("LANGFUSE_RELEASE") ?? getCommonReleaseEnvs() ?? undefined;
@@ -1060,6 +1062,7 @@ abstract class LangfuseCoreStateless {
         "X-Langfuse-Sdk-Variant": this.getLibraryId(),
         "X-Langfuse-Sdk-Integration": this.sdkIntegration,
         "X-Langfuse-Public-Key": this.publicKey,
+        ...this.additionalHeaders,
         ...this.constructAuthorizationHeader(this.publicKey, this.secretKey),
       },
       body: p.body,

--- a/langfuse-core/src/types.ts
+++ b/langfuse-core/src/types.ts
@@ -9,6 +9,8 @@ export type LangfuseCoreOptions = {
   secretKey?: string;
   // Langfuse API baseUrl (https://cloud.langfuse.com by default)
   baseUrl?: string;
+  // Additional HTTP headers to send with each request
+  additionalHeaders?: Record<string, string>;
   // The number of events to queue before sending to Langfuse (flushing)
   flushAt?: number;
   // The interval in milliseconds between periodic flushes


### PR DESCRIPTION
## Problem

For organizations self-hosting their Langfuse server, custom authentication methods often require special HTTP headers. This enhancement addresses the need for flexible authentication configurations in self-hosted environments.

## Changes

Added support for an `additionalHeaders` field on `LangfuseCoreStateless`, implemented in the `_getFetchOptions` function. The existing `constructAuthorizationHeader` function maintains priority over these additional headers.

## Release info Sub-libraries affected
- langfuse-core

### Bump level

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

- [x] All of them
- [ ] langfuse
- [ ] langfuse-node

### Changelog notes

- Added support to provide additional HTTP headers on fetch requests

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for custom HTTP headers in fetch requests via `additionalHeaders` in `LangfuseCoreStateless`.
> 
>   - **Behavior**:
>     - Adds `additionalHeaders` field to `LangfuseCoreStateless` in `index.ts` for custom HTTP headers in fetch requests.
>     - Merges `additionalHeaders` with existing headers in `_getFetchOptions()`.
>     - `constructAuthorizationHeader` takes precedence over `additionalHeaders`.
>   - **Types**:
>     - Updates `LangfuseCoreOptions` in `types.ts` to include `additionalHeaders` field.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 373cf260d1e63addebdb383f7616dd97c4cd7612. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->