### PR TITLE
fix(langfuse-vercel): fix attribute parsing in LangfuseExporter

### DIFF
--- a/langfuse-core/package.json
+++ b/langfuse-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse-core",
-  "version": "3.30.4",
+  "version": "3.30.5",
   "engines": {
     "node": ">=18"
   },

--- a/langfuse-langchain/package.json
+++ b/langfuse-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse-langchain",
-  "version": "3.30.4",
+  "version": "3.30.5",
   "engines": {
     "node": ">=18"
   },
@@ -34,8 +34,8 @@
   ],
   "gitHead": "c3e0ccf0b1ad08049e4ad5d4f7ea8b3b30857091",
   "dependencies": {
-    "langfuse": "^3.30.4",
-    "langfuse-core": "^3.30.4"
+    "langfuse": "^3.30.5",
+    "langfuse-core": "^3.30.5"
   },
   "peerDependencies": {
     "langchain": ">=0.0.157 <0.4.0"

--- a/langfuse-node/package.json
+++ b/langfuse-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse-node",
-  "version": "3.30.4",
+  "version": "3.30.5",
   "scripts": {
     "prepublishOnly": "cd .. && yarn build"
   },
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "axios": "^1.7.4",
-    "langfuse-core": "^3.30.4"
+    "langfuse-core": "^3.30.5"
   },
   "devDependencies": {
     "@types/node": "^22.7.4",

--- a/langfuse-vercel/package.json
+++ b/langfuse-vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse-vercel",
-  "version": "3.30.4",
+  "version": "3.30.5",
   "engines": {
     "node": ">=18"
   },
@@ -34,8 +34,8 @@
   ],
   "gitHead": "c3e0ccf0b1ad08049e4ad5d4f7ea8b3b30857091",
   "dependencies": {
-    "langfuse": "^3.30.4",
-    "langfuse-core": "^3.30.4"
+    "langfuse": "^3.30.5",
+    "langfuse-core": "^3.30.5"
   },
   "peerDependencies": {
     "ai": ">=3.2.44"

--- a/langfuse/package.json
+++ b/langfuse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse",
-  "version": "3.30.4",
+  "version": "3.30.5",
   "engines": {
     "node": ">=18"
   },
@@ -32,7 +32,7 @@
     "Readme.md"
   ],
   "dependencies": {
-    "langfuse-core": "^3.30.4"
+    "langfuse-core": "^3.30.5"
   },
   "gitHead": "c3e0ccf0b1ad08049e4ad5d4f7ea8b3b30857091",
   "devDependencies": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "npmClient": "yarn",
-  "version": "3.30.4"
+  "version": "3.30.5"
 }


### PR DESCRIPTION
- Refactor output parsing to use array of possible keys
- Update output attribute keys to match current Vercel AI SDK
- Add number parsing helper to properly handle maxTokens parameter
- Add integration test for Vercel AI SDK attribute mapping
- Add dotenv config import for test environment

The output parsing is now more maintainable with a centralized list of possible keys. Integration tests verify correct mapping of all relevant Vercel AI SDK attributes.