### PR TITLE
feat(prompts): add commit message

### DIFF
--- a/integration-test/langfuse-integration-fetch.spec.ts
+++ b/integration-test/langfuse-integration-fetch.spec.ts
@@ -455,6 +455,7 @@ describe("Langfuse (fetch)", () => {
         name: promptName,
         isActive: true,
         prompt: "A {{animal}} usually has {{animal}} friends.",
+        commitMessage: "initial commit",
       });
 
       expect(createdPrompt.constructor.name).toBe("TextPromptClient");
@@ -464,6 +465,7 @@ describe("Langfuse (fetch)", () => {
       expect(createdPrompt.constructor.name).toBe("TextPromptClient");
       expect(fetchedPrompt.name).toEqual(promptName);
       expect(fetchedPrompt.prompt).toEqual("A {{animal}} usually has {{animal}} friends.");
+      expect(fetchedPrompt.commitMessage).toBe("initial commit");
       expect(fetchedPrompt.compile({ animal: "dog" })).toEqual("A dog usually has dog friends.");
     });
 
@@ -529,6 +531,7 @@ describe("Langfuse (fetch)", () => {
         type: "chat",
         isActive: true,
         prompt: [{ role: "system", content: "A {{animal}} usually has {{animal}} friends." }],
+        commitMessage: "initial commit",
       });
 
       expect(createdPrompt.constructor.name).toBe("ChatPromptClient");
@@ -543,6 +546,7 @@ describe("Langfuse (fetch)", () => {
       expect(fetchedPrompt.compile({ animal: "dog" })).toEqual([
         { role: "system", content: "A dog usually has dog friends." },
       ]);
+      expect(fetchedPrompt.commitMessage).toBe("initial commit");
     });
 
     it("should not return fallback if fetch succeeds", async () => {

--- a/langfuse-core/openapi-spec/openapi-server.yaml
+++ b/langfuse-core/openapi-spec/openapi-server.yaml
@@ -4523,6 +4523,10 @@ components:
             type: string
           nullable: true
           description: List of tags to apply to all versions of this prompt.
+        commitMessage:
+          type: string
+          nullable: true
+          description: Commit message for this prompt version.
       required:
         - name
         - prompt
@@ -4548,6 +4552,10 @@ components:
             type: string
           nullable: true
           description: List of tags to apply to all versions of this prompt.
+        commitMessage:
+          type: string
+          nullable: true
+          description: Commit message for this prompt version.
       required:
         - name
         - prompt
@@ -4597,6 +4605,10 @@ components:
           description: >-
             List of tags. Used to filter via UI and API. The same across
             versions of a prompt.
+        commitMessage:
+          type: string
+          nullable: true
+          description: Commit message for this prompt version.
       required:
         - name
         - version

--- a/langfuse-core/src/openapi/server.ts
+++ b/langfuse-core/src/openapi/server.ts
@@ -1569,6 +1569,8 @@ export interface components {
       labels?: string[] | null;
       /** @description List of tags to apply to all versions of this prompt. */
       tags?: string[] | null;
+      /** @description Commit message for this prompt version. */
+      commitMessage?: string | null;
     };
     /** CreateTextPromptRequest */
     CreateTextPromptRequest: {
@@ -1579,6 +1581,8 @@ export interface components {
       labels?: string[] | null;
       /** @description List of tags to apply to all versions of this prompt. */
       tags?: string[] | null;
+      /** @description Commit message for this prompt version. */
+      commitMessage?: string | null;
     };
     /** Prompt */
     Prompt:
@@ -1599,6 +1603,8 @@ export interface components {
       labels: string[];
       /** @description List of tags. Used to filter via UI and API. The same across versions of a prompt. */
       tags: string[];
+      /** @description Commit message for this prompt version. */
+      commitMessage?: string | null;
     };
     /** ChatMessage */
     ChatMessage: {

--- a/langfuse-core/src/prompts/promptClients.ts
+++ b/langfuse-core/src/prompts/promptClients.ts
@@ -15,6 +15,7 @@ abstract class BasePromptClient {
   public readonly isFallback: boolean;
   public readonly type: "text" | "chat";
   public readonly prompt: string | ChatMessage[];
+  public readonly commitMessage: string | null | undefined;
 
   constructor(prompt: CreateLangfusePromptResponse, isFallback = false, type: "text" | "chat") {
     this.name = prompt.name;
@@ -25,6 +26,7 @@ abstract class BasePromptClient {
     this.isFallback = isFallback;
     this.type = type;
     this.prompt = prompt.prompt;
+    this.commitMessage = prompt.commitMessage;
   }
 
   abstract compile(variables?: Record<string, string>): string | ChatMessage[];

--- a/langfuse/src/publicApi.ts
+++ b/langfuse/src/publicApi.ts
@@ -1077,6 +1077,8 @@ export interface ApiCreateChatPromptRequest {
   labels?: string[] | null;
   /** List of tags to apply to all versions of this prompt. */
   tags?: string[] | null;
+  /** Commit message for this prompt version. */
+  commitMessage?: string | null;
 }
 
 /** CreateTextPromptRequest */
@@ -1088,6 +1090,8 @@ export interface ApiCreateTextPromptRequest {
   labels?: string[] | null;
   /** List of tags to apply to all versions of this prompt. */
   tags?: string[] | null;
+  /** Commit message for this prompt version. */
+  commitMessage?: string | null;
 }
 
 /** Prompt */
@@ -1108,6 +1112,8 @@ export interface ApiBasePrompt {
   labels: string[];
   /** List of tags. Used to filter via UI and API. The same across versions of a prompt. */
   tags: string[];
+  /** Commit message for this prompt version. */
+  commitMessage?: string | null;
 }
 
 /** ChatMessage */


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `commitMessage` support for prompt versions in API and client interfaces.
> 
>   - **Behavior**:
>     - Adds `commitMessage` field to prompt creation and fetching in `langfuse-integration-fetch.spec.ts`.
>     - Updates OpenAPI spec in `openapi-server.yaml` to include `commitMessage` for prompt versions.
>   - **Models**:
>     - Adds `commitMessage` to `BasePromptClient` in `promptClients.ts`.
>     - Updates `ApiCreateChatPromptRequest` and `ApiCreateTextPromptRequest` in `publicApi.ts` to include `commitMessage`.
>   - **Misc**:
>     - Updates `components` in `server.ts` to include `commitMessage` for prompt-related schemas.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for b303a6e508cdff0441530bfe0aac72631ed5f5dc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Added support for commit messages in prompts across the Langfuse JS SDK, enabling better version tracking and documentation of prompt changes.

- Added optional `commitMessage` field to prompt interfaces in `/langfuse/src/publicApi.ts` and OpenAPI specs
- Added `commitMessage` property to `BasePromptClient` class in `/langfuse-core/src/prompts/promptClients.ts`
- Added integration tests in `/integration-test/langfuse-integration-fetch.spec.ts` to verify commit message functionality
- Note: `commitMessage` is missing from `toJSON()` method in `BasePromptClient` which could cause serialization inconsistencies



<!-- /greptile_comment -->