### PR TITLE
Support exporting all spans.

### DIFF
--- a/langfuse-vercel/src/LangfuseExporter.ts
+++ b/langfuse-vercel/src/LangfuseExporter.ts
@@ -4,6 +4,7 @@ import { Langfuse, type LangfuseOptions, type LangfusePromptRecord } from "langf
 import type { ExportResult, ExportResultCode } from "@opentelemetry/core";
 
 type LangfuseExporterParams = {
+  shouldExportNonAiSpans?: boolean;
   publicKey?: string;
   secretKey?: string;
   baseUrl?: string;
@@ -13,10 +14,12 @@ type LangfuseExporterParams = {
 export class LangfuseExporter implements SpanExporter {
   static langfuse: Langfuse | null = null; // Singleton instance
   private readonly debug: boolean;
+  private readonly shouldExportNonAiSpans: boolean;
   private readonly langfuse: Langfuse;
 
   constructor(params: LangfuseExporterParams = {}) {
     this.debug = params.debug ?? false;
+    this.shouldExportNonAiSpans = params.shouldExportNonAiSpans ?? false;
 
     if (!LangfuseExporter.langfuse) {
       LangfuseExporter.langfuse = new Langfuse({
@@ -40,7 +43,7 @@ export class LangfuseExporter implements SpanExporter {
       const traceSpanMap = new Map<string, ReadableSpan[]>();
 
       for (const span of allSpans) {
-        if (!this.isAiSdkSpan(span)) {
+        if (!this.shouldExportNonAiSpans && !this.isAiSdkSpan(span)) {
           this.logDebug("Ignoring non-AI SDK span", span.name);
 
           continue;

--- a/langfuse-vercel/src/LangfuseExporter.ts
+++ b/langfuse-vercel/src/LangfuseExporter.ts
@@ -4,7 +4,7 @@ import { Langfuse, type LangfuseOptions, type LangfusePromptRecord } from "langf
 import type { ExportResult, ExportResultCode } from "@opentelemetry/core";
 
 type LangfuseExporterParams = {
-  preserveRootSpanName?: boolean;
+  preserveRootSpanName?: boolean; // If true, preserves the original root span name in traces instead of using a generated name.
   enableNonAiSpans?: boolean;
   publicKey?: string;
   secretKey?: string;

--- a/langfuse-vercel/src/LangfuseExporter.ts
+++ b/langfuse-vercel/src/LangfuseExporter.ts
@@ -5,7 +5,7 @@ import type { ExportResult, ExportResultCode } from "@opentelemetry/core";
 
 type LangfuseExporterParams = {
   preserveRootSpanName?: boolean;
-  shouldExportNonAiSpans?: boolean;
+  enableNonAiSpans?: boolean;
   publicKey?: string;
   secretKey?: string;
   baseUrl?: string;
@@ -16,13 +16,13 @@ export class LangfuseExporter implements SpanExporter {
   static langfuse: Langfuse | null = null; // Singleton instance
   private readonly debug: boolean;
   private readonly preserveRootSpanName: boolean;
-  private readonly shouldExportNonAiSpans: boolean;
+  private readonly enableNonAiSpans: boolean;
   private readonly langfuse: Langfuse;
 
   constructor(params: LangfuseExporterParams = {}) {
     this.debug = params.debug ?? false;
     this.preserveRootSpanName = params.preserveRootSpanName ?? false;
-    this.shouldExportNonAiSpans = params.shouldExportNonAiSpans ?? false;
+    this.enableNonAiSpans = params.enableNonAiSpans ?? false;
 
     if (!LangfuseExporter.langfuse) {
       LangfuseExporter.langfuse = new Langfuse({
@@ -46,7 +46,7 @@ export class LangfuseExporter implements SpanExporter {
       const traceSpanMap = new Map<string, ReadableSpan[]>();
 
       for (const span of allSpans) {
-        if (!this.shouldExportNonAiSpans && !this.isAiSdkSpan(span)) {
+        if (!this.enableNonAiSpans && !this.isAiSdkSpan(span)) {
           this.logDebug("Ignoring non-AI SDK span", span.name);
 
           continue;


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/6489.

Adds a feature to `langfuse-vercel` that allows us to use `LangfuseExporter` as a generic span exporter to Langfuse (e.g. for OTel):
* The flag `enableNonAiSpans` will not return early on non-AI spans. This enables exporting OTel spans.
* If we enable the above, it's probably nice _not_ to rename the root span/trace. Hence the flag `preserveRootSpanName`.

Here's a screenshot of OTel _and_ AI SDK spans nested together:
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/8e04b959-4d40-4247-aa77-758edcd8c5bb" />
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `enableNonAiSpans` and `preserveRootSpanName` flags to `LangfuseExporter` to support exporting non-AI spans and preserving root span names.
> 
>   - **Behavior**:
>     - Adds `enableNonAiSpans` flag to `LangfuseExporter` to export non-AI spans.
>     - Adds `preserveRootSpanName` flag to prevent renaming root spans.
>     - Modifies `export()` in `LangfuseExporter` to respect `enableNonAiSpans`.
>     - Updates `processSpanAsLangfuseSpan()` to use `preserveRootSpanName`.
>   - **Misc**:
>     - Refactors span name logic in `processSpanAsLangfuseSpan()` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 0126d48f5a0909c35a0a108d88245b5818d0d9cf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Added two new configuration flags to LangfuseExporter in langfuse-vercel for enhanced OpenTelemetry span handling and name preservation.

- Added `enableNonAiSpans` flag in `LangfuseExporter.ts` to allow exporting all OpenTelemetry spans, not just AI SDK spans
- Added `preserveRootSpanName` flag in `LangfuseExporter.ts` to maintain original span/trace names
- Fixed duplicate condition check for 'ai.response.msToFirstChunk' in completionStartTime calculation
- Updated span filtering logic to respect `enableNonAiSpans` setting
- Modified name processing to conditionally preserve original names based on `preserveRootSpanName`



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->