### PR TITLE
feat: use projectid when generating trace urls

### DIFF
--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -1606,7 +1606,7 @@ export abstract class LangfuseObjectClient {
         return `${this.client.baseUrl}/trace/${this.traceId}`;
       }
     }
-    return `${this.client.baseUrl}/${this.projectId}/traces/${this.traceId}`;
+    return `${this.client.baseUrl}/project/${this.projectId}/traces/${this.traceId}`;
   }
 }
 

--- a/langfuse-core/src/types.ts
+++ b/langfuse-core/src/types.ts
@@ -116,6 +116,9 @@ export type GetLangfuseSessionsQuery = FixTypes<paths["/api/public/sessions"]["g
 export type GetLangfuseSessionsResponse = FixTypes<
   paths["/api/public/sessions"]["get"]["responses"]["200"]["content"]["application/json"]
 >;
+export type GetLangfuseProjectsResponse = FixTypes<
+  paths["/api/public/projects"]["get"]["responses"]["200"]["content"]["application/json"]
+>;
 export type GetLangfuseDatasetParams = FixTypes<
   paths["/api/public/v2/datasets/{datasetName}"]["get"]["parameters"]["path"]
 >;
@@ -220,16 +223,6 @@ type FixTypes<T> = T extends undefined
       },
       "externalId" | "traceIdType"
     >;
-
-export type DeferRuntime = {
-  langfuseTraces: (
-    traces: {
-      id: string;
-      name: string;
-      url: string;
-    }[]
-  ) => void;
-};
 
 // Datasets
 export type DatasetItemData = GetLangfuseDatasetItemsResponse["data"][number];

--- a/langfuse-core/test/langfuse.traces.spec.ts
+++ b/langfuse-core/test/langfuse.traces.spec.ts
@@ -455,7 +455,7 @@ describe("Langfuse Core", () => {
         }),
       });
 
-      expect(trace.getTraceUrl()).toBe(`http://localhost:3000/project/test-project-id/traces/${traceId}`);
+      expect(await trace.getTraceUrl()).toBe(`http://localhost:3000/project/test-project-id/traces/${traceId}`);
 
       expect(mocks.fetch).toHaveBeenCalledTimes(2);
       const [url2, options2] = mocks.fetch.mock.calls[1];

--- a/langfuse-core/test/langfuse.traces.spec.ts
+++ b/langfuse-core/test/langfuse.traces.spec.ts
@@ -455,7 +455,7 @@ describe("Langfuse Core", () => {
         }),
       });
 
-      expect(trace.getTraceUrl()).toBe(`http://localhost:3000/test-project-id/traces/${traceId}`);
+      expect(trace.getTraceUrl()).toBe(`http://localhost:3000/project/test-project-id/traces/${traceId}`);
 
       expect(mocks.fetch).toHaveBeenCalledTimes(2);
       const [url2, options2] = mocks.fetch.mock.calls[1];

--- a/langfuse-core/test/langfuse.traces.spec.ts
+++ b/langfuse-core/test/langfuse.traces.spec.ts
@@ -402,6 +402,8 @@ describe("Langfuse Core", () => {
       });
     });
     it("should return the correct traceId", async () => {
+      jest.setSystemTime(new Date("2022-01-01"));
+
       const traceId = randomUUID();
       const trace = langfuse.trace({
         id: traceId,
@@ -414,7 +416,7 @@ describe("Langfuse Core", () => {
           hello: "world",
         },
       });
-
+      await jest.advanceTimersByTimeAsync(1);
       expect(mocks.fetch).toHaveBeenCalledTimes(1);
       const [url, options] = mocks.fetch.mock.calls[0];
       expect(url).toMatch(/^https:\/\/cloud\.langfuse\.com\/api\/public\/ingestion$/);

--- a/langfuse-core/test/langfuse.traces.spec.ts
+++ b/langfuse-core/test/langfuse.traces.spec.ts
@@ -402,8 +402,6 @@ describe("Langfuse Core", () => {
       });
     });
     it("should return the correct traceId", async () => {
-      jest.setSystemTime(new Date("2022-01-01"));
-
       const traceId = randomUUID();
       const trace = langfuse.trace({
         id: traceId,
@@ -416,7 +414,6 @@ describe("Langfuse Core", () => {
           hello: "world",
         },
       });
-      await jest.advanceTimersByTimeAsync(1);
 
       expect(mocks.fetch).toHaveBeenCalledTimes(1);
       const [url, options] = mocks.fetch.mock.calls[0];

--- a/langfuse-core/test/langfuse.traces.spec.ts
+++ b/langfuse-core/test/langfuse.traces.spec.ts
@@ -457,7 +457,7 @@ describe("Langfuse Core", () => {
         }),
       });
 
-      expect(await trace.getTraceUrl()).toBe(`http://localhost:3000/project/test-project-id/traces/${traceId}`);
+      expect(await trace.getTraceUrl()).toBe(`https://cloud.langfuse.com/project/test-project-id/traces/${traceId}`);
 
       expect(mocks.fetch).toHaveBeenCalledTimes(2);
       const [url2, options2] = mocks.fetch.mock.calls[1];


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance `getTraceUrl()` to include `projectId` and add project fetching functionality with tests.
> 
>   - **Behavior**:
>     - `getTraceUrl()` in `LangfuseObjectClient` now includes `projectId` in the URL. If `projectId` is not set, it fetches from `/api/public/projects`.
>     - Removes `DeferRuntime` type from `types.ts`.
>   - **Functions**:
>     - Adds `fetchProjects()` in `LangfuseCoreStateless` to retrieve project data.
>   - **Tests**:
>     - Adds test in `langfuse.traces.spec.ts` to verify `getTraceUrl()` returns correct URL with `projectId`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for b28ad60e0d44643f0cf9944888620c2294f5caff. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->