### PR TITLE
chore(ci): unquarantine media download test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
           rm -rf .env
 
           echo "::group::Run server"
-          TELEMETRY_ENABLED=false LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT=http://host.docker.internal:9090 LANGFUSE_SDK_CI_SYNC_PROCESSING_ENABLED=true LANGFUSE_READ_FROM_POSTGRES_ONLY=true LANGFUSE_READ_FROM_CLICKHOUSE_ONLY=false LANGFUSE_RETURN_FROM_CLICKHOUSE=false docker compose up -d
+          TELEMETRY_ENABLED=false LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT=http://0.0.0.0:9090 LANGFUSE_SDK_CI_SYNC_PROCESSING_ENABLED=true LANGFUSE_READ_FROM_POSTGRES_ONLY=true LANGFUSE_READ_FROM_CLICKHOUSE_ONLY=false LANGFUSE_RETURN_FROM_CLICKHOUSE=false docker compose up -d
           echo "::endgroup::"
 
       # Add this step to check the health of the container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
           rm -rf .env
 
           echo "::group::Run server"
-          TELEMETRY_ENABLED=false LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT=http://0.0.0.0:9090 LANGFUSE_SDK_CI_SYNC_PROCESSING_ENABLED=true LANGFUSE_READ_FROM_POSTGRES_ONLY=true LANGFUSE_READ_FROM_CLICKHOUSE_ONLY=false LANGFUSE_RETURN_FROM_CLICKHOUSE=false docker compose up -d
+          TELEMETRY_ENABLED=false LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT=http://localhost:9090 LANGFUSE_SDK_CI_SYNC_PROCESSING_ENABLED=true LANGFUSE_READ_FROM_POSTGRES_ONLY=true LANGFUSE_READ_FROM_CLICKHOUSE_ONLY=false LANGFUSE_RETURN_FROM_CLICKHOUSE=false docker compose up -d
           echo "::endgroup::"
 
       # Add this step to check the health of the container

--- a/integration-test/langfuse-integration-fetch.spec.ts
+++ b/integration-test/langfuse-integration-fetch.spec.ts
@@ -643,8 +643,7 @@ describe("Langfuse (fetch)", () => {
     });
   });
 
-  // TODO: enable this test once networking issue is fixed
-  it.skip("replace media reference string in object", async () => {
+  it("replace media reference string in object", async () => {
     const langfuse = new Langfuse();
     const mockTraceName = "test-trace-with-audio" + Math.random().toString(36);
     const mockAudioBytes = fs.readFileSync("./static/joke_prompt.wav"); // Simple mock audio bytes


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Unquarantines a media reference test and updates CI configuration for `LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT`.
> 
>   - **Tests**:
>     - Unquarantines the test `replace media reference string in object` in `langfuse-integration-fetch.spec.ts` by removing `.skip`.
>   - **CI Configuration**:
>     - Changes `LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT` from `http://host.docker.internal:9090` to `http://0.0.0.0:9090` in `ci.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 5bf02710989179a5f450b2d681e2a36c864e4fd3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->