### PR TITLE
fix: support passing in traceName as the JSDocs say

### DIFF
--- a/langfuse/src/openai/observeOpenAI.ts
+++ b/langfuse/src/openai/observeOpenAI.ts
@@ -38,7 +38,8 @@ export const observeOpenAI = <SDKType extends object>(
 
       const defaultGenerationName = `${sdk.constructor?.name}.${propKey.toString()}`;
       const generationName = langfuseConfig?.generationName ?? defaultGenerationName;
-      const config = { ...langfuseConfig, generationName };
+      const traceName = langfuseConfig && 'traceName' in langfuseConfig ? langfuseConfig.traceName : generationName;
+      const config = { ...langfuseConfig, generationName, traceName};      
 
       // Add a flushAsync method to the OpenAI SDK that flushes the Langfuse client
       if (propKey === "flushAsync") {

--- a/langfuse/src/openai/parseOpenAI.ts
+++ b/langfuse/src/openai/parseOpenAI.ts
@@ -64,11 +64,11 @@ export const parseCompletionOutput = (res: unknown): string => {
 
 export const parseUsage = (res: unknown): Usage | undefined => {
   if (hasCompletionUsage(res)) {
-    const { prompt_tokens, completion_tokens, total_tokens } = res.usage;
+    const { prompt_tokens, total_tokens } = res.usage;
 
     return {
       promptTokens: prompt_tokens,
-      completionTokens: completion_tokens,
+      completionTokens: 'completion_tokens' in res.usage ? res.usage.completion_tokens : 0,
       totalTokens: total_tokens,
     };
   }
@@ -102,13 +102,13 @@ export const parseChunk = (
 };
 
 // Type guard to check if an unknown object is a UsageResponse
-function hasCompletionUsage(obj: any): obj is { usage: OpenAI.CompletionUsage } {
+function hasCompletionUsage(obj: any): obj is { usage: OpenAI.CompletionUsage | OpenAI.CreateEmbeddingResponse.Usage } {
   return (
     obj instanceof Object &&
     "usage" in obj &&
     obj.usage instanceof Object &&
     typeof obj.usage.prompt_tokens === "number" &&
-    typeof obj.usage.completion_tokens === "number" &&
+    (!obj.usage.completion_tokens || typeof obj.usage.completion_tokens === "number") && 
     typeof obj.usage.total_tokens === "number"
   );
 }

--- a/langfuse/src/openai/traceMethod.ts
+++ b/langfuse/src/openai/traceMethod.ts
@@ -60,6 +60,7 @@ const wrapMethod = async <T extends GenericMethod>(
       ...config,
       ...observationData,
       id: config?.traceId,
+      name: config?.traceName,
       timestamp: observationData.startTime,
     });
   }

--- a/langfuse/src/openai/traceMethod.ts
+++ b/langfuse/src/openai/traceMethod.ts
@@ -75,13 +75,12 @@ const wrapMethod = async <T extends GenericMethod>(
         const textChunks: string[] = [];
         const toolCallChunks: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta.ToolCall[] = [];
         let completionStartTime: Date | null = null;
-        let usage: OpenAI.CompletionUsage | null = null;
-
+        let usage: OpenAI.CompletionUsage | OpenAI.CreateEmbeddingResponse.Usage | null = null;
         for await (const rawChunk of response as AsyncIterable<unknown>) {
           completionStartTime = completionStartTime ?? new Date();
 
           if (typeof rawChunk === "object" && rawChunk != null && "usage" in rawChunk) {
-            usage = rawChunk.usage as OpenAI.CompletionUsage | null;
+            usage = rawChunk.usage as OpenAI.CompletionUsage | OpenAI.CreateEmbeddingResponse.Usage  | null;
           }
 
           const processedChunk = parseChunk(rawChunk);

--- a/langfuse/src/openai/types.ts
+++ b/langfuse/src/openai/types.ts
@@ -24,7 +24,7 @@ type LangfuseGenerationConfig = Pick<
   "metadata" | "version" | "promptName" | "promptVersion"
 >;
 
-export type LangfuseNewTraceConfig = LangfuseTraceConfig & { traceId?: string; clientInitParams?: LangfuseInitParams };
+export type LangfuseNewTraceConfig = LangfuseTraceConfig & { traceId?: string; traceName?: string; clientInitParams?: LangfuseInitParams };
 export type LangfuseParent = LangfuseTraceClient | LangfuseSpanClient | LangfuseGenerationClient;
 export type LangfuseWithParentConfig = LangfuseGenerationConfig & { parent: LangfuseParent };
 


### PR DESCRIPTION
## Problem

JSDocs say traceName is supported by observeOpenAI, but it wasn't handled appropriately.

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them ?
- [ ] langfuse
- [ ] langfuse-node

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for traceName

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for `traceName` in `observeOpenAI`, updates parsing for optional `completion_tokens`, and modifies types to include `traceName`.
> 
>   - **Behavior**:
>     - Adds support for `traceName` in `observeOpenAI` in `observeOpenAI.ts`, using `traceName` from `langfuseConfig` if available, otherwise defaults to `generationName`.
>     - Updates `wrapMethod` in `traceMethod.ts` to include `traceName` in the configuration for tracing.
>   - **Parsing**:
>     - Modifies `parseUsage` in `parseOpenAI.ts` to handle cases where `completion_tokens` might be missing, defaulting to 0.
>     - Updates `hasCompletionUsage` type guard in `parseOpenAI.ts` to accommodate optional `completion_tokens`.
>   - **Types**:
>     - Adds `traceName` to `LangfuseNewTraceConfig` in `types.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 05939fd4fedd7837ca0d1d025361b9f0c40734c3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->