### PR TITLE
fix: missing generation metatdata for AI SDK logging

### DIFF
--- a/langfuse-vercel/src/LangfuseExporter.ts
+++ b/langfuse-vercel/src/LangfuseExporter.ts
@@ -181,8 +181,8 @@ export class LangfuseExporter implements SpanExporter {
             ? attributes["gen_ai.request.max_tokens"]?.toString() ?? null
             : null,
         finishReason:
-          "gai.response.finishReason" in attributes
-            ? attributes["ai.response.finishReason"]?.toString() ?? null
+          "gen_ai.response.finish_reasons" in attributes
+            ? attributes["gen_ai.response.finish_reasons"]?.toString() ?? null
             : "gen_ai.finishReason" in attributes //  Legacy support for ai SDK versions < 4.0.0
               ? attributes["gen_ai.finishReason"]?.toString() ?? null
               : null,
@@ -195,6 +195,10 @@ export class LangfuseExporter implements SpanExporter {
         maxRetries:
           "ai.settings.maxRetries" in attributes ? attributes["ai.settings.maxRetries"]?.toString() ?? null : null,
         mode: "ai.settings.mode" in attributes ? attributes["ai.settings.mode"]?.toString() ?? null : null,
+        temperature:
+          "gen_ai.request.temperature" in attributes
+            ? attributes["gen_ai.request.temperature"]?.toString() ?? null
+            : null,
       },
       usage: this.parseUsageDetails(attributes),
       usageDetails: this.parseUsageDetails(attributes),


### PR DESCRIPTION
## Problem

When logging generations from Vercel AI SDK, some metadata are missing from the trace due to incorrect/missing references to LLM span attributes, specifically the **_finish reason_** and **_temperature_** fields.

## Changes

Fix typo for the **finishReason** attribute and add a missing temperature attribute to allow these metadata to be logged to Langfuse.

See AI SDK [docs](https://ai-sdk.dev/docs/ai-sdk-core/telemetry#call-llm-span-information) for all supported attributes.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix typo and add missing attribute in `LangfuseExporter` to log AI SDK metadata correctly.
> 
>   - **Behavior**:
>     - Fix typo in `LangfuseExporter` for `finishReason` attribute to `gen_ai.response.finish_reasons`.
>     - Add missing `temperature` attribute in `LangfuseExporter` to log AI SDK metadata.
>   - **References**:
>     - Refer to AI SDK documentation for supported attributes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 6508613101e003aab0b3a5339fcac1afaeb653a1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
This PR fixes metadata logging in the Vercel AI SDK integration by correcting attribute references for finishReason and temperature parameters in the LangfuseExporter class.

- Fixed attribute key from `gai.response.finishReason` to `gen_ai.response.finish_reasons` in `langfuse-vercel/src/LangfuseExporter.ts`
- Added `gen_ai.request.temperature` attribute support for temperature parameter logging
- Changes align with AI SDK's telemetry attribute documentation



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->