### PR TITLE
feat(client): add environment to traces, scores, obs

### DIFF
--- a/integration-test/langfuse-integration-fetch.spec.ts
+++ b/integration-test/langfuse-integration-fetch.spec.ts
@@ -774,6 +774,9 @@ describe("Langfuse (fetch)", () => {
     const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     const environment = "PRODUCTION";
     const langfuse = new Langfuse({ environment });
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Invalid tracing environment"));
+
     const traceId = randomUUID();
 
     const trace = langfuse.trace({ id: traceId });
@@ -782,16 +785,12 @@ describe("Langfuse (fetch)", () => {
 
     await langfuse.flushAsync();
 
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Invalid tracing environment"));
-
-    const fetchedTrace = await (
-      await getAxiosClient()
-    ).get(`${LANGFUSE_BASEURL}/api/public/traces/${traceId}`, {
-      headers: getHeaders(),
-    });
-
-    expect(fetchedTrace.status).toBe(404);
-  }, 10_000);
+    await expect(
+      (await getAxiosClient()).get(`${LANGFUSE_BASEURL}/api/public/traces/${traceId}`, {
+        headers: getHeaders(),
+      })
+    ).rejects.toThrow();
+  }, 15_000);
 
   it("should set environment if specified in environment variable", async () => {
     const environment = "staging";

--- a/integration-test/langfuse-integration-fetch.spec.ts
+++ b/integration-test/langfuse-integration-fetch.spec.ts
@@ -748,6 +748,53 @@ describe("Langfuse (fetch)", () => {
     }, 10_000);
   });
 
+  it("should set environment if specified in constructor arg", async () => {
+    const environment = "production";
+    const langfuse = new Langfuse({ environment });
+    const traceId = randomUUID();
+
+    const trace = langfuse.trace({ id: traceId });
+    trace.generation({ name: "test-gen" });
+    trace.score({ name: "test", value: 1 });
+
+    await langfuse.flushAsync();
+
+    const fetchedTrace = await (
+      await getAxiosClient()
+    ).get(`${LANGFUSE_BASEURL}/api/public/traces/${traceId}`, {
+      headers: getHeaders(),
+    });
+
+    expect(fetchedTrace.data.environment).toEqual(environment);
+    expect(fetchedTrace.data.observations[0].environment).toEqual(environment);
+    expect(fetchedTrace.data.scores[0].environment).toEqual(environment);
+  }, 10_000);
+
+  it("should set environment if specified in environment variable", async () => {
+    const environment = "staging";
+    process.env.LANGFUSE_TRACING_ENVIRONMENT = environment;
+    const langfuse = new Langfuse();
+    const traceId = randomUUID();
+
+    const trace = langfuse.trace({ id: traceId });
+    trace.generation({ name: "test-gen" });
+    trace.score({ name: "test", value: 1 });
+
+    await langfuse.flushAsync();
+
+    const fetchedTrace = await (
+      await getAxiosClient()
+    ).get(`${LANGFUSE_BASEURL}/api/public/traces/${traceId}`, {
+      headers: getHeaders(),
+    });
+
+    expect(fetchedTrace.data.environment).toEqual(environment);
+    expect(fetchedTrace.data.observations[0].environment).toEqual(environment);
+    expect(fetchedTrace.data.scores[0].environment).toEqual(environment);
+
+    delete process.env.LANGFUSE_TRACING_ENVIRONMENT;
+  }, 10_000);
+
   it("replace media reference string in object", async () => {
     const langfuse = new Langfuse();
     const mockTraceName = "test-trace-with-audio" + Math.random().toString(36);

--- a/langfuse-core/openapi-spec/openapi-server.yaml
+++ b/langfuse-core/openapi-spec/openapi-server.yaml
@@ -3755,6 +3755,9 @@ components:
         version:
           type: string
           nullable: true
+        environment:
+          type: string
+          nullable: true
     CreateEventBody:
       title: CreateEventBody
       type: object
@@ -3922,6 +3925,9 @@ components:
         parentObservationId:
           type: string
           nullable: true
+        environment:
+          type: string
+          nullable: true
       required:
         - type
     TraceBody:
@@ -3961,6 +3967,9 @@ components:
           items:
             type: string
           nullable: true
+        environment:
+          type: string
+          nullable: true
         public:
           type: boolean
           nullable: true
@@ -3985,6 +3994,9 @@ components:
         name:
           type: string
           example: novelty
+        environment:
+          type: string
+          nullable: true
         value:
           $ref: "#/components/schemas/CreateScoreValue"
           description: >-

--- a/langfuse-core/openapi-spec/openapi-server.yaml
+++ b/langfuse-core/openapi-spec/openapi-server.yaml
@@ -715,9 +715,29 @@ paths:
   /api/public/ingestion:
     post:
       description: >-
-        Batched ingestion for Langfuse Tracing. If you want to use tracing via
-        the API, such as to build your own Langfuse client implementation, this
-        is the only API route you need to implement.
+        Batched ingestion for Langfuse Tracing.
+
+        If you want to use tracing via the API, such as to build your own
+        Langfuse client implementation, this is the only API route you need to
+        implement.
+
+
+        Within each batch, there can be multiple events.
+
+        Each event has a type, an id, a timestamp, metadata and a body.
+
+        Internally, we refer to this as the "event envelope" as it tells us
+        something about the event but not the trace.
+
+        We use the event id within this envelope to deduplicate messages to
+        avoid processing the same event twice, i.e. the event id should be
+        unique per request.
+
+        The event.body.id is the ID of the actual trace and will be used for
+        updates and will be visible within the Langfuse App.
+
+        I.e. if you want to update a trace, you'd use the same body id, but
+        separate event IDs.
 
 
         Notes:
@@ -743,6 +763,25 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/IngestionResponse"
+              examples:
+                Example1:
+                  value:
+                    successes:
+                      - id: abcdef-1234-5678-90ab
+                        status: 201
+                    errors: []
+                Example2:
+                  value:
+                    successes:
+                      - id: abcdef-1234-5678-90ab
+                        status: 201
+                    errors: []
+                Example3:
+                  value:
+                    successes:
+                      - id: abcdef-1234-5678-90ab
+                        status: 201
+                    errors: []
         "400":
           description: ""
           content:
@@ -791,6 +830,49 @@ paths:
                     debugging.
               required:
                 - batch
+            examples:
+              Example1:
+                value:
+                  batch:
+                    - id: abcdef-1234-5678-90ab
+                      timestamp: "2022-01-01T00:00:00.000Z"
+                      type: trace-create
+                      body:
+                        id: abcdef-1234-5678-90ab
+                        timestamp: "2022-01-01T00:00:00.000Z"
+                        name: My Trace
+                        userId: 1234-5678-90ab-cdef
+                        input: My input
+                        output: My output
+                        sessionId: 1234-5678-90ab-cdef
+                        release: 1.0.0
+                        version: 1.0.0
+                        metadata: My metadata
+                        tags:
+                          - tag1
+                          - tag2
+                        public: true
+              Example2:
+                value:
+                  batch:
+                    - id: abcdef-1234-5678-90ab
+                      timestamp: "2022-01-01T00:00:00.000Z"
+                      type: span-create
+                      body:
+                        id: abcdef-1234-5678-90ab
+                        traceId: 1234-5678-90ab-cdef
+                        startTime: "2022-01-01T00:00:00.000Z"
+              Example3:
+                value:
+                  batch:
+                    - id: abcdef-1234-5678-90ab
+                      timestamp: "2022-01-01T00:00:00.000Z"
+                      type: score-create
+                      body:
+                        id: abcdef-1234-5678-90ab
+                        traceId: 1234-5678-90ab-cdef
+                        name: My Score
+                        value: 0.9
   /api/public/media/{mediaId}:
     get:
       description: Get a media record
@@ -2546,6 +2628,13 @@ components:
           type: boolean
           nullable: true
           description: Public traces are accessible via url without login
+        environment:
+          type: string
+          nullable: true
+          description: >-
+            The environment from which this trace originated. Can be any
+            lowercase alphanumeric string with hyphens and underscores that does
+            not start with 'langfuse'.
       required:
         - id
         - timestamp
@@ -2737,6 +2826,13 @@ components:
             The cost details of the observation. Key is the name of the cost
             metric, value is the cost in USD. The total key is the sum of all
             (non-total) cost metrics or the total value ingested.
+        environment:
+          type: string
+          nullable: true
+          description: >-
+            The environment from which this observation originated. Can be any
+            lowercase alphanumeric string with hyphens and underscores that does
+            not start with 'langfuse'.
       required:
         - id
         - type
@@ -2951,6 +3047,13 @@ components:
           description: >-
             Reference an annotation queue on a score. Populated if the score was
             initially created in an annotation queue.
+        environment:
+          type: string
+          nullable: true
+          description: >-
+            The environment from which this score originated. Can be any
+            lowercase alphanumeric string with hyphens and underscores that does
+            not start with 'langfuse'.
       required:
         - id
         - traceId

--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -1077,7 +1077,7 @@ abstract class LangfuseCoreStateless {
 
     const done = (err?: any): void => {
       if (err) {
-        this._events.emit("error", err);
+        this._events.emit("warning", err);
       }
       callback?.(err, items);
       this._events.emit("flush", items);
@@ -1157,7 +1157,7 @@ abstract class LangfuseCoreStateless {
         totalSize += itemSize;
         processedItems.push(queue[i]);
       } catch (error) {
-        console.error(`[Langfuse SDK] ${error}`);
+        this._events.emit("error", error);
         remainingItems.push(...queue.slice(i));
         break;
       }

--- a/langfuse-core/src/openapi/server.ts
+++ b/langfuse-core/src/openapi/server.ts
@@ -1168,6 +1168,7 @@ export interface components {
       statusMessage?: string | null;
       parentObservationId?: string | null;
       version?: string | null;
+      environment?: string | null;
     };
     /** CreateEventBody */
     CreateEventBody: {
@@ -1243,6 +1244,7 @@ export interface components {
       level?: components["schemas"]["ObservationLevel"];
       statusMessage?: string | null;
       parentObservationId?: string | null;
+      environment?: string | null;
     };
     /** TraceBody */
     TraceBody: {
@@ -1258,6 +1260,7 @@ export interface components {
       version?: string | null;
       metadata?: unknown;
       tags?: string[] | null;
+      environment?: string | null;
       /** @description Make trace publicly accessible via url */
       public?: boolean | null;
     };
@@ -1272,6 +1275,7 @@ export interface components {
       traceId: string;
       /** @example novelty */
       name: string;
+      environment?: string | null;
       /** @description The value of the score. Must be passed as string for categorical scores, and numeric for boolean and numeric scores. Boolean score values must equal either 1 or 0 (true or false) */
       value: components["schemas"]["CreateScoreValue"];
       observationId?: string | null;

--- a/langfuse-core/src/openapi/server.ts
+++ b/langfuse-core/src/openapi/server.ts
@@ -186,7 +186,15 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** @description Batched ingestion for Langfuse Tracing. If you want to use tracing via the API, such as to build your own Langfuse client implementation, this is the only API route you need to implement.
+    /** @description Batched ingestion for Langfuse Tracing.
+     *     If you want to use tracing via the API, such as to build your own Langfuse client implementation, this is the only API route you need to implement.
+     *
+     *     Within each batch, there can be multiple events.
+     *     Each event has a type, an id, a timestamp, metadata and a body.
+     *     Internally, we refer to this as the "event envelope" as it tells us something about the event but not the trace.
+     *     We use the event id within this envelope to deduplicate messages to avoid processing the same event twice, i.e. the event id should be unique per request.
+     *     The event.body.id is the ID of the actual trace and will be used for updates and will be visible within the Langfuse App.
+     *     I.e. if you want to update a trace, you'd use the same body id, but separate event IDs.
      *
      *     Notes:
      *
@@ -586,6 +594,8 @@ export interface components {
       tags?: string[] | null;
       /** @description Public traces are accessible via url without login */
       public?: boolean | null;
+      /** @description The environment from which this trace originated. Can be any lowercase alphanumeric string with hyphens and underscores that does not start with 'langfuse'. */
+      environment?: string | null;
     };
     /** TraceWithDetails */
     TraceWithDetails: {
@@ -693,6 +703,8 @@ export interface components {
       costDetails?: {
         [key: string]: number;
       } | null;
+      /** @description The environment from which this observation originated. Can be any lowercase alphanumeric string with hyphens and underscores that does not start with 'langfuse'. */
+      environment?: string | null;
     };
     /** ObservationsView */
     ObservationsView: {
@@ -825,6 +837,8 @@ export interface components {
       configId?: string | null;
       /** @description Reference an annotation queue on a score. Populated if the score was initially created in an annotation queue. */
       queueId?: string | null;
+      /** @description The environment from which this score originated. Can be any lowercase alphanumeric string with hyphens and underscores that does not start with 'langfuse'. */
+      environment?: string | null;
     };
     /** NumericScore */
     NumericScore: {
@@ -1006,10 +1020,11 @@ export interface components {
      */
     ObservationLevel: "DEBUG" | "DEFAULT" | "WARNING" | "ERROR";
     /** MapValue */
-    MapValue: (string | null) | (number | null) | (boolean | null) | (string[] | null) | undefined /**
+    MapValue: (string | null) | (number | null) | (boolean | null) | (string[] | null) | undefined;
+    /**
      * CommentObjectType
      * @enum {string}
-     */;
+     */
     CommentObjectType: "TRACE" | "OBSERVATION" | "SESSION" | "PROMPT";
     /**
      * DatasetStatus

--- a/langfuse-core/src/types.ts
+++ b/langfuse-core/src/types.ts
@@ -31,6 +31,8 @@ export type LangfuseCoreOptions = {
   mask?: MaskFunction;
   // Trace sampling rate. Approx. sampleRate % traces will be sent to LF servers
   sampleRate?: number;
+  // Environment from which traces originate
+  environment?: string;
   // Project ID to use for the SDK in admin mode. This should never be set by users.
   _projectId?: string;
   // Whether to enable local event export. Defaults to false.

--- a/langfuse-core/test/langfuse.debug.spec.ts
+++ b/langfuse-core/test/langfuse.debug.spec.ts
@@ -28,8 +28,8 @@ describe("Langfuse Core", () => {
       langfuse.trace({ name: "test-trace2" });
       await jest.advanceTimersByTimeAsync(1);
       expect(spy).toHaveBeenCalledTimes(4);
-      expect(spy).toHaveBeenCalledWith("Langfuse Debug", "trace-create", expect.stringContaining("test-trace2"));
-      expect(spy).toHaveBeenCalledWith("Langfuse Debug", "flush", expect.stringContaining("test-trace2"));
+      expect(spy).toHaveBeenCalledWith("[Langfuse Debug]", "trace-create", expect.stringContaining("test-trace2"));
+      expect(spy).toHaveBeenCalledWith("[Langfuse Debug]", "flush", expect.stringContaining("test-trace2"));
 
       spy.mockReset();
       langfuse.debug(false);

--- a/langfuse/src/publicApi.ts
+++ b/langfuse/src/publicApi.ts
@@ -64,6 +64,8 @@ export interface ApiTrace {
   tags?: string[] | null;
   /** Public traces are accessible via url without login */
   public?: boolean | null;
+  /** The environment from which this trace originated. Can be any lowercase alphanumeric string with hyphens and underscores that does not start with 'langfuse'. */
+  environment?: string | null;
 }
 
 /** TraceWithDetails */
@@ -170,6 +172,8 @@ export interface ApiObservation {
   usageDetails?: Record<string, number>;
   /** The cost details of the observation. Key is the name of the cost metric, value is the cost in USD. The total key is the sum of all (non-total) cost metrics or the total value ingested. */
   costDetails?: Record<string, number>;
+  /** The environment from which this observation originated. Can be any lowercase alphanumeric string with hyphens and underscores that does not start with 'langfuse'. */
+  environment?: string | null;
 }
 
 /** ObservationsView */
@@ -308,6 +312,8 @@ export interface ApiBaseScore {
   configId?: string | null;
   /** Reference an annotation queue on a score. Populated if the score was initially created in an annotation queue. */
   queueId?: string | null;
+  /** The environment from which this score originated. Can be any lowercase alphanumeric string with hyphens and underscores that does not start with 'langfuse'. */
+  environment?: string | null;
 }
 
 /** NumericScore */
@@ -1935,7 +1941,7 @@ export class LangfusePublicApi<SecurityDataType extends unknown> extends HttpCli
       }),
 
     /**
-     * @description Batched ingestion for Langfuse Tracing. If you want to use tracing via the API, such as to build your own Langfuse client implementation, this is the only API route you need to implement. Notes: - Introduction to data model: https://langfuse.com/docs/tracing-data-model - Batch sizes are limited to 3.5 MB in total. You need to adjust the number of events per batch accordingly. - The API does not return a 4xx status code for input errors. Instead, it responds with a 207 status code, which includes a list of the encountered errors.
+     * @description Batched ingestion for Langfuse Tracing. If you want to use tracing via the API, such as to build your own Langfuse client implementation, this is the only API route you need to implement. Within each batch, there can be multiple events. Each event has a type, an id, a timestamp, metadata and a body. Internally, we refer to this as the "event envelope" as it tells us something about the event but not the trace. We use the event id within this envelope to deduplicate messages to avoid processing the same event twice, i.e. the event id should be unique per request. The event.body.id is the ID of the actual trace and will be used for updates and will be visible within the Langfuse App. I.e. if you want to update a trace, you'd use the same body id, but separate event IDs. Notes: - Introduction to data model: https://langfuse.com/docs/tracing-data-model - Batch sizes are limited to 3.5 MB in total. You need to adjust the number of events per batch accordingly. - The API does not return a 4xx status code for input errors. Instead, it responds with a 207 status code, which includes a list of the encountered errors.
      *
      * @tags Ingestion
      * @name IngestionBatch

--- a/langfuse/src/publicApi.ts
+++ b/langfuse/src/publicApi.ts
@@ -642,6 +642,7 @@ export interface ApiOptionalObservationBody {
   statusMessage?: string | null;
   parentObservationId?: string | null;
   version?: string | null;
+  environment?: string | null;
 }
 
 /** CreateEventBody */
@@ -715,6 +716,7 @@ export interface ApiObservationBody {
   level?: ApiObservationLevel | null;
   statusMessage?: string | null;
   parentObservationId?: string | null;
+  environment?: string | null;
 }
 
 /** TraceBody */
@@ -731,6 +733,7 @@ export interface ApiTraceBody {
   version?: string | null;
   metadata?: any;
   tags?: string[] | null;
+  environment?: string | null;
   /** Make trace publicly accessible via url */
   public?: boolean | null;
 }
@@ -747,6 +750,7 @@ export interface ApiScoreBody {
   traceId: string;
   /** @example "novelty" */
   name: string;
+  environment?: string | null;
   /** The value of the score. Must be passed as string for categorical scores, and numeric for boolean and numeric scores. Boolean score values must equal either 1 or 0 (true or false) */
   value: ApiCreateScoreValue;
   observationId?: string | null;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add environment tracking to Langfuse JavaScript SDK for traces, observations, and scores with validation and error handling.
> 
>   - **Behavior**:
>     - Added `environment` property to core types in `langfuse-core/src/index.ts` with validation pattern `/^(?!langfuse)[a-z0-9_-]+$/`.
>     - Environment can be set via constructor option or `LANGFUSE_TRACING_ENVIRONMENT` environment variable.
>     - Implemented error logging for invalid environment values.
>   - **Testing**:
>     - Added integration tests in `langfuse-integration-fetch.spec.ts` to verify environment propagation to traces, observations, and scores.
>   - **OpenAPI**:
>     - Updated OpenAPI specification in `openapi-server.yaml` to include the new environment property.
>   - **Misc**:
>     - Improved debug logging format in `langfuse-core/src/index.ts` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for da84789c7fc065f7974040b450964a8cb66c5506. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
This PR adds environment tracking support to the Langfuse JavaScript SDK, allowing users to specify which environment (production, staging, etc.) traces, observations, and scores originate from.

- Added `environment` property to core types with validation pattern `/^(?!langfuse)[a-z0-9_-]+$/`
- Environment can be set via constructor option or `LANGFUSE_TRACING_ENVIRONMENT` environment variable
- Added integration tests verifying environment propagation to traces, observations, and scores
- Implemented error logging for invalid environment values (events will be rejected by server)
- Updated OpenAPI specification and interfaces to include the new environment property
- Improved debug logging format for consistency

Greptile AI



<!-- /greptile_comment -->