### PR TITLE
fix(openai): support passing in traceName

### DIFF
--- a/langfuse/src/openai/observeOpenAI.ts
+++ b/langfuse/src/openai/observeOpenAI.ts
@@ -38,7 +38,8 @@ export const observeOpenAI = <SDKType extends object>(
 
       const defaultGenerationName = `${sdk.constructor?.name}.${propKey.toString()}`;
       const generationName = langfuseConfig?.generationName ?? defaultGenerationName;
-      const config = { ...langfuseConfig, generationName };
+      const traceName = langfuseConfig && 'traceName' in langfuseConfig ? langfuseConfig.traceName : generationName;
+      const config = { ...langfuseConfig, generationName, traceName};      
 
       // Add a flushAsync method to the OpenAI SDK that flushes the Langfuse client
       if (propKey === "flushAsync") {

--- a/langfuse/src/openai/observeOpenAI.ts
+++ b/langfuse/src/openai/observeOpenAI.ts
@@ -38,8 +38,8 @@ export const observeOpenAI = <SDKType extends object>(
 
       const defaultGenerationName = `${sdk.constructor?.name}.${propKey.toString()}`;
       const generationName = langfuseConfig?.generationName ?? defaultGenerationName;
-      const traceName = langfuseConfig && 'traceName' in langfuseConfig ? langfuseConfig.traceName : generationName;
-      const config = { ...langfuseConfig, generationName, traceName};      
+      const traceName = langfuseConfig && "traceName" in langfuseConfig ? langfuseConfig.traceName : generationName;
+      const config = { ...langfuseConfig, generationName, traceName };
 
       // Add a flushAsync method to the OpenAI SDK that flushes the Langfuse client
       if (propKey === "flushAsync") {

--- a/langfuse/src/openai/traceMethod.ts
+++ b/langfuse/src/openai/traceMethod.ts
@@ -60,6 +60,7 @@ const wrapMethod = async <T extends GenericMethod>(
       ...config,
       ...observationData,
       id: config?.traceId,
+      name: config?.traceName,
       timestamp: observationData.startTime,
     });
   }

--- a/langfuse/src/openai/types.ts
+++ b/langfuse/src/openai/types.ts
@@ -24,7 +24,7 @@ type LangfuseGenerationConfig = Pick<
   "metadata" | "version" | "promptName" | "promptVersion"
 >;
 
-export type LangfuseNewTraceConfig = LangfuseTraceConfig & { traceId?: string; clientInitParams?: LangfuseInitParams };
+export type LangfuseNewTraceConfig = LangfuseTraceConfig & { traceId?: string; traceName?: string; clientInitParams?: LangfuseInitParams };
 export type LangfuseParent = LangfuseTraceClient | LangfuseSpanClient | LangfuseGenerationClient;
 export type LangfuseWithParentConfig = LangfuseGenerationConfig & { parent: LangfuseParent };
 

--- a/langfuse/src/openai/types.ts
+++ b/langfuse/src/openai/types.ts
@@ -24,7 +24,11 @@ type LangfuseGenerationConfig = Pick<
   "metadata" | "version" | "promptName" | "promptVersion"
 >;
 
-export type LangfuseNewTraceConfig = LangfuseTraceConfig & { traceId?: string; traceName?: string; clientInitParams?: LangfuseInitParams };
+export type LangfuseNewTraceConfig = LangfuseTraceConfig & {
+  traceId?: string;
+  traceName?: string;
+  clientInitParams?: LangfuseInitParams;
+};
 export type LangfuseParent = LangfuseTraceClient | LangfuseSpanClient | LangfuseGenerationClient;
 export type LangfuseWithParentConfig = LangfuseGenerationConfig & { parent: LangfuseParent };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for `traceName` in Langfuse configuration for OpenAI SDK tracing, defaulting to `generationName` if not provided.
> 
>   - **Behavior**:
>     - Support for `traceName` in `LangfuseConfig` in `observeOpenAI.ts` and `traceMethod.ts`.
>     - `traceName` defaults to `generationName` if not provided.
>   - **Types**:
>     - Add `traceName` to `LangfuseNewTraceConfig` in `types.ts`.
>   - **Functions**:
>     - Update `observeOpenAI()` to include `traceName` in config.
>     - Update `wrapMethod()` to use `traceName` for tracing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 78db7d9d381436e883fd26512602f29bce68f53a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->