### PR TITLE
fix: support passing in traceName

### DIFF
--- a/langfuse/src/openai/observeOpenAI.ts
+++ b/langfuse/src/openai/observeOpenAI.ts
@@ -38,7 +38,8 @@ export const observeOpenAI = <SDKType extends object>(
 
       const defaultGenerationName = `${sdk.constructor?.name}.${propKey.toString()}`;
       const generationName = langfuseConfig?.generationName ?? defaultGenerationName;
-      const config = { ...langfuseConfig, generationName };
+      const traceName = langfuseConfig && 'traceName' in langfuseConfig ? langfuseConfig.traceName : generationName;
+      const config = { ...langfuseConfig, generationName, traceName};      
 
       // Add a flushAsync method to the OpenAI SDK that flushes the Langfuse client
       if (propKey === "flushAsync") {

--- a/langfuse/src/openai/traceMethod.ts
+++ b/langfuse/src/openai/traceMethod.ts
@@ -60,6 +60,7 @@ const wrapMethod = async <T extends GenericMethod>(
       ...config,
       ...observationData,
       id: config?.traceId,
+      name: config?.traceName,
       timestamp: observationData.startTime,
     });
   }

--- a/langfuse/src/openai/types.ts
+++ b/langfuse/src/openai/types.ts
@@ -24,7 +24,7 @@ type LangfuseGenerationConfig = Pick<
   "metadata" | "version" | "promptName" | "promptVersion"
 >;
 
-export type LangfuseNewTraceConfig = LangfuseTraceConfig & { traceId?: string; clientInitParams?: LangfuseInitParams };
+export type LangfuseNewTraceConfig = LangfuseTraceConfig & { traceId?: string; traceName?: string; clientInitParams?: LangfuseInitParams };
 export type LangfuseParent = LangfuseTraceClient | LangfuseSpanClient | LangfuseGenerationClient;
 export type LangfuseWithParentConfig = LangfuseGenerationConfig & { parent: LangfuseParent };
 


### PR DESCRIPTION
## Problem

JSDocs say traceName is supported by observeOpenAI, but it wasn't handled appropriately.

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them ?
- [ ] langfuse
- [ ] langfuse-node

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for traceName

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for `traceName` in `observeOpenAI`, ensuring it is handled and passed through the tracing process.
> 
>   - **Behavior**:
>     - Adds support for `traceName` in `observeOpenAI()` in `observeOpenAI.ts`, defaulting to `generationName` if not provided.
>     - Passes `traceName` to `wrapMethod()` in `traceMethod.ts` for tracing.
>   - **Types**:
>     - Adds `traceName` to `LangfuseNewTraceConfig` in `types.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for f24e2313244a3021400cab1906d2d66a8f781bbe. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->