### PR TITLE
fix(prompts): handle non-json gateway errors

### DIFF
--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -587,7 +587,7 @@ abstract class LangfuseCoreStateless {
         );
 
         if (res.status >= 500) {
-          throw new LangfuseFetchHttpError(res, JSON.stringify(await res.text()));
+          throw new LangfuseFetchHttpError(res, await res.text());
         }
 
         const data = await res.json();

--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -586,11 +586,11 @@ abstract class LangfuseCoreStateless {
           }
         );
 
-        const data = await res.json();
-
         if (res.status >= 500) {
-          throw new LangfuseFetchHttpError(res, JSON.stringify(data));
+          throw new LangfuseFetchHttpError(res, JSON.stringify(await res.text()));
         }
+
+        const data = await res.json();
 
         return { fetchResult: res.status === 200 ? "success" : "failure", data };
       },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix error handling in `LangfuseCoreStateless` to handle non-JSON HTTP error responses by using `res.text()` for status >= 500.
> 
>   - **Error Handling**:
>     - In `LangfuseCoreStateless`, modify error handling for HTTP responses with status >= 500 to handle non-JSON responses by using `res.text()` instead of `res.json()`.
>     - Affects the `fetch` method in `LangfuseCoreStateless` class.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 99a484aacfbdde6c5a273ed9f35c470d44231c1c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Improved error handling for non-JSON server responses in the prompt retrieval functionality, particularly for 5xx gateway errors.

- Modified `getPromptStateless` in `langfuse-core/src/index.ts` to handle raw text responses for 5xx errors
- Prevents JSON parsing failures when server returns HTML error pages (e.g., 502 gateway errors)
- Makes error handling more robust for prompt retrieval operations



<!-- /greptile_comment -->