### PR TITLE
add getPromptsStateless to list all prompts

### DIFF
--- a/langfuse-core/src/types.ts
+++ b/langfuse-core/src/types.ts
@@ -1,6 +1,6 @@
 import { type LangfuseObjectClient } from "./index";
-import { type LangfusePromptClient } from "./prompts/promptClients";
 import { type components, type paths } from "./openapi/server";
+import { type LangfusePromptClient } from "./prompts/promptClients";
 
 export type LangfuseCoreOptions = {
   // Langfuse API publicKey obtained from the Langfuse UI project settings
@@ -174,6 +174,17 @@ export type GetLangfusePromptResponse =
       data: GetLangfusePromptSuccessData;
     }
   | { fetchResult: "failure"; data: GetLangfusePromptFailureData };
+
+export type GetLangfusePromptsSuccessData =
+  paths["/api/public/v2/prompts"]["get"]["responses"]["200"]["content"]["application/json"];
+
+export type GetLangfusePromptsFailureData = { message?: string };
+export type GetLangfusePromptsResponse =
+  | {
+      fetchResult: "success";
+      data: GetLangfusePromptsSuccessData;
+    }
+  | { fetchResult: "failure"; data: GetLangfusePromptsFailureData };
 
 export type ChatMessage = FixTypes<components["schemas"]["ChatMessage"]>;
 export type ChatPrompt = FixTypes<components["schemas"]["ChatPrompt"]> & { type: "chat" };


### PR DESCRIPTION
## Problem

I want to hit the promtps API to list all prompts.

## Changes

Added a getPromptsStateless method trying to mimic the existing getPromptStateless

## Release info Sub-libraries affected

### Bump level

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] langfuse
- [ x] langfuse-node

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for getting all prompts and their versions via `getPromptsStateless`

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `getPromptsStateless` method to fetch all prompts with optional filters and error handling, including tests.
> 
>   - **Behavior**:
>     - Adds `getPromptsStateless` method in `LangfuseCoreStateless` to fetch all prompts with optional filters like `name`, `label`, `tag`, `page`, `limit`, `fromUpdatedAt`, and `toUpdatedAt`.
>     - Handles network and HTTP errors using `LangfuseFetchNetworkError` and `LangfuseFetchHttpError`.
>   - **Types**:
>     - Adds `GetLangfusePromptsResponse`, `GetLangfusePromptsSuccessData`, and `GetLangfusePromptsFailureData` types in `types.ts`.
>   - **Tests**:
>     - Adds tests in `langfuse.prompts.spec.ts` for `getPromptsStateless` to verify fetching prompts with and without filters and error handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for d140455087477e02ba20efbbe1e50da7bf7dc016. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->