### PR TITLE
feat(cost): allow all usage types

### DIFF
--- a/integration-test/langfuse-integration-error-handling.spec.ts
+++ b/integration-test/langfuse-integration-error-handling.spec.ts
@@ -84,7 +84,7 @@ describe("No errors should be thrown by SDKs", () => {
       await handler.shutdownAsync();
 
       // expect no errors to be thrown (would kill jest)
-      expect(global.console.error).toHaveBeenCalledTimes(1);
+      expect(global.console.error).toHaveBeenCalledTimes(0);
     }, 10000);
 
     it("incorrect keys", async () => {
@@ -109,7 +109,7 @@ describe("No errors should be thrown by SDKs", () => {
       await handler.shutdownAsync();
 
       // expect no errors to be thrown (would kill jest)
-      expect(global.console.error).toHaveBeenCalledTimes(1);
+      expect(global.console.error).toHaveBeenCalledTimes(0);
     }, 10000);
   });
 });
@@ -185,7 +185,7 @@ describe("shutdown async behavior", () => {
     }
 
     await handler.shutdownAsync();
-    expect(flushCallback).toHaveBeenCalledTimes(15);
+    expect(flushCallback).toHaveBeenCalledTimes(8);
 
     const anyCallbackCount = anyCallback.mock.calls.length;
 

--- a/integration-test/langfuse-integration-langchain.spec.ts
+++ b/integration-test/langfuse-integration-langchain.spec.ts
@@ -793,9 +793,9 @@ describe("Langchain", () => {
           role: "assistant",
         },
         usage: {
-          completionTokens: expect.any(Number),
-          promptTokens: expect.any(Number),
-          totalTokens: expect.any(Number),
+          input: expect.any(Number),
+          output: expect.any(Number),
+          total: expect.any(Number),
         },
         version: "1.0.0",
       });

--- a/integration-test/langfuse-integration-langchain.spec.ts
+++ b/integration-test/langfuse-integration-langchain.spec.ts
@@ -146,7 +146,7 @@ describe("Langchain", () => {
 
     it("should execute simple non chat llm call", async () => {
       const handler = new CallbackHandler({});
-      const llm = new OpenAI({ modelName: "gpt-4-1106-preview", maxTokens: 20 });
+      const llm = new OpenAI({ modelName: "gpt-3.5-turbo-instruct", maxTokens: 20 });
       const res = await llm.invoke("Tell me a joke on a non chat api", { callbacks: [handler] });
       const traceId = handler.traceId;
       await handler.flushAsync();
@@ -169,7 +169,7 @@ describe("Langchain", () => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const singleGeneration = generation![0];
 
-      expect(singleGeneration.name).toBe("OpenAIChat");
+      expect(singleGeneration.name).toBe("OpenAI");
       expect(singleGeneration.input).toMatchObject(["Tell me a joke on a non chat api"]);
       expect(singleGeneration.usage?.input).toBeDefined();
       expect(singleGeneration.usage?.output).toBeDefined();

--- a/langfuse-core/openapi-spec/openapi-server.yaml
+++ b/langfuse-core/openapi-spec/openapi-server.yaml
@@ -2389,7 +2389,7 @@ components:
           type: string
           description: >-
             The content of the comment. May include markdown. Currently limited
-            to 500 characters.
+            to 3000 characters.
         authorUserId:
           type: string
           nullable: true
@@ -2627,7 +2627,9 @@ components:
         usage:
           $ref: '#/components/schemas/Usage'
           nullable: true
-          description: The usage data of the observation
+          description: >-
+            (Deprecated. Use usageDetails and costDetails instead.) The usage
+            data of the observation
         level:
           $ref: '#/components/schemas/ObservationLevel'
           description: The level of the observation
@@ -2643,6 +2645,25 @@ components:
           type: string
           nullable: true
           description: The prompt ID associated with the observation
+        usageDetails:
+          type: object
+          additionalProperties:
+            type: integer
+          nullable: true
+          description: >-
+            The usage details of the observation. Key is the name of the usage
+            metric, value is the number of units consumed. The total key is the
+            sum of all (non-total) usage metrics or the total value ingested.
+        costDetails:
+          type: object
+          additionalProperties:
+            type: number
+            format: double
+          nullable: true
+          description: >-
+            The cost details of the observation. Key is the name of the cost
+            metric, value is the cost in USD. The total key is the sum of all
+            (non-total) cost metrics or the total value ingested.
       required:
         - id
         - type
@@ -2683,17 +2704,23 @@ components:
           type: number
           format: double
           nullable: true
-          description: The calculated cost of the input in USD
+          description: >-
+            (Deprecated. Use usageDetails and costDetails instead.) The
+            calculated cost of the input in USD
         calculatedOutputCost:
           type: number
           format: double
           nullable: true
-          description: The calculated cost of the output in USD
+          description: >-
+            (Deprecated. Use usageDetails and costDetails instead.) The
+            calculated cost of the output in USD
         calculatedTotalCost:
           type: number
           format: double
           nullable: true
-          description: The calculated total cost in USD
+          description: >-
+            (Deprecated. Use usageDetails and costDetails instead.) The
+            calculated total cost in USD
         latency:
           type: number
           format: double
@@ -2709,7 +2736,9 @@ components:
     Usage:
       title: Usage
       type: object
-      description: Standard interface for usage and cost
+      description: >-
+        (Deprecated. Use usageDetails and costDetails instead.) Standard
+        interface for usage and cost
       properties:
         input:
           type: integer
@@ -3608,6 +3637,15 @@ components:
         usage:
           $ref: '#/components/schemas/IngestionUsage'
           nullable: true
+        usageDetails:
+          $ref: '#/components/schemas/UsageDetails'
+          nullable: true
+        costDetails:
+          type: object
+          additionalProperties:
+            type: number
+            format: double
+          nullable: true
         promptName:
           type: string
           nullable: true
@@ -3637,6 +3675,15 @@ components:
           nullable: true
         promptName:
           type: string
+          nullable: true
+        usageDetails:
+          $ref: '#/components/schemas/UsageDetails'
+          nullable: true
+        costDetails:
+          type: object
+          additionalProperties:
+            type: number
+            format: double
           nullable: true
         promptVersion:
           type: integer
@@ -3955,6 +4002,37 @@ components:
       required:
         - successes
         - errors
+    OpenAIUsageSchema:
+      title: OpenAIUsageSchema
+      type: object
+      properties:
+        prompt_tokens:
+          type: integer
+        completion_tokens:
+          type: integer
+        total_tokens:
+          type: integer
+        prompt_tokens_details:
+          type: object
+          additionalProperties:
+            type: integer
+          nullable: true
+        completion_tokens_details:
+          type: object
+          additionalProperties:
+            type: integer
+          nullable: true
+      required:
+        - prompt_tokens
+        - completion_tokens
+        - total_tokens
+    UsageDetails:
+      title: UsageDetails
+      oneOf:
+        - type: object
+          additionalProperties:
+            type: integer
+        - $ref: '#/components/schemas/OpenAIUsageSchema'
     GetMediaResponse:
       title: GetMediaResponse
       type: object
@@ -4058,8 +4136,35 @@ components:
       title: MediaContentType
       type: string
       enum:
-        - >-
-          image/png","image/jpeg","image/jpg","image/webp","image/gif","image/svg+xml","image/tiff","image/bmp","audio/mpeg","audio/mp3","audio/wav","audio/ogg","audio/oga","audio/aac","audio/mp4","audio/flac","video/mp4","video/webm","text/plain","text/html","text/css","text/csv","application/pdf","application/msword","application/vnd.ms-excel","application/zip","application/json","application/xml","application/octet-stream
+        - image/png
+        - image/jpeg
+        - image/jpg
+        - image/webp
+        - image/gif
+        - image/svg+xml
+        - image/tiff
+        - image/bmp
+        - audio/mpeg
+        - audio/mp3
+        - audio/wav
+        - audio/ogg
+        - audio/oga
+        - audio/aac
+        - audio/mp4
+        - audio/flac
+        - video/mp4
+        - video/webm
+        - text/plain
+        - text/html
+        - text/css
+        - text/csv
+        - application/pdf
+        - application/msword
+        - application/vnd.ms-excel
+        - application/zip
+        - application/json
+        - application/xml
+        - application/octet-stream
       description: The MIME type of the media record
     DailyMetrics:
       title: DailyMetrics

--- a/langfuse-core/src/openapi/server.ts
+++ b/langfuse-core/src/openapi/server.ts
@@ -524,7 +524,7 @@ export interface components {
       objectType: string;
       /** @description The id of the object to attach the comment to. If this does not reference a valid existing object, an error will be thrown. */
       objectId: string;
-      /** @description The content of the comment. May include markdown. Currently limited to 500 characters. */
+      /** @description The content of the comment. May include markdown. Currently limited to 3000 characters. */
       content: string;
       /** @description The id of the user who created the comment. */
       authorUserId?: string | null;
@@ -657,7 +657,7 @@ export interface components {
       metadata?: unknown;
       /** @description The output data of the observation */
       output?: unknown;
-      /** @description The usage data of the observation */
+      /** @description (Deprecated. Use usageDetails and costDetails instead.) The usage data of the observation */
       usage?: components["schemas"]["Usage"];
       /** @description The level of the observation */
       level: components["schemas"]["ObservationLevel"];
@@ -667,6 +667,14 @@ export interface components {
       parentObservationId?: string | null;
       /** @description The prompt ID associated with the observation */
       promptId?: string | null;
+      /** @description The usage details of the observation. Key is the name of the usage metric, value is the number of units consumed. The total key is the sum of all (non-total) usage metrics or the total value ingested. */
+      usageDetails?: {
+        [key: string]: number;
+      } | null;
+      /** @description The cost details of the observation. Key is the name of the cost metric, value is the cost in USD. The total key is the sum of all (non-total) cost metrics or the total value ingested. */
+      costDetails?: {
+        [key: string]: number;
+      } | null;
     };
     /** ObservationsView */
     ObservationsView: {
@@ -693,17 +701,17 @@ export interface components {
       totalPrice?: number | null;
       /**
        * Format: double
-       * @description The calculated cost of the input in USD
+       * @description (Deprecated. Use usageDetails and costDetails instead.) The calculated cost of the input in USD
        */
       calculatedInputCost?: number | null;
       /**
        * Format: double
-       * @description The calculated cost of the output in USD
+       * @description (Deprecated. Use usageDetails and costDetails instead.) The calculated cost of the output in USD
        */
       calculatedOutputCost?: number | null;
       /**
        * Format: double
-       * @description The calculated total cost in USD
+       * @description (Deprecated. Use usageDetails and costDetails instead.) The calculated total cost in USD
        */
       calculatedTotalCost?: number | null;
       /**
@@ -719,7 +727,7 @@ export interface components {
     } & components["schemas"]["Observation"];
     /**
      * Usage
-     * @description Standard interface for usage and cost
+     * @description (Deprecated. Use usageDetails and costDetails instead.) Standard interface for usage and cost
      */
     Usage: {
       /** @description Number of input units (e.g. tokens) */
@@ -1156,6 +1164,10 @@ export interface components {
         [key: string]: components["schemas"]["MapValue"];
       } | null;
       usage?: components["schemas"]["IngestionUsage"];
+      usageDetails?: components["schemas"]["UsageDetails"];
+      costDetails?: {
+        [key: string]: number;
+      } | null;
       promptName?: string | null;
       promptVersion?: number | null;
     } & components["schemas"]["CreateSpanBody"];
@@ -1169,6 +1181,10 @@ export interface components {
       } | null;
       usage?: components["schemas"]["IngestionUsage"];
       promptName?: string | null;
+      usageDetails?: components["schemas"]["UsageDetails"];
+      costDetails?: {
+        [key: string]: number;
+      } | null;
       promptVersion?: number | null;
     } & components["schemas"]["UpdateSpanBody"];
     /** ObservationBody */
@@ -1299,6 +1315,24 @@ export interface components {
       successes: components["schemas"]["IngestionSuccess"][];
       errors: components["schemas"]["IngestionError"][];
     };
+    /** OpenAIUsageSchema */
+    OpenAIUsageSchema: {
+      prompt_tokens: number;
+      completion_tokens: number;
+      total_tokens: number;
+      prompt_tokens_details?: {
+        [key: string]: number;
+      } | null;
+      completion_tokens_details?: {
+        [key: string]: number;
+      } | null;
+    };
+    /** UsageDetails */
+    UsageDetails:
+      | {
+          [key: string]: number;
+        }
+      | components["schemas"]["OpenAIUsageSchema"];
     /** GetMediaResponse */
     GetMediaResponse: {
       /** @description The unique langfuse identifier of a media record */
@@ -1362,11 +1396,31 @@ export interface components {
       | "image/jpeg"
       | "image/jpg"
       | "image/webp"
+      | "image/gif"
+      | "image/svg+xml"
+      | "image/tiff"
+      | "image/bmp"
       | "audio/mpeg"
       | "audio/mp3"
       | "audio/wav"
+      | "audio/ogg"
+      | "audio/oga"
+      | "audio/aac"
+      | "audio/mp4"
+      | "audio/flac"
+      | "video/mp4"
+      | "video/webm"
       | "text/plain"
-      | "application/pdf";
+      | "text/html"
+      | "text/css"
+      | "text/csv"
+      | "application/pdf"
+      | "application/msword"
+      | "application/vnd.ms-excel"
+      | "application/zip"
+      | "application/json"
+      | "application/xml"
+      | "application/octet-stream";
     /** DailyMetrics */
     DailyMetrics: {
       /** @description A list of daily metrics, only days with ingested data are included. */

--- a/langfuse-core/src/types.ts
+++ b/langfuse-core/src/types.ts
@@ -93,6 +93,7 @@ export type EventBody =
   | UpdateLangfuseGenerationBody;
 
 export type Usage = FixTypes<components["schemas"]["IngestionUsage"]>;
+export type UsageDetails = FixTypes<components["schemas"]["UsageDetails"]>;
 export type CreateLangfuseGenerationBody = FixTypes<components["schemas"]["CreateGenerationBody"]>;
 export type UpdateLangfuseGenerationBody = FixTypes<components["schemas"]["UpdateGenerationBody"]>;
 

--- a/langfuse-langchain/src/callback.ts
+++ b/langfuse-langchain/src/callback.ts
@@ -594,13 +594,12 @@ export class CallbackHandler extends BaseCallbackHandler {
 
       const lastResponse =
         output.generations[output.generations.length - 1][output.generations[output.generations.length - 1].length - 1];
-      const llmUsage =
-        (output.llmOutput?.["tokenUsage"] as UsageMetadata | undefined) ?? this.extractUsageMetadata(lastResponse);
+      const llmUsage = this.extractUsageMetadata(lastResponse) ?? output.llmOutput?.["tokenUsage"];
 
       const usageDetails: Record<string, any> = {
-        input: llmUsage?.input_tokens,
-        output: llmUsage?.output_tokens,
-        total: llmUsage?.total_tokens,
+        input: llmUsage?.input_tokens ?? ("promptTokens" in llmUsage ? llmUsage?.promptTokens : undefined),
+        output: llmUsage?.output_tokens ?? ("completionTokens" in llmUsage ? llmUsage?.completionTokens : undefined),
+        total: llmUsage?.total_tokens ?? ("totalTokens" in llmUsage ? llmUsage?.totalTokens : undefined),
       };
 
       if (llmUsage && "input_token_details" in llmUsage) {

--- a/langfuse-vercel/src/LangfuseExporter.ts
+++ b/langfuse-vercel/src/LangfuseExporter.ts
@@ -190,28 +190,33 @@ export class LangfuseExporter implements SpanExporter {
           "ai.settings.maxRetries" in attributes ? attributes["ai.settings.maxRetries"]?.toString() : undefined,
         mode: "ai.settings.mode" in attributes ? attributes["ai.settings.mode"]?.toString() : undefined,
       },
-      usage: {
-        input:
-          "gen_ai.usage.prompt_tokens" in attributes // Backward compat, input_tokens used in latest ai SDK versions
-            ? parseInt(attributes["gen_ai.usage.prompt_tokens"]?.toString() ?? "0")
-            : "gen_ai.usage.input_tokens" in attributes
-              ? parseInt(attributes["gen_ai.usage.input_tokens"]?.toString() ?? "0")
-              : undefined,
-
-        output:
-          "gen_ai.usage.completion_tokens" in attributes // Backward compat, output_tokens used in latest ai SDK versions
-            ? parseInt(attributes["gen_ai.usage.completion_tokens"]?.toString() ?? "0")
-            : "gen_ai.usage.output_tokens" in attributes
-              ? parseInt(attributes["gen_ai.usage.output_tokens"]?.toString() ?? "0")
-              : undefined,
-        total: "ai.usage.tokens" in attributes ? parseInt(attributes["ai.usage.tokens"]?.toString() ?? "0") : undefined,
-      },
+      usage: this.parseUsageDetails(attributes),
+      usageDetails: this.parseUsageDetails(attributes),
       input: this.parseInput(span),
       output: this.parseOutput(span),
 
       metadata: this.filterTraceAttributes(this.parseSpanMetadata(span)),
       prompt: langfusePrompt,
     });
+  }
+
+  private parseUsageDetails(attributes: Record<string, any>): Record<string, any> {
+    return {
+      input:
+        "gen_ai.usage.prompt_tokens" in attributes // Backward compat, input_tokens used in latest ai SDK versions
+          ? parseInt(attributes["gen_ai.usage.prompt_tokens"]?.toString() ?? "0")
+          : "gen_ai.usage.input_tokens" in attributes
+            ? parseInt(attributes["gen_ai.usage.input_tokens"]?.toString() ?? "0")
+            : undefined,
+
+      output:
+        "gen_ai.usage.completion_tokens" in attributes // Backward compat, output_tokens used in latest ai SDK versions
+          ? parseInt(attributes["gen_ai.usage.completion_tokens"]?.toString() ?? "0")
+          : "gen_ai.usage.output_tokens" in attributes
+            ? parseInt(attributes["gen_ai.usage.output_tokens"]?.toString() ?? "0")
+            : undefined,
+      total: "ai.usage.tokens" in attributes ? parseInt(attributes["ai.usage.tokens"]?.toString() ?? "0") : undefined,
+    };
   }
 
   private parseSpanMetadata(span: ReadableSpan): Record<string, (typeof span.attributes)[0]> {

--- a/langfuse/src/openai/traceMethod.ts
+++ b/langfuse/src/openai/traceMethod.ts
@@ -2,7 +2,15 @@ import type OpenAI from "openai";
 import type { LangfuseParent } from "./types";
 
 import { LangfuseSingleton } from "./LangfuseSingleton";
-import { getToolCallOutput, parseChunk, parseCompletionOutput, parseInputArgs, parseUsage } from "./parseOpenAI";
+import {
+  getToolCallOutput,
+  parseChunk,
+  parseCompletionOutput,
+  parseInputArgs,
+  parseUsage,
+  parseUsageDetails,
+  parseUsageDetailsFromResponse,
+} from "./parseOpenAI";
 import { isAsyncIterable } from "./utils";
 import type { LangfuseConfig } from "./types";
 
@@ -108,6 +116,7 @@ const wrapMethod = async <T extends GenericMethod>(
                 total: "total_tokens" in usage ? usage.total_tokens : undefined,
               }
             : undefined,
+          usageDetails: usage ? parseUsageDetails(usage) : undefined,
         });
 
         if (!hasUserProvidedParent) {
@@ -120,12 +129,14 @@ const wrapMethod = async <T extends GenericMethod>(
 
     const output = parseCompletionOutput(res);
     const usage = parseUsage(res);
+    const usageDetails = parseUsageDetailsFromResponse(res);
 
     langfuseParent.generation({
       ...observationData,
       output,
       endTime: new Date(),
       usage,
+      usageDetails,
     });
 
     if (!hasUserProvidedParent) {
@@ -143,6 +154,11 @@ const wrapMethod = async <T extends GenericMethod>(
         inputCost: 0,
         outputCost: 0,
         totalCost: 0,
+      },
+      costDetails: {
+        input: 0,
+        output: 0,
+        total: 0,
       },
     });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Deprecates old usage and cost fields, introduces `usageDetails` and `costDetails`, and updates related logic across multiple files for improved tracking.
> 
>   - **Behavior**:
>     - Deprecates `usage`, `calculatedInputCost`, `calculatedOutputCost`, and `calculatedTotalCost` fields in favor of `usageDetails` and `costDetails` in `openapi-server.yaml` and `server.ts`.
>     - Increases comment content limit from 500 to 3000 characters in `openapi-server.yaml` and `server.ts`.
>   - **Models**:
>     - Adds `UsageDetails` and `OpenAIUsageSchema` to `openapi-server.yaml`.
>     - Updates `Usage` model to be deprecated in `openapi-server.yaml`.
>   - **Functions**:
>     - Updates `parseUsageDetails` and `parseUsageDetailsFromResponse` in `parseOpenAI.ts` to handle new usage details format.
>     - Modifies `handleLLMEnd` in `callback.ts` to use `usageDetails`.
>     - Adjusts `processSpanAsLangfuseGeneration` in `LangfuseExporter.ts` to include `usageDetails`.
>   - **Misc**:
>     - Refactors `parseUsageDetails` logic in `LangfuseExporter.ts` and `traceMethod.ts` for consistency.
>     - Updates `CallbackHandler` in `callback.ts` to handle new usage details format.
>     - Fixes test expectations in `langfuse-integration-error-handling.spec.ts` and `langfuse-integration-langchain.spec.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for ec413566d5cb90fd008773584dcecf4c4f49d20a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->