### PR TITLE
fix: handle OpenAI.CreateEmbeddingResponse.Usage instead of only Open…

### DIFF
--- a/langfuse/src/openai/parseOpenAI.ts
+++ b/langfuse/src/openai/parseOpenAI.ts
@@ -64,11 +64,11 @@ export const parseCompletionOutput = (res: unknown): string => {
 
 export const parseUsage = (res: unknown): Usage | undefined => {
   if (hasCompletionUsage(res)) {
-    const { prompt_tokens, completion_tokens, total_tokens } = res.usage;
+    const { prompt_tokens, total_tokens } = res.usage;
 
     return {
       promptTokens: prompt_tokens,
-      completionTokens: completion_tokens,
+      completionTokens: 'completion_tokens' in res.usage ? res.usage.completion_tokens : 0,
       totalTokens: total_tokens,
     };
   }
@@ -102,13 +102,13 @@ export const parseChunk = (
 };
 
 // Type guard to check if an unknown object is a UsageResponse
-function hasCompletionUsage(obj: any): obj is { usage: OpenAI.CompletionUsage } {
+function hasCompletionUsage(obj: any): obj is { usage: OpenAI.CompletionUsage | OpenAI.CreateEmbeddingResponse.Usage } {
   return (
     obj instanceof Object &&
     "usage" in obj &&
     obj.usage instanceof Object &&
     typeof obj.usage.prompt_tokens === "number" &&
-    typeof obj.usage.completion_tokens === "number" &&
+    (!obj.usage.completion_tokens || typeof obj.usage.completion_tokens === "number") && 
     typeof obj.usage.total_tokens === "number"
   );
 }

--- a/langfuse/src/openai/traceMethod.ts
+++ b/langfuse/src/openai/traceMethod.ts
@@ -74,13 +74,13 @@ const wrapMethod = async <T extends GenericMethod>(
         const textChunks: string[] = [];
         const toolCallChunks: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta.ToolCall[] = [];
         let completionStartTime: Date | null = null;
-        let usage: OpenAI.CompletionUsage | null = null;
+        let usage: OpenAI.CompletionUsage | OpenAI.CreateEmbeddingResponse.Usage | null = null;
 
         for await (const rawChunk of response as AsyncIterable<unknown>) {
           completionStartTime = completionStartTime ?? new Date();
 
           if (typeof rawChunk === "object" && rawChunk != null && "usage" in rawChunk) {
-            usage = rawChunk.usage as OpenAI.CompletionUsage | null;
+            usage = rawChunk.usage as OpenAI.CompletionUsage | OpenAI.CreateEmbeddingResponse.Usage  | null;
           }
 
           const processedChunk = parseChunk(rawChunk);


### PR DESCRIPTION
## Problem

OpenAI embeddings.create not reporting prompt_tokens because the embeddings Usage type is different from CompletionsUsage 

## Changes

handle OpenAI.CreateEmbeddingResponse.Usage instead of only OpenAI.CompletionsUsage

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them?
- [ ] langfuse
- [ ] langfuse-node

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Fixed token usage reporting for embeddings

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes token usage reporting for OpenAI embeddings by handling `OpenAI.CreateEmbeddingResponse.Usage` in `parseUsage` and `wrapMethod`.
> 
>   - **Behavior**:
>     - Fixes token usage reporting for OpenAI embeddings by handling `OpenAI.CreateEmbeddingResponse.Usage` in `parseUsage` in `parseOpenAI.ts`.
>     - Updates `wrapMethod` in `traceMethod.ts` to support `OpenAI.CreateEmbeddingResponse.Usage`.
>   - **Functions**:
>     - Modifies `hasCompletionUsage` in `parseOpenAI.ts` to check for `OpenAI.CreateEmbeddingResponse.Usage`.
>     - Updates `wrapMethod` to handle both `OpenAI.CompletionUsage` and `OpenAI.CreateEmbeddingResponse.Usage` for streaming responses.
>   - **Misc**:
>     - Adjusts `completionTokens` handling in `parseUsage` to default to 0 if not present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 7cbb60cad89c8e56e8b98378138681a99bfe9909. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->