### PR TITLE
fix(vercel): allow nested executions in parent trace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
           rm -rf .env
 
           echo "::group::Run server"
-          TELEMETRY_ENABLED=false LANGFUSE_ASYNC_INGESTION_PROCESSING=false LANGFUSE_ASYNC_CLICKHOUSE_INGESTION_PROCESSING=false LANGFUSE_READ_FROM_POSTGRES_ONLY=true LANGFUSE_READ_FROM_CLICKHOUSE_ONLY=false docker compose -f docker-compose.v3preview.yml up -d
+          TELEMETRY_ENABLED=false CLICKHOUSE_CLUSTER_ENABLED=false LANGFUSE_ASYNC_INGESTION_PROCESSING=false LANGFUSE_ASYNC_CLICKHOUSE_INGESTION_PROCESSING=false LANGFUSE_READ_FROM_POSTGRES_ONLY=true LANGFUSE_READ_FROM_CLICKHOUSE_ONLY=false docker compose -f docker-compose.v3preview.yml up -d
           echo "::endgroup::"
 
       # Add this step to check the health of the container

--- a/integration-test/langfuse-integration-vercel.spec.ts
+++ b/integration-test/langfuse-integration-vercel.spec.ts
@@ -632,6 +632,7 @@ describe("langfuse-integration-vercel", () => {
           functionId,
           metadata: {
             langfuseTraceId: traceId,
+            langfuseUpdateParent: false,
             userId,
             sessionId,
             tags,

--- a/integration-test/langfuse-integration-vercel.spec.ts
+++ b/integration-test/langfuse-integration-vercel.spec.ts
@@ -593,4 +593,72 @@ describe("langfuse-integration-vercel", () => {
       expect(generation.promptVersion).toBe(fetchedPrompt.version);
     }
   }, 10_000);
+
+  it("should nest multiple generateText call under a trace", async () => {
+    const langfuse = new Langfuse();
+    const traceName = "parent_generate_text_multiple";
+
+    // Create parent trace
+    const parentTraceId = randomUUID();
+    langfuse.trace({ id: parentTraceId, name: traceName });
+    const baseRootSpanName = "root-span";
+
+    const NESTED_RUN_COUNT = 3;
+
+    for (let i = 0; i < NESTED_RUN_COUNT; i++) {
+      const testParams = {
+        traceId: parentTraceId,
+        modelName: "gpt-3.5-turbo",
+        maxTokens: 50,
+        prompt: "Invent a new holiday and describe its traditions.",
+        functionId: `${baseRootSpanName}-${i}`,
+        userId: "some-user-id",
+        sessionId: "some-session-id",
+        metadata: {
+          something: "custom",
+          someOtherThing: "other-value",
+        },
+        tags: ["vercel", "openai"],
+      };
+
+      const { traceId, modelName, maxTokens, prompt, functionId, userId, sessionId, metadata, tags } = testParams;
+
+      await generateText({
+        model: openai(modelName),
+        maxTokens,
+        prompt,
+        experimental_telemetry: {
+          isEnabled: true,
+          functionId,
+          metadata: {
+            langfuseTraceId: traceId,
+            userId,
+            sessionId,
+            tags,
+            ...metadata,
+          },
+        },
+      });
+    }
+
+    await langfuse.flushAsync();
+    await sdk.shutdown();
+
+    // Fetch trace
+    const traceFetchResult = await fetchTraceById(parentTraceId);
+    expect(traceFetchResult.status).toBe(200);
+
+    // Validate trace
+    const fetchedTrace = traceFetchResult.data;
+    expect(fetchedTrace.name).toBe(traceName);
+
+    const rootObservations = fetchedTrace.observations
+      .filter((o: any) => !Boolean(o.parentObservationId))
+      .sort((a: any, b: any) => a.name - b.name);
+
+    for (let i = 0; i < NESTED_RUN_COUNT; i++) {
+      const obs = rootObservations[i];
+      expect(obs.name).toBe(`${baseRootSpanName}-${i}`);
+    }
+  }, 15_000);
 });

--- a/integration-test/langfuse-integration-vercel.spec.ts
+++ b/integration-test/langfuse-integration-vercel.spec.ts
@@ -654,7 +654,7 @@ describe("langfuse-integration-vercel", () => {
 
     const rootObservations = fetchedTrace.observations
       .filter((o: any) => !Boolean(o.parentObservationId))
-      .sort((a: any, b: any) => a.name - b.name);
+      .sort((a: any, b: any) => a.name.localeCompare(b.name));
 
     for (let i = 0; i < NESTED_RUN_COUNT; i++) {
       const obs = rootObservations[i];


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance `LangfuseExporter` to support nested `generateText` calls and improve trace management with new test coverage.
> 
>   - **Behavior**:
>     - Add test in `langfuse-integration-vercel.spec.ts` to verify nesting of multiple `generateText` calls under a single trace.
>     - Modify `LangfuseExporter` in `LangfuseExporter.ts` to handle trace updates and creations based on user-provided trace ID.
>   - **Functions**:
>     - Update `processTraceSpans()` in `LangfuseExporter.ts` to separate trace update and creation logic.
>     - Update `processSpanAsLangfuseSpan()` to optionally use `rootSpanName` for root spans.
>   - **Misc**:
>     - Add `traceUpdate` and `traceCreate` objects in `LangfuseExporter.ts` for better trace management.
>     - Update CI configuration in `.github/workflows/ci.yml` to disable `CLICKHOUSE_CLUSTER_ENABLED`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for fcc427d44158a134d29d44513de8b5a40973312b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->