### PR TITLE
fix(flush): handle items exceeding batch size limit

### DIFF
--- a/integration-test/langfuse-integration-node.spec.ts
+++ b/integration-test/langfuse-integration-node.spec.ts
@@ -627,7 +627,7 @@ describe("Langfuse Node.js", () => {
     expect(fetchedTraces.data[0]).toMatchObject({
       name: traceName,
       sessionId: "session-1",
-      input: JSON.stringify({ key: "value" }),
+      input: { key: "value" },
       output: "output-value",
       timestamp: traceParams[1].timestamp.toISOString(),
     });

--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -955,15 +955,13 @@ abstract class LangfuseCoreStateless {
     }
 
     const items = queue.splice(0, this.flushAt);
-    this.setPersistedProperty<LangfuseQueueItem[]>(LangfusePersistedProperty.Queue, queue);
 
     const MAX_MSG_SIZE = 1_000_000;
     const BATCH_SIZE_LIMIT = 2_500_000;
 
     const { processedItems, remainingItems } = this.processQueueItems(items, MAX_MSG_SIZE, BATCH_SIZE_LIMIT);
 
-    // Add remaining items back to the start of the queue
-    queue.unshift(...remainingItems);
+    this.setPersistedProperty<LangfuseQueueItem[]>(LangfusePersistedProperty.Queue, [...remainingItems, ...queue]);
 
     const promiseUUID = generateUUID();
 

--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -960,7 +960,10 @@ abstract class LangfuseCoreStateless {
     const MAX_MSG_SIZE = 1_000_000;
     const BATCH_SIZE_LIMIT = 2_500_000;
 
-    this.processQueueItems(items, MAX_MSG_SIZE, BATCH_SIZE_LIMIT);
+    const { processedItems, remainingItems } = this.processQueueItems(items, MAX_MSG_SIZE, BATCH_SIZE_LIMIT);
+
+    // Add remaining items back to the start of the queue
+    queue.unshift(...remainingItems);
 
     const promiseUUID = generateUUID();
 
@@ -985,9 +988,9 @@ abstract class LangfuseCoreStateless {
     }
 
     const payload = JSON.stringify({
-      batch: items,
+      batch: processedItems,
       metadata: {
-        batch_size: items.length,
+        batch_size: processedItems.length,
         sdk_integration: this.sdkIntegration,
         sdk_version: this.getLibraryVersion(),
         sdk_variant: this.getLibraryId(),

--- a/langfuse-core/test/langfuse.flush.spec.ts
+++ b/langfuse-core/test/langfuse.flush.spec.ts
@@ -244,7 +244,7 @@ describe("Langfuse Core", () => {
 
       expect(mocks.fetch).toHaveBeenCalledTimes(1);
     });
-    
+
     it("should not send events in admin mode", async () => {
       [langfuse, mocks] = createTestClient({
         publicKey: "pk-lf-111",
@@ -265,6 +265,7 @@ describe("Langfuse Core", () => {
 
       expect(mocks.fetch).not.toHaveBeenCalled();
     });
+  });
 
   describe("when queue is completely full", () => {
     const MAX_MSG_SIZE = 1_000_000;
@@ -273,7 +274,7 @@ describe("Langfuse Core", () => {
     const MSG_SIZE = MAX_MSG_SIZE - 1000;
     const BIG_STRING = "a".repeat(MSG_SIZE);
 
-    it("should flush remaining items on subsequent flush", () => {
+    it("should flush remaining items on subsequent flush", async () => {
       const n = Math.floor(BATCH_SIZE_LIMIT / MSG_SIZE) + 1;
 
       [langfuse, mocks] = createTestClient({
@@ -288,12 +289,7 @@ describe("Langfuse Core", () => {
         langfuse.trace({ name: `test-trace-${i}`, input: { content: BIG_STRING } });
       }
 
-      // First call flushes the messages that fit under the batch size limit
-      expect(mocks.fetch).toHaveBeenCalledTimes(1);
-
-      jest.advanceTimersByTime(300);
-
-      // Second call flushes the remaining messages
+      await jest.advanceTimersByTimeAsync(200);
       expect(mocks.fetch).toHaveBeenCalledTimes(2);
     });
   });

--- a/langfuse-core/test/langfuse.flush.spec.ts
+++ b/langfuse-core/test/langfuse.flush.spec.ts
@@ -244,7 +244,7 @@ describe("Langfuse Core", () => {
 
       expect(mocks.fetch).toHaveBeenCalledTimes(1);
     });
-
+    
     it("should not send events in admin mode", async () => {
       [langfuse, mocks] = createTestClient({
         publicKey: "pk-lf-111",
@@ -264,6 +264,37 @@ describe("Langfuse Core", () => {
       await jest.runAllTimersAsync();
 
       expect(mocks.fetch).not.toHaveBeenCalled();
+    });
+
+  describe("when queue is completely full", () => {
+    const MAX_MSG_SIZE = 1_000_000;
+    const BATCH_SIZE_LIMIT = 2_500_000;
+    // Message is right under the message size limit
+    const MSG_SIZE = MAX_MSG_SIZE - 1000;
+    const BIG_STRING = "a".repeat(MSG_SIZE);
+
+    it("should flush remaining items on subsequent flush", () => {
+      const n = Math.floor(BATCH_SIZE_LIMIT / MSG_SIZE) + 1;
+
+      [langfuse, mocks] = createTestClient({
+        publicKey: "pk-lf-111",
+        secretKey: "sk-lf-111",
+        flushAt: n,
+        flushInterval: 200,
+      });
+
+      // Adds enough messages to exceed batch size limit
+      for (let i = 0; i < n; i++) {
+        langfuse.trace({ name: `test-trace-${i}`, input: { content: BIG_STRING } });
+      }
+
+      // First call flushes the messages that fit under the batch size limit
+      expect(mocks.fetch).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(300);
+
+      // Second call flushes the remaining messages
+      expect(mocks.fetch).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
Co-authored-by: Hassieb Pakzad <68423100+hassiebp@users.noreply.github.com>
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix handling of items exceeding batch size limit in `LangfuseCoreStateless` and update tests accordingly.
> 
>   - **Behavior**:
>     - Fix handling of items exceeding batch size limit in `LangfuseCoreStateless`.
>     - `processQueueItems()` now returns `processedItems` and `remainingItems`.
>     - `flush()` updates queue with `remainingItems`.
>   - **Tests**:
>     - Add test in `langfuse.flush.spec.ts` to verify flushing of remaining items when batch size limit is exceeded.
>   - **Misc**:
>     - Update test in `langfuse-integration-node.spec.ts` to expect `input` as an object instead of a string.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for d3e0206d4ca48ce23ba15536141d4c6dd6125a13. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->