### PR TITLE
fix: correct return type for dataset item link function call

### DIFF
--- a/langfuse-core/src/types.ts
+++ b/langfuse-core/src/types.ts
@@ -252,7 +252,7 @@ export type LinkDatasetItem = (
     description?: string;
     metadata?: any;
   }
-) => Promise<{ id: string }>;
+) => Promise<components['schemas']['DatasetRunItem']>;
 export type DatasetItem = DatasetItemData & { link: LinkDatasetItem };
 
 export type MaskFunction = (params: { data: any }) => any;


### PR DESCRIPTION
## Problem

TypeScript types appear to be inaccurate for the `DatasetItem.link` return type. The types indicate only an `id: string` property returned, but at runtime, there is all data associated with `DatasetRunItem`.

## Changes

update the return type of `DatasetItem.link` to reflect the `DatasetRunItem` schema, instead of just an object with an `id` property, as that's what comes back from the API in production.

## Release info Sub-libraries affected

Note: I'm not certain of the desired answers for this section, but I took my best guess.

### Bump level

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

- [X] All of them
- [ ] langfuse
- [ ] langfuse-node

### Changelog notes

- Update return type for `DatasetItem.Link` to match `DatasetRunItem`

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `DatasetItem.link` return type to `DatasetRunItem` in `types.ts` to match API response.
> 
>   - **Type Changes**:
>     - Update return type of `DatasetItem.link` in `types.ts` to `Promise<components['schemas']['DatasetRunItem']>` from `Promise<{ id: string }>` to match API response.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 754fd48f06313d071a687ee6fed00707c30b7ef2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
This PR corrects the TypeScript return type for the `DatasetItem.link` function to accurately reflect the full `DatasetRunItem` schema.

- Updated return type in `/langfuse-core/src/types.ts` from `Promise<{ id: string }>` to `Promise<components['schemas']['DatasetRunItem']>`.
- Ensures type safety by aligning the TS definition with the actual API response.
- Enhances consistency across Langfuse sub-libraries that utilize this functionality.



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->