### PR TITLE
feat(media): support additional content types

### DIFF
--- a/langfuse-core/openapi-spec/openapi-server.yaml
+++ b/langfuse-core/openapi-spec/openapi-server.yaml
@@ -4059,7 +4059,7 @@ components:
       type: string
       enum:
         - >-
-          image/png","image/jpeg","image/jpg","image/webp","audio/mpeg","audio/mp3","audio/wav","text/plain","application/pdf
+          image/png","image/jpeg","image/jpg","image/webp","image/gif","image/svg+xml","image/tiff","image/bmp","audio/mpeg","audio/mp3","audio/wav","audio/ogg","audio/oga","audio/aac","audio/mp4","audio/flac","video/mp4","video/webm","text/plain","text/html","text/css","text/csv","application/pdf","application/msword","application/vnd.ms-excel","application/zip","application/json","application/xml","application/octet-stream
       description: The MIME type of the media record
     DailyMetrics:
       title: DailyMetrics


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Expanded supported MIME types for media records in `openapi-server.yaml` to include additional image, audio, video, text, and application formats.
> 
>   - **Behavior**:
>     - Expanded supported MIME types in `openapi-server.yaml` for media records to include additional image, audio, and video formats such as `image/gif`, `image/svg+xml`, `audio/ogg`, `audio/aac`, `video/mp4`, and `video/webm`.
>     - Now supports text formats like `text/html`, `text/css`, `text/csv`, and application formats like `application/msword`, `application/vnd.ms-excel`, `application/zip`, `application/json`, `application/xml`, `application/octet-stream`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 299b37d1a3194ccf764fce9cb4611e995e74efd1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->