### PR TITLE
Add trigger.dev deployment id

### DIFF
--- a/langfuse-core/src/release-env.ts
+++ b/langfuse-core/src/release-env.ts
@@ -18,6 +18,8 @@ const common_release_envs = [
   "REACT_APP_GIT_SHA",
   // Heroku
   "SOURCE_VERSION",
+  // Trigger.dev
+  "TRIGGER_DEPLOYMENT_ID"
 ] as const;
 
 export function getCommonReleaseEnvs(): string | undefined {

--- a/langfuse-core/src/release-env.ts
+++ b/langfuse-core/src/release-env.ts
@@ -19,7 +19,7 @@ const common_release_envs = [
   // Heroku
   "SOURCE_VERSION",
   // Trigger.dev
-  "TRIGGER_DEPLOYMENT_ID"
+  "TRIGGER_DEPLOYMENT_ID",
 ] as const;
 
 export function getCommonReleaseEnvs(): string | undefined {


### PR DESCRIPTION
## Problem

When using langfuse-js in a trigger.dev trigger, it would be great if the traces referenced the deployment that it was running on at the time of the trace.

## Changes

Add an additional env to the lookup table as per: https://discord.com/channels/1066956501299777596/1316809593611091989/1316860943493365810

## Release info Sub-libraries affected

### Bump level
- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

- [x] langfuse-core

### Changelog notes
- Langfuse core now detects Trigger.dev deployment Id

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `TRIGGER_DEPLOYMENT_ID` to detect Trigger.dev deployment ID in `release-env.ts`.
> 
>   - **Behavior**:
>     - Add `TRIGGER_DEPLOYMENT_ID` to `common_release_envs` in `release-env.ts` to detect Trigger.dev deployment ID.
>   - **Misc**:
>     - Update `getCommonReleaseEnvs()` in `release-env.ts` to include the new environment variable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for e96bef579f4e7c144da32c17ab7bb1ec2e2b4e17. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->