### PR TITLE
chore: pin swagger-typescript-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prettier:check": "prettier --check \"./**/*.{ts,tsx}\"",
     "generateAPI": "yarn generateAPITypes && yarn generateAPIClient",
     "generateAPITypes": "openapi-typescript langfuse-core/openapi-spec/openapi-server.yaml --output langfuse-core/src/openapi/server.ts && openapi-typescript langfuse-core/openapi-spec/openapi-client.yaml --output langfuse-core/src/openapi/client.ts && yarn prettier",
-    "generateAPIClient": "npx swagger-typescript-api --path ./langfuse-core/openapi-spec/openapi-server.yaml --output ./langfuse/src --name publicApi.ts --api-class-name LangfusePublicApi --union-enums --unwrap-response-data --type-prefix Api --sort-routes --extract-request-params --extract-request-body",
+    "generateAPIClient": "npx swagger-typescript-api@13.0.23 --path ./langfuse-core/openapi-spec/openapi-server.yaml --output ./langfuse/src --name publicApi.ts --api-class-name LangfusePublicApi --union-enums --unwrap-response-data --type-prefix Api --sort-routes --extract-request-params --extract-request-body",
     "test": "dotenv -- jest langfuse-core/* langfuse-node/* langfuse/*",
     "test:watch": "dotenv -- jest langfuse-core/* langfuse-node/* langfuse/* --watch --runInBand",
     "test:all": "dotenv -- jest langfuse-core/* langfuse-node/* langfuse/*",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Pin `swagger-typescript-api` to version `13.0.23` in `package.json`.
> 
>   - **Dependencies**:
>     - Pin `swagger-typescript-api` to version `13.0.23` in `package.json` to ensure consistent API client generation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 930e31253a85c086fb0e2d330af745ce3aa2030b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->