### PR TITLE
fix(vercel): schedule flush post span processing

### DIFF
--- a/integration-test/langfuse-integration-vercel.spec.ts
+++ b/integration-test/langfuse-integration-vercel.spec.ts
@@ -314,8 +314,6 @@ describe("langfuse-integration-vercel", () => {
       },
     });
 
-    console.log(JSON.stringify(result.object.recipe, null, 2));
-
     await sdk.shutdown();
 
     // Fetch trace
@@ -403,8 +401,6 @@ describe("langfuse-integration-vercel", () => {
     for await (const partialObject of partialObjectStream) {
       currentObject = partialObject;
     }
-
-    console.log(currentObject);
 
     await sdk.shutdown();
 

--- a/langfuse-vercel/src/LangfuseExporter.ts
+++ b/langfuse-vercel/src/LangfuseExporter.ts
@@ -55,6 +55,9 @@ export class LangfuseExporter implements SpanExporter {
         this.processTraceSpans(traceId, spans);
       }
 
+      // Schedule a flush. Necessary to ensure event delivery in Vercel Cloud Functions with streaming responses
+      this.langfuse.flushAsync();
+
       const successCode: ExportResultCode.SUCCESS = 0; // Do not use enum directly to avoid adding a dependency on the enum
 
       resultCallback({ code: successCode });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Schedule a flush in `LangfuseExporter` to ensure event delivery in Vercel Cloud Functions and remove console logs from integration tests.
> 
>   - **Behavior**:
>     - In `LangfuseExporter`, schedule a flush with `flushAsync()` after processing spans to ensure event delivery in Vercel Cloud Functions.
>   - **Tests**:
>     - Remove `console.log` statements from `langfuse-integration-vercel.spec.ts` for cleaner test output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for f6143d34a2a20b33ac73e8f26fd0881c6bbe5c7c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->