### PR TITLE
fix azure model name empty error

### DIFF
--- a/langfuse-vercel/src/LangfuseExporter.ts
+++ b/langfuse-vercel/src/LangfuseExporter.ts
@@ -163,7 +163,7 @@ export class LangfuseExporter implements SpanExporter {
               ? new Date(this.hrTimeToDate(span.startTime).getTime() + Number(attributes["ai.stream.msToFirstChunk"]))
               : undefined,
       model:
-        "ai.response.model" in attributes
+        "ai.response.model" in attributes && attributes["ai.response.model"]?.toString()
           ? attributes["ai.response.model"]?.toString()
           : "gen_ai.request.model" in attributes
             ? attributes["gen_ai.request.model"]?.toString()


### PR DESCRIPTION
## Problem

Azure OpenAI model names were not being correctly captured in vercel AI SDK  traces due to missing attribute parsing.
 
## Changes

Parsing Azure OpenAI model names in the Langfuse exporter by adding an additional check for the `ai.response.model` attribute.

## Release info Sub-libraries affected

langfuse-vercel

### Libraries affected

none

### Changelog notes
- Fix Azure OpenAI model name parsing in Langfuse exporter
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix Azure OpenAI model name parsing in `LangfuseExporter` by adding a check for `ai.response.model` attribute.
> 
>   - **Behavior**:
>     - Fix Azure OpenAI model name parsing in `LangfuseExporter` by adding a check for `ai.response.model` attribute.
>   - **Misc**:
>     - Update changelog notes to reflect the fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for b2aa2993b34b698e0d487382f3cdb5d292d12407. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->