### PR TITLE
fix(langfuse-vercel): OTEL SDK v2 compatibility

### DIFF
--- a/langfuse-core/src/types.ts
+++ b/langfuse-core/src/types.ts
@@ -252,7 +252,7 @@ export type LinkDatasetItem = (
     description?: string;
     metadata?: any;
   }
-) => Promise<components['schemas']['DatasetRunItem']>;
+) => Promise<{ id: string }>;
 export type DatasetItem = DatasetItemData & { link: LinkDatasetItem };
 
 export type MaskFunction = (params: { data: any }) => any;


### PR DESCRIPTION
This reverts commit 63f5861adeda1aa0c026e6ed499ad44f1bc184bf.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts changes to `LinkDatasetItem` return type and span parent ID handling in `LangfuseExporter` for OTEL SDK compatibility.
> 
>   - **Revert Changes**:
>     - Reverts return type of `LinkDatasetItem` in `types.ts` from `Promise<components['schemas']['DatasetRunItem']>` to `Promise<{ id: string }>`.
>     - Reverts changes in `LangfuseExporter.ts` to use `this.getParentSpanId(span)` instead of `span.parentSpanId` for `parentObservationId` in `span()` and `generation()` methods.
>     - Reverts `isAiSdkSpan()` and `isRootAiSdkSpan()` to use `this.getParentSpanId(span)` for compatibility with OTEL SDKs v1 and v2.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for d74a0dfea0409a099e34c0cfd40cd98c0a5327cc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
This PR reverts a dataset item link function return type and enhances OpenTelemetry compatibility in the Langfuse Vercel exporter.

- Reverts `LinkDatasetItem` return type from full `DatasetRunItem` schema to simpler `Promise<{ id: string }>` in `langfuse-core/src/types.ts`
- Adds compatibility with OpenTelemetry SDK v1 and v2 in `LangfuseExporter` through consistent parent span ID handling
- Improves root span detection logic and span processing in the Vercel exporter
- Updates instrumentation scope naming conventions to support both SDK versions
- Maintains backward compatibility with older AI SDK versions while supporting newer features



<!-- /greptile_comment -->