### PR TITLE
fix: correct return type for dataset item link function call

### DIFF
--- a/langfuse-core/src/types.ts
+++ b/langfuse-core/src/types.ts
@@ -252,7 +252,7 @@ export type LinkDatasetItem = (
     description?: string;
     metadata?: any;
   }
-) => Promise<{ id: string }>;
+) => Promise<components['schemas']['DatasetRunItem']>;
 export type DatasetItem = DatasetItemData & { link: LinkDatasetItem };
 
 export type MaskFunction = (params: { data: any }) => any;


### PR DESCRIPTION
## Problem

Re-submit the changes from #535 since they were reverted (unintentionally?)

TypeScript types appear to be inaccurate for the DatasetItem.link return type. The types indicate only an id: string property returned, but at runtime, there is all data associated with DatasetRunItem.

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

Re-submit the changes from #535 since they were reverted (unintentionally?)

update the return type of DatasetItem.link to reflect the DatasetRunItem schema, instead of just an object with an id property, as that's what comes back from the API in production.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [X] All of them
- [ ] langfuse
- [ ] langfuse-node

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Updated return type for DatasetItem.Link to match DatasetRunItem

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update return type of `LinkDatasetItem` in `types.ts` to match actual API response.
> 
>   - **TypeScript Types**:
>     - Update return type of `LinkDatasetItem` in `types.ts` from `Promise<{ id: string }>` to `Promise<components['schemas']['DatasetRunItem']>` to reflect actual API response.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 4209ee86d57beef9a620f22e29047dcce5ac531c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Updates the return type of DatasetItem.link function to correctly reflect the full DatasetRunItem schema returned by the API instead of just an ID property.

- Changed return type in `/langfuse-core/src/types.ts` from `Promise<{ id: string }>` to `Promise<components['schemas']['DatasetRunItem']>`
- Fixes type mismatch between TypeScript definition and actual API response
- Improves type safety for dataset run item handling in the SDK



<sub>💡 (2/5) Greptile learns from your feedback when you react with 👍/👎!</sub>

<!-- /greptile_comment -->