### PR TITLE
feat(vercel): add v4 support

### DIFF
--- a/integration-test/langfuse-integration-vercel.spec.ts
+++ b/integration-test/langfuse-integration-vercel.spec.ts
@@ -1,4 +1,4 @@
-import { embed, embedMany, generateObject, generateText, streamObject, streamText, streamToResponse, tool } from "ai";
+import { embed, embedMany, generateObject, generateText, streamObject, streamText, tool } from "ai";
 import { randomUUID } from "crypto";
 import z from "zod";
 
@@ -46,7 +46,7 @@ describe("langfuse-integration-vercel", () => {
   it("should trace a generateText call", async () => {
     const testParams = {
       traceId: randomUUID(),
-      modelName: "gpt-3.5-turbo",
+      modelName: "gpt-3.5-turbo-0125",
       maxTokens: 50,
       prompt: "Invent a new holiday and describe its traditions.",
       functionId: "test-vercel-generate-text",
@@ -118,7 +118,7 @@ describe("langfuse-integration-vercel", () => {
     const testParams = {
       traceId: randomUUID(),
       functionId: "test-vercel-tool-call",
-      modelName: "gpt-3.5-turbo",
+      modelName: "gpt-3.5-turbo-0125",
       maxTokens: 512,
       prompt: "What is the weather in San Francisco?",
       userId: "some-user-id",
@@ -136,7 +136,7 @@ describe("langfuse-integration-vercel", () => {
       model: openai(modelName),
       maxTokens,
       prompt,
-      maxToolRoundtrips: 3,
+      maxSteps: 3,
       tools: {
         weather: weatherTool,
       },
@@ -193,7 +193,7 @@ describe("langfuse-integration-vercel", () => {
     const testParams = {
       traceId: randomUUID(),
       functionId: "test-vercel-stream-text",
-      modelName: "gpt-3.5-turbo",
+      modelName: "gpt-3.5-turbo-0125",
       maxTokens: 512,
       prompt: "Invent a new holiday and describe its traditions.",
       userId: "some-user-id",
@@ -272,7 +272,7 @@ describe("langfuse-integration-vercel", () => {
     const testParams = {
       traceId: randomUUID(),
       functionId: "test-vercel-generate-object",
-      modelName: "gpt-4-turbo",
+      modelName: "gpt-4-turbo-2024-04-09",
       maxTokens: 512,
       prompt: "Generate a lasagna recipe.",
       userId: "some-user-id",
@@ -357,7 +357,7 @@ describe("langfuse-integration-vercel", () => {
     const testParams = {
       traceId: randomUUID(),
       functionId: "test-vercel-streamObject",
-      modelName: "gpt-4-turbo",
+      modelName: "gpt-4-turbo-2024-04-09",
       maxTokens: 512,
       prompt: "Generate a lasagna recipe.",
       userId: "some-user-id",
@@ -517,7 +517,7 @@ describe("langfuse-integration-vercel", () => {
     const testParams = {
       traceId: randomUUID(),
       functionId: "test-vercel-stream-text",
-      modelName: "gpt-3.5-turbo",
+      modelName: "gpt-3.5-turbo-0125",
       maxTokens: 512,
       prompt: fetchedPrompt.prompt,
       userId: "some-user-id",
@@ -608,7 +608,7 @@ describe("langfuse-integration-vercel", () => {
     for (let i = 0; i < NESTED_RUN_COUNT; i++) {
       const testParams = {
         traceId: parentTraceId,
-        modelName: "gpt-3.5-turbo",
+        modelName: "gpt-3.5-turbo-0125",
         maxTokens: 50,
         prompt: "Invent a new holiday and describe its traditions.",
         functionId: `${baseRootSpanName}-${i}`,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "docs": "yarn build && typedoc --options ./typedoc.config.cjs"
   },
   "devDependencies": {
-    "@ai-sdk/openai": "^0.0.48",
+    "@ai-sdk/openai": "^1.0.5",
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
     "@babel/preset-react": "^7.24.7",
@@ -59,7 +59,7 @@
     "@types/node": "^22.7.4",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^6.21.0",
-    "ai": "^3.3.27",
+    "ai": "^4.0.6",
     "axios": "^1.7.4",
     "babel-jest": "^29.7.0",
     "dotenv-cli": "^7.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,93 +7,49 @@
   resolved "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@ai-sdk/openai@^0.0.48":
-  version "0.0.48"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/openai/-/openai-0.0.48.tgz#7a9dcfc84f6f781cea58b6eb0edfa6edd17e864f"
-  integrity sha512-buw9cT/55VGjvtcNvQGDljHQMan8C3/D1UvkcpY8XPfnimffrjAQa66fXldahhFQM20didNJawh0vlTM1MvRDw==
+"@ai-sdk/openai@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/openai/-/openai-1.0.5.tgz#cafc58f91f585597b855aa65aae743fee2e6c280"
+  integrity sha512-JDCPBJQx9o3LgboBPaA55v+9EZ7Vm/ozy0+J5DIr2jJF8WETjeCnigdxixyzEy/Od4wX871jOTSuGffwNIi0kA==
   dependencies:
-    "@ai-sdk/provider" "0.0.20"
-    "@ai-sdk/provider-utils" "1.0.13"
+    "@ai-sdk/provider" "1.0.1"
+    "@ai-sdk/provider-utils" "2.0.2"
 
-"@ai-sdk/provider-utils@1.0.13":
-  version "1.0.13"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-1.0.13.tgz#073feeeb4baefe9efb5106b99126d69b379f229b"
-  integrity sha512-NDQUUBDQoWk9aGn2pOA5wiM5CdO57KeYTEph7PpKGEU8IyqI0d+CiYKISOia6Omy17d+Dw/ZM6KP98F89BGJ5A==
+"@ai-sdk/provider-utils@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-2.0.2.tgz#ea9d510be442b38bd40ae50dbf5b64ffc396952b"
+  integrity sha512-IAvhKhdlXqiSmvx/D4uNlFYCl8dWT+M9K+IuEcSgnE2Aj27GWu8sDIpAf4r4Voc+wOUkOECVKQhFo8g9pozdjA==
   dependencies:
-    "@ai-sdk/provider" "0.0.20"
-    eventsource-parser "1.1.2"
-    nanoid "3.3.6"
-    secure-json-parse "2.7.0"
+    "@ai-sdk/provider" "1.0.1"
+    eventsource-parser "^3.0.0"
+    nanoid "^3.3.7"
+    secure-json-parse "^2.7.0"
 
-"@ai-sdk/provider-utils@1.0.18":
-  version "1.0.18"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-1.0.18.tgz#bd30948d6b4ad73a3fbc94f3beeb92f4fa198ded"
-  integrity sha512-9u/XE/dB1gsIGcxiC5JfGOLzUz+EKRXt66T8KYWwDg4x8d02P+fI/EPOgkf+T4oLBrcQgvs4GPXPKoXGPJxBbg==
+"@ai-sdk/provider@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-1.0.1.tgz#8172a3cbbfa61bb40b88512165f70fe3c186cb60"
+  integrity sha512-mV+3iNDkzUsZ0pR2jG0sVzU6xtQY5DtSCBy3JFycLp6PwjyLw/iodfL3MwdmMCRJWgs3dadcHejRnMvF9nGTBg==
   dependencies:
-    "@ai-sdk/provider" "0.0.23"
-    eventsource-parser "1.1.2"
-    nanoid "3.3.6"
-    secure-json-parse "2.7.0"
+    json-schema "^0.4.0"
 
-"@ai-sdk/provider@0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-0.0.20.tgz#a51a8e6f42ce251bf4517523d31652e3bcbca401"
-  integrity sha512-nCQZRUTi/+y+kf1ep9rujpbQEtsIwySzlQAudiFeVhzzDi9rYvWp5tOSVu8/ArT+i1xSc2tw40akxb1TX73ofQ==
+"@ai-sdk/react@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/react/-/react-1.0.3.tgz#b9bc24e20bdc5768cbb0d9c65471fb60ab2675ec"
+  integrity sha512-Mak7qIRlbgtP4I7EFoNKRIQTlABJHhgwrN8SV2WKKdmsfWK2RwcubQWz1hp88cQ0bpF6KxxjSY1UUnS/S9oR5g==
   dependencies:
-    json-schema "0.4.0"
+    "@ai-sdk/provider-utils" "2.0.2"
+    "@ai-sdk/ui-utils" "1.0.2"
+    swr "^2.2.5"
+    throttleit "2.1.0"
 
-"@ai-sdk/provider@0.0.23":
-  version "0.0.23"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-0.0.23.tgz#a69a9103854bbfb500dddf0b44a399edf3db4735"
-  integrity sha512-oAc49O5+xypVrKM7EUU5P/Y4DUL4JZUWVxhejoAVOTOl3WZUEWsMbP3QZR+TrimQIsS0WR/n9UuF6U0jPdp0tQ==
+"@ai-sdk/ui-utils@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/ui-utils/-/ui-utils-1.0.2.tgz#2b5ad527f821b055663ddc60f2c45a82956091a0"
+  integrity sha512-hHrUdeThGHu/rsGZBWQ9PjrAU9Htxgbo9MFyR5B/aWoNbBeXn1HLMY1+uMEnXL5pRPlmyVRjgIavWg7UgeNDOw==
   dependencies:
-    json-schema "0.4.0"
-
-"@ai-sdk/react@0.0.55":
-  version "0.0.55"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/react/-/react-0.0.55.tgz#77342e7f5936fe184e6a7839e8c3cc02e9aef8b3"
-  integrity sha512-9fUUEEEoH01M6ZhvyZ/2v0DI6tiYnSldBg6RaKoy+qx2tSeKvOpFNZhT/iOvQ7oqAyyp0Ocg5Rj7L/jcLXSMxw==
-  dependencies:
-    "@ai-sdk/provider-utils" "1.0.18"
-    "@ai-sdk/ui-utils" "0.0.41"
-    swr "2.2.5"
-
-"@ai-sdk/solid@0.0.44":
-  version "0.0.44"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/solid/-/solid-0.0.44.tgz#948a5663ac88bec45303c6cf2ac60d6ffdafd562"
-  integrity sha512-3kMhxalepc78jWr2Qg1BAHbY04JKYxp8wRu3TACrRUdokxzwD5sbZYtTb7vu9tw2wx78rfu0DH44CESFWpSfZg==
-  dependencies:
-    "@ai-sdk/provider-utils" "1.0.18"
-    "@ai-sdk/ui-utils" "0.0.41"
-
-"@ai-sdk/svelte@0.0.46":
-  version "0.0.46"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/svelte/-/svelte-0.0.46.tgz#21b4258b211635e5f9d8bb6eab52c2609e54aec3"
-  integrity sha512-cokqS91vQkpqiRgf8xKwOONFb/RwkIbRg9jYVRb+z5NR9OsWXKMEfoCAf8+VgURfVbp8nqA+ddRXvtgYCwqQjQ==
-  dependencies:
-    "@ai-sdk/provider-utils" "1.0.18"
-    "@ai-sdk/ui-utils" "0.0.41"
-    sswr "2.1.0"
-
-"@ai-sdk/ui-utils@0.0.41":
-  version "0.0.41"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/ui-utils/-/ui-utils-0.0.41.tgz#411d6764bb154689834cf13487917a37df729e2d"
-  integrity sha512-I0trJKWxVG8hXeG0MvKqLG54fZjdeGjXvcVZocaSnWMBhl9lpTQxrqAR6ZsQMFDXs5DbvXoKtQs488qu2Bzaiw==
-  dependencies:
-    "@ai-sdk/provider" "0.0.23"
-    "@ai-sdk/provider-utils" "1.0.18"
-    json-schema "0.4.0"
-    secure-json-parse "2.7.0"
-    zod-to-json-schema "3.23.2"
-
-"@ai-sdk/vue@0.0.46":
-  version "0.0.46"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/vue/-/vue-0.0.46.tgz#4c67334c561128db2a2843513f794887be942438"
-  integrity sha512-H366ydskPbZP8uRs4sm3SAi97P3JVTRI5Q8xYTI6uTaY4UFBA6aOWdDxniYZNa67ebemfe11m7ksX4wHW6Wl8g==
-  dependencies:
-    "@ai-sdk/provider-utils" "1.0.18"
-    "@ai-sdk/ui-utils" "0.0.41"
-    swrv "1.0.4"
+    "@ai-sdk/provider" "1.0.1"
+    "@ai-sdk/provider-utils" "2.0.2"
+    zod-to-json-schema "^3.23.5"
 
 "@ampproject/remapping@^2.2.0":
   version "2.2.1"
@@ -3828,25 +3784,18 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ai@^3.3.27:
-  version "3.3.27"
-  resolved "https://registry.yarnpkg.com/ai/-/ai-3.3.27.tgz#6bfb445354b494e2f60658561a4f9cbff7f24352"
-  integrity sha512-ARKVzndpE4ujlXWU7I72Ei7nlEcUGC84HvbduOFZW1jdTG0EU/pgT6meRLYCuY+khKfmsI7VCJcgyXuZrvwN5g==
+ai@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ai/-/ai-4.0.6.tgz#94ef793df8525c01043e15a60030ce88d7b5c7d5"
+  integrity sha512-TD7fH0LymjIYWmdQViB5SoBb1iuuDPOZ7RMU3W9r4SeUf68RzWyixz118QHQTENNqPiGA6vs5NDVAmZOnhzqYA==
   dependencies:
-    "@ai-sdk/provider" "0.0.23"
-    "@ai-sdk/provider-utils" "1.0.18"
-    "@ai-sdk/react" "0.0.55"
-    "@ai-sdk/solid" "0.0.44"
-    "@ai-sdk/svelte" "0.0.46"
-    "@ai-sdk/ui-utils" "0.0.41"
-    "@ai-sdk/vue" "0.0.46"
+    "@ai-sdk/provider" "1.0.1"
+    "@ai-sdk/provider-utils" "2.0.2"
+    "@ai-sdk/react" "1.0.3"
+    "@ai-sdk/ui-utils" "1.0.2"
     "@opentelemetry/api" "1.9.0"
-    eventsource-parser "1.1.2"
-    json-schema "0.4.0"
     jsondiffpatch "0.6.0"
-    nanoid "3.3.6"
-    secure-json-parse "2.7.0"
-    zod-to-json-schema "3.23.2"
+    zod-to-json-schema "^3.23.5"
 
 ajv@^6.12.4:
   version "6.12.6"
@@ -5575,10 +5524,10 @@ eventemitter3@^4.0.4:
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-eventsource-parser@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-1.1.2.tgz#ed6154a4e3dbe7cda9278e5e35d2ffc58b309f89"
-  integrity sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==
+eventsource-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.0.tgz#9303e303ef807d279ee210a17ce80f16300d9f57"
+  integrity sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA==
 
 execa@5.0.0:
   version "5.0.0"
@@ -7463,7 +7412,7 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-schema@0.4.0:
+json-schema@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
   integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
@@ -8247,10 +8196,10 @@ mute-stream@^1.0.0, mute-stream@~1.0.0:
   resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz"
   integrity sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==
 
-nanoid@3.3.6:
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
-  integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
+nanoid@^3.3.7:
+  version "3.3.8"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
+  integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -9697,7 +9646,7 @@ saxes@^6.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-secure-json-parse@2.7.0:
+secure-json-parse@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.7.0.tgz#5a5f9cd6ae47df23dba3151edd06855d47e09862"
   integrity sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==
@@ -9954,13 +9903,6 @@ ssri@^10.0.0, ssri@^10.0.6:
   dependencies:
     minipass "^7.0.3"
 
-sswr@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/sswr/-/sswr-2.1.0.tgz#1eb64cd647cc9e11f871e7f43554abd8c64e1103"
-  integrity sha512-Cqc355SYlTAaUt8iDPaC/4DPPXK925PePLMxyBKuWd5kKc5mwsG3nT9+Mq2tyguL5s7b4Jg+IRMpTRsNTAfpSQ==
-  dependencies:
-    swrev "^4.0.0"
-
 stack-utils@^2.0.3:
   version "2.0.6"
   resolved "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz"
@@ -10194,23 +10136,13 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-swr@2.2.5:
+swr@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/swr/-/swr-2.2.5.tgz#063eea0e9939f947227d5ca760cc53696f46446b"
   integrity sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==
   dependencies:
     client-only "^0.0.1"
     use-sync-external-store "^1.2.0"
-
-swrev@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/swrev/-/swrev-4.0.0.tgz#83da6983c7ef9d71ac984a9b169fc197cbf18ff8"
-  integrity sha512-LqVcOHSB4cPGgitD1riJ1Hh4vdmITOp+BkmfmXRh4hSF/t7EnS4iD+SOTmq7w5pPm/SiPeto4ADbKS6dHUDWFA==
-
-swrv@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/swrv/-/swrv-1.0.4.tgz#278b4811ed4acbb1ae46654972a482fd1847e480"
-  integrity sha512-zjEkcP8Ywmj+xOJW3lIT65ciY/4AL4e/Or7Gj0MzU3zBJNMdJiT8geVZhINavnlHRMMCcJLHhraLTAiDOTmQ9g==
 
 symbol-tree@^3.2.4:
   version "3.2.4"
@@ -10271,6 +10203,11 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
+
+throttleit@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-2.1.0.tgz#a7e4aa0bf4845a5bd10daa39ea0c783f631a07b4"
+  integrity sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==
 
 through2@^2.0.0:
   version "2.0.5"
@@ -11135,10 +11072,15 @@ yocto-queue@^0.1.0:
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zod-to-json-schema@3.23.2, zod-to-json-schema@^3.22.3, zod-to-json-schema@^3.22.5:
+zod-to-json-schema@^3.22.3, zod-to-json-schema@^3.22.5:
   version "3.23.2"
   resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.23.2.tgz#bc7e379c8050462538383e382964c03d8fe008f9"
   integrity sha512-uSt90Gzc/tUfyNqxnjlfBs8W6WSGpNBv0rVsNxP/BVSMHMKGdthPYff4xtCHYloJGM0CFxFsb3NbC0eqPhfImw==
+
+zod-to-json-schema@^3.23.5:
+  version "3.23.5"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.23.5.tgz#ec23def47dcafe3a4d640eba6a346b34f9a693a5"
+  integrity sha512-5wlSS0bXfF/BrL4jPAbz9da5hDlDptdEppYfe+x4eIJ7jioqKG9uUxOwPzqof09u/XeVdrgFu29lZi+8XNDJtA==
 
 zod@^3.22.3, zod@^3.22.4:
   version "3.23.8"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add V4 support in Vercel integration by updating model names and handling legacy AI SDK versions.
> 
>   - **Behavior**:
>     - Update model names in `langfuse-integration-vercel.spec.ts` to `gpt-3.5-turbo-0125` and `gpt-4-turbo-2024-04-09`.
>     - Handle legacy support for AI SDK versions < 4.0.0 in `LangfuseExporter.ts` by checking for older attribute names.
>   - **Dependencies**:
>     - Update `@ai-sdk/openai` to `^1.0.5` and `ai` to `^4.0.6` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for c8addf7598b8829f97c26a3b09d3cdf20d7fa473. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->