### PR TITLE
feat(core): add sampling

### DIFF
--- a/langfuse-core/src/openapi/server.ts
+++ b/langfuse-core/src/openapi/server.ts
@@ -1006,10 +1006,10 @@ export interface components {
      */
     ObservationLevel: "DEBUG" | "DEFAULT" | "WARNING" | "ERROR";
     /** MapValue */
-    MapValue: (string | null) | (number | null) | (boolean | null) | (string[] | null) | undefined; /**
+    MapValue: (string | null) | (number | null) | (boolean | null) | (string[] | null) | undefined /**
      * CommentObjectType
      * @enum {string}
-     */
+     */;
     CommentObjectType: "TRACE" | "OBSERVATION" | "SESSION" | "PROMPT";
     /**
      * DatasetStatus

--- a/langfuse-core/src/sampling.ts
+++ b/langfuse-core/src/sampling.ts
@@ -1,0 +1,41 @@
+/**
+ * A consistent sampling function that works for arbitrary strings across all JavaScript runtimes.
+ */
+export function isInSample(input: string, sampleRate: number | undefined): boolean {
+  if (sampleRate === undefined) {
+    return true;
+  } else if (sampleRate === 0) {
+    return false;
+  }
+
+  if (sampleRate < 0 || sampleRate > 1 || isNaN(sampleRate)) {
+    console.warn("Sample rate must be between 0 and 1. Ignoring setting.");
+
+    return true;
+  }
+
+  console.log({ input, simpleHash: simpleHash(input), sampleRate });
+
+  return simpleHash(input) < sampleRate;
+}
+
+/**
+ * Simple and consistent string hashing function.
+ * Uses character codes and prime numbers for good distribution.
+ */
+function simpleHash(str: string): number {
+  let hash = 0;
+  const prime = 31;
+
+  for (let i = 0; i < str.length; i++) {
+    // Use rolling multiplication instead of Math.pow
+    hash = (hash * prime + str.charCodeAt(i)) >>> 0;
+  }
+
+  // Use bit operations for better distribution
+  hash = ((hash >>> 16) ^ hash) * 0x45d9f3b;
+  hash = ((hash >>> 16) ^ hash) * 0x45d9f3b;
+  hash = (hash >>> 16) ^ hash;
+
+  return Math.abs(hash) / 0x7fffffff;
+}

--- a/langfuse-core/src/sampling.ts
+++ b/langfuse-core/src/sampling.ts
@@ -14,7 +14,6 @@ export function isInSample(input: string, sampleRate: number | undefined): boole
     return true;
   }
 
-  console.log({ input, simpleHash: simpleHash(input), sampleRate });
 
   return simpleHash(input) < sampleRate;
 }

--- a/langfuse-core/src/sampling.ts
+++ b/langfuse-core/src/sampling.ts
@@ -14,7 +14,6 @@ export function isInSample(input: string, sampleRate: number | undefined): boole
     return true;
   }
 
-
   return simpleHash(input) < sampleRate;
 }
 

--- a/langfuse-core/src/types.ts
+++ b/langfuse-core/src/types.ts
@@ -29,6 +29,8 @@ export type LangfuseCoreOptions = {
   enabled?: boolean;
   // Mask function to mask data in the event body
   mask?: MaskFunction;
+  // Trace sampling rate. Approx. sampleRate % traces will be sent to LF servers
+  sampleRate?: number;
   // Project ID to use for the SDK in admin mode. This should never be set by users.
   _projectId?: string;
   // Whether to enable local event export. Defaults to false.

--- a/langfuse-core/test/langfuse.sampling.spec.ts
+++ b/langfuse-core/test/langfuse.sampling.spec.ts
@@ -1,0 +1,170 @@
+import { isInSample } from "../src/sampling";
+
+describe("isInSample", () => {
+  describe("edge cases", () => {
+    it("should always return true when sample rate is undefined", () => {
+      expect(isInSample("test-string", undefined)).toBe(true);
+      expect(isInSample("", undefined)).toBe(true);
+      expect(isInSample("12345", undefined)).toBe(true);
+    });
+
+    it("should always return false when sample rate is 0", () => {
+      expect(isInSample("test-string", 0)).toBe(false);
+      expect(isInSample("", 0)).toBe(false);
+      expect(isInSample("12345", 0)).toBe(false);
+    });
+
+    it("should always return true when sample rate is 1", () => {
+      expect(isInSample("test-string", 1)).toBe(true);
+      expect(isInSample("", 1)).toBe(true);
+      expect(isInSample("12345", 1)).toBe(true);
+    });
+
+    it("should log warning and return true for invalid sample rates", () => {
+      const consoleSpy = jest.spyOn(console, "warn").mockImplementation();
+
+      expect(isInSample("test", -0.5)).toBe(true);
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockClear();
+      expect(isInSample("test", 1.5)).toBe(true);
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("consistency", () => {
+    it("should return consistent results for the same input", () => {
+      const testString = "test-consistency";
+      const sampleRate = 0.5;
+      const firstResult = isInSample(testString, sampleRate);
+
+      for (let i = 0; i < 100; i++) {
+        expect(isInSample(testString, sampleRate)).toBe(firstResult);
+      }
+    });
+
+    it("should return different results for different strings", () => {
+      const sampleRate = 0.5;
+      const results = new Set();
+
+      ["test1", "test2", "test3", "different", "strings"].forEach((str) => {
+        results.add(isInSample(str, sampleRate));
+      });
+
+      expect(results.size).toBeGreaterThan(1);
+    });
+  });
+
+  describe("distribution", () => {
+    it("should roughly match the sample rate for large numbers of inputs", () => {
+      const sampleRate = 0.3;
+      let inSampleCount = 0;
+      const totalTests = 10_000;
+
+      // Generate random strings and count how many are in sample
+      for (let i = 0; i < totalTests; i++) {
+        const testString = `test-${Math.random()}-${i}`;
+        if (isInSample(testString, sampleRate)) {
+          inSampleCount++;
+        }
+      }
+
+      const actualRate = inSampleCount / totalTests;
+      // Allow for 5% deviation from expected rate
+      expect(Math.abs(actualRate - sampleRate)).toBeLessThan(0.05);
+    });
+  });
+
+  describe("special inputs", () => {
+    it("should handle empty strings", () => {
+      const sampleRate = 0.5;
+      // Just verify it doesn't throw and returns a boolean
+      const result = isInSample("", sampleRate);
+      expect(typeof result).toBe("boolean");
+    });
+
+    it("should handle special characters", () => {
+      const sampleRate = 0.5;
+      const specialChars = "!@#$%^&*()_+-=[]{}|;:,.<>?`~";
+      // Just verify it doesn't throw and returns a boolean
+      const result = isInSample(specialChars, sampleRate);
+      expect(typeof result).toBe("boolean");
+    });
+
+    it("should handle very long strings", () => {
+      const sampleRate = 0.5;
+      const longString = "a".repeat(10000);
+      // Just verify it doesn't throw and returns a boolean
+      const result = isInSample(longString, sampleRate);
+      expect(typeof result).toBe("boolean");
+    });
+
+    it("should handle unicode characters", () => {
+      const sampleRate = 0.5;
+      const unicodeString = "你好世界😀🌍👋";
+      // Just verify it doesn't throw and returns a boolean
+      const result = isInSample(unicodeString, sampleRate);
+      expect(typeof result).toBe("boolean");
+    });
+  });
+
+  // UUID specific tests
+  describe("UUID handling", () => {
+    it("should maintain consistent sampling across different UUID versions", () => {
+      const sampleRate = 0.5;
+      const uuidV4 = "123e4567-e89b-12d3-a456-426614174000";
+      const uuidV1 = "123e4567-e89b-11d3-a456-426614174000";
+
+      // Store initial results
+      const v4Result = isInSample(uuidV4, sampleRate);
+      const v1Result = isInSample(uuidV1, sampleRate);
+
+      // Test consistency 100 times
+      for (let i = 0; i < 100; i++) {
+        expect(isInSample(uuidV4, sampleRate)).toBe(v4Result);
+        expect(isInSample(uuidV1, sampleRate)).toBe(v1Result);
+      }
+    });
+
+    it("should handle sequential UUIDs appropriately", () => {
+      const sampleRate = 0.5;
+      const results = new Set();
+
+      // Generate 1000 sequential UUIDs
+      for (let i = 0; i < 1000; i++) {
+        const sequentialUUID = `00000000-0000-4000-8000-${i.toString().padStart(12, "0")}`;
+        results.add(isInSample(sequentialUUID, sampleRate));
+      }
+
+      // Ensure we got both true and false results
+      expect(results.size).toBe(2);
+    });
+  });
+
+  describe("performance", () => {
+    // Helper to measure execution time
+    const measureExecutionTime = (fn: () => void): number => {
+      const start = performance.now();
+      fn();
+      return performance.now() - start;
+    };
+
+    it("should handle high-frequency calls efficiently", () => {
+      const sampleRate = 0.5;
+      const shortString = "test-string";
+      const iterations = 100_000;
+
+      const executionTime = measureExecutionTime(() => {
+        for (let i = 0; i < iterations; i++) {
+          isInSample(shortString, sampleRate);
+        }
+      });
+
+      // Average time per call should be less than 0.01ms (10 microseconds)
+      const avgTimePerCall = executionTime / iterations;
+      expect(avgTimePerCall).toBeLessThan(0.01);
+    });
+  });
+});


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds sampling functionality to Langfuse SDK for configurable trace sampling using consistent hashing, with tests for edge cases and performance.
> 
>   - **Behavior**:
>     - Adds sampling functionality to Langfuse SDK using `isInSample()` in `langfuse-core/src/sampling.ts`.
>     - Integrates sampling in `LangfuseCoreStateless` in `langfuse-core/src/index.ts` to filter events based on trace ID.
>     - Sample rate can be set via constructor or `LANGFUSE_SAMPLE_RATE` environment variable.
>     - Invalid sample rates log a warning and default to including all traces.
>   - **Tests**:
>     - Adds `langfuse-core/test/langfuse.sampling.spec.ts` to test `isInSample()` for edge cases, consistency, distribution, and performance.
>   - **Misc**:
>     - Removes debug `console.log` in `langfuse-core/src/sampling.ts`.
>     - Updates `LangfuseCoreOptions` in `langfuse-core/src/types.ts` to include `sampleRate`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for c89cbf6f362b2776c3034acfcb1ff0ea17953859. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Added sampling functionality to the Langfuse SDK, enabling configurable trace sampling through a consistent hashing mechanism that ensures all events from the same trace are either included or excluded.

- Remove debug `console.log` statement in `langfuse-core/src/sampling.ts` that exposes internal sampling details
- Consider throwing errors for invalid sample rates instead of defaulting to `true` in `isInSample` function
- Add documentation for the sampling feature in the README or docs, explaining configuration options and behavior
- Consider adding a warning when sampling rate is very low (e.g. < 0.01) to prevent accidental data loss
- Consider adding a method to check if a trace ID would be sampled without creating the trace



<!-- /greptile_comment -->