### PR TITLE
feat(langchain): DEBUG log level for langsmith:hidden

### DIFF
--- a/langfuse-langchain/src/callback.ts
+++ b/langfuse-langchain/src/callback.ts
@@ -23,6 +23,8 @@ import type { Document } from "@langchain/core/documents";
 
 import type { ChatPromptClient, LangfuseSpanClient, LangfuseTraceClient, TextPromptClient } from "langfuse-core";
 
+const LANGSMITH_HIDDEN_TAG = "langsmith:hidden";
+
 export type LlmMessage = {
   role: string;
   content: BaseMessageFields["content"];
@@ -216,6 +218,7 @@ export class CallbackHandler extends BaseCallbackHandler {
         metadata: this.joinTagsAndMetaData(tags, metadata),
         input: finalInput,
         version: this.version,
+        level: tags && tags.includes(LANGSMITH_HIDDEN_TAG) ? "DEBUG" : undefined,
       });
 
       // If there's no parent run, this is a top-level chain execution.
@@ -414,6 +417,7 @@ export class CallbackHandler extends BaseCallbackHandler {
       modelParameters: modelParameters,
       version: this.version,
       prompt: registeredPrompt,
+      level: tags && tags.includes(LANGSMITH_HIDDEN_TAG) ? "DEBUG" : undefined,
     });
   }
 
@@ -500,6 +504,7 @@ export class CallbackHandler extends BaseCallbackHandler {
         input: input,
         metadata: this.joinTagsAndMetaData(tags, metadata),
         version: this.version,
+        level: tags && tags.includes(LANGSMITH_HIDDEN_TAG) ? "DEBUG" : undefined,
       });
     } catch (e) {
       this._log(e);
@@ -526,6 +531,7 @@ export class CallbackHandler extends BaseCallbackHandler {
         input: query,
         metadata: this.joinTagsAndMetaData(tags, metadata),
         version: this.version,
+        level: tags && tags.includes(LANGSMITH_HIDDEN_TAG) ? "DEBUG" : undefined,
       });
     } catch (e) {
       this._log(e);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `DEBUG` log level for spans and generations in `CallbackHandler` when `langsmith:hidden` tag is present.
> 
>   - **Behavior**:
>     - Introduces `LANGSMITH_HIDDEN_TAG` constant in `callback.ts`.
>     - Sets log level to `DEBUG` in `CallbackHandler` methods (`handleChainStart`, `handleGenerationStart`, `handleToolStart`, `handleRetrieverStart`) if `LANGSMITH_HIDDEN_TAG` is present in tags.
>   - **Misc**:
>     - Adds `level` property to span and generation calls in `callback.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for e515f338a6407fa41b1234740a408589ebf1e58d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->