### PR TITLE
fix(media): retries on media upload

### DIFF
--- a/integration-test/langfuse-openai.spec.ts
+++ b/integration-test/langfuse-openai.spec.ts
@@ -558,7 +558,7 @@ describe("Langfuse-OpenAI-Integation", () => {
       expect(trace.sessionId).toBe("Langfuse");
       expect(trace.userId).toBeDefined();
       expect(trace.userId).toBe("LangfuseUser");
-    }, 10000);
+    }, 15000);
 
     it("Error Handling in openai", async () => {
       const name = `Error-Handling-in-wrapper-${randomUUID()}`;
@@ -1107,7 +1107,7 @@ describe("Langfuse-OpenAI-Integation", () => {
       },
     });
     expect(generation.model).toBe("gpt-4o-2024-08-06");
-  }, 15_000);
+  }, 10000);
 
   it("should work with vision input", async () => {
     const traceId = randomUUID();
@@ -1165,7 +1165,7 @@ describe("Langfuse-OpenAI-Integation", () => {
         },
       ],
     });
-  }, 10_000);
+  }, 15_000);
 
   it("should work with audio input and output", async () => {
     const traceId = randomUUID();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces `uploadMediaWithBackoff` in `LangfuseCoreStateless` for reliable media uploads with retries and exponential backoff, and adjusts test timeouts.
> 
>   - **Behavior**:
>     - Added `uploadMediaWithBackoff` method in `LangfuseCoreStateless` in `index.ts` for media uploads with exponential backoff and jitter.
>     - Handles HTTP status codes to determine retry behavior and logs errors for failed uploads.
>     - Prevents thundering herd problem with jitter in retry delays.
>   - **Tests**:
>     - Adjusted test timeouts in `langfuse-openai.spec.ts` for better reliability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for a2ff8c6182f4074c2240e49e8caf7a03a3878f5f. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Added a new method for handling media uploads with exponential backoff and retries in the Langfuse JS SDK, improving reliability of media upload operations.

- Added `uploadMediaWithBackoff` method in `langfuse-core/src/index.ts` implementing exponential backoff with jitter
- Handles HTTP status codes appropriately to determine retry behavior
- Includes proper error handling and logging for failed upload attempts
- Prevents thundering herd problems through jitter in retry delays



<!-- /greptile_comment -->