### PR TITLE
fix(core): do not log warning messages for explicitly disabled client

### DIFF
--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -1349,14 +1349,20 @@ export abstract class LangfuseCore extends LangfuseCoreStateless {
       isObservabilityEnabled = true;
     } else if (!secretKey) {
       isObservabilityEnabled = false;
-      console.warn(
-        "Langfuse secret key was not passed to constructor or not set as 'LANGFUSE_SECRET_KEY' environment variable. No observability data will be sent to Langfuse."
-      );
+
+      if (enabled !== false) {
+        console.warn(
+          "Langfuse secret key was not passed to constructor or not set as 'LANGFUSE_SECRET_KEY' environment variable. No observability data will be sent to Langfuse."
+        );
+      }
     } else if (!publicKey) {
       isObservabilityEnabled = false;
-      console.warn(
-        "Langfuse public key was not passed to constructor or not set as 'LANGFUSE_PUBLIC_KEY' environment variable. No observability data will be sent to Langfuse."
-      );
+
+      if (enabled !== false) {
+        console.warn(
+          "Langfuse public key was not passed to constructor or not set as 'LANGFUSE_PUBLIC_KEY' environment variable. No observability data will be sent to Langfuse."
+        );
+      }
     }
 
     super({ ...params, enabled: isObservabilityEnabled });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevent logging warnings in `LangfuseCore` when client is explicitly disabled and keys are missing.
> 
>   - **Behavior**:
>     - In `LangfuseCore` constructor, added condition to prevent logging warnings if `enabled` is explicitly set to `false` and `secretKey` or `publicKey` is missing.
>     - Similar condition added for `publicKey` check to prevent logging warnings when `enabled` is `false`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 0ce13fa08a7abfa4ba0f2ef4544f49403fd3dba0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
This PR modifies the Langfuse Core SDK to prevent unnecessary warning messages when the client is explicitly disabled, improving log clarity by only showing key-related warnings when the client is not intentionally disabled.

- Modified warning logic in `langfuse-core/src/index.ts` to check `enabled !== false` before logging missing key warnings
- Reduces log noise by avoiding unnecessary warnings when SDK is intentionally disabled
- Maintains warning behavior for cases where keys are missing but client is not explicitly disabled
- Improves developer experience by reducing irrelevant log messages



<!-- /greptile_comment -->