### PR TITLE
fix(vercel-ai-sdk): missing generation metatdata for AI SDK logging (#542)

### DIFF
--- a/langfuse-vercel/src/LangfuseExporter.ts
+++ b/langfuse-vercel/src/LangfuseExporter.ts
@@ -181,8 +181,8 @@ export class LangfuseExporter implements SpanExporter {
             ? attributes["gen_ai.request.max_tokens"]?.toString() ?? null
             : null,
         finishReason:
-          "gai.response.finishReason" in attributes
-            ? attributes["ai.response.finishReason"]?.toString() ?? null
+          "gen_ai.response.finish_reasons" in attributes
+            ? attributes["gen_ai.response.finish_reasons"]?.toString() ?? null
             : "gen_ai.finishReason" in attributes //  Legacy support for ai SDK versions < 4.0.0
               ? attributes["gen_ai.finishReason"]?.toString() ?? null
               : null,
@@ -195,6 +195,10 @@ export class LangfuseExporter implements SpanExporter {
         maxRetries:
           "ai.settings.maxRetries" in attributes ? attributes["ai.settings.maxRetries"]?.toString() ?? null : null,
         mode: "ai.settings.mode" in attributes ? attributes["ai.settings.mode"]?.toString() ?? null : null,
+        temperature:
+          "gen_ai.request.temperature" in attributes
+            ? attributes["gen_ai.request.temperature"]?.toString() ?? null
+            : null,
       },
       usage: this.parseUsageDetails(attributes),
       usageDetails: this.parseUsageDetails(attributes),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `LangfuseExporter` to fix AI SDK logging by renaming `finishReason` attribute and adding `temperature` attribute.
> 
>   - **Behavior**:
>     - Update `finishReason` attribute key from `gai.response.finishReason` to `gen_ai.response.finish_reasons` in `LangfuseExporter`.
>     - Add `temperature` attribute to `modelParameters` in `LangfuseExporter` for AI SDK logging.
>   - **Misc**:
>     - Ensure backward compatibility with legacy AI SDK versions by checking for old attribute keys.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 095f582d0c23d63d19145c4418e254bf7c7ed733. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Implemented fixes for generation metadata handling in the Vercel AI SDK integration, focusing on accurate attribute collection and backward compatibility.

- Fixed attribute key for finish reasons from 'gai.response.finishReason' to 'gen_ai.response.finish_reasons' in `/langfuse-vercel/src/LangfuseExporter.ts`
- Added fallback support for older AI SDK versions using 'gen_ai.finishReason'
- Added temperature metadata capture from 'gen_ai.request.temperature' in modelParameters



<!-- /greptile_comment -->