### PR TITLE
fix(core): update timeout and propagate across HTTP client calls

### DIFF
--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -250,7 +250,7 @@ abstract class LangfuseCoreStateless {
       retryDelay: options?.fetchRetryDelay ?? 3000,
       retryCheck: isLangfuseFetchError,
     };
-    this.requestTimeout = options?.requestTimeout ?? 5000; // 5 seconds
+    this.requestTimeout = options?.requestTimeout ?? 10000; // 10 seconds
 
     this.sdkIntegration = options?.sdkIntegration ?? "DEFAULT";
 
@@ -1184,7 +1184,7 @@ abstract class LangfuseCoreStateless {
         ...this.constructAuthorizationHeader(this.publicKey, this.secretKey),
       },
       body: p.body,
-      signal: AbortSignal.timeout(p.fetchTimeout ?? this.requestTimeout),
+      ...(p.fetchTimeout !== undefined ? { signal: AbortSignal.timeout(p.fetchTimeout) } : {}),
     };
 
     return fetchOptions;

--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -250,7 +250,7 @@ abstract class LangfuseCoreStateless {
       retryDelay: options?.fetchRetryDelay ?? 3000,
       retryCheck: isLangfuseFetchError,
     };
-    this.requestTimeout = options?.requestTimeout ?? 10000; // 10 seconds
+    this.requestTimeout = options?.requestTimeout ?? 5000; // 5 seconds
 
     this.sdkIntegration = options?.sdkIntegration ?? "DEFAULT";
 
@@ -607,14 +607,15 @@ abstract class LangfuseCoreStateless {
 
     return retriable(
       async () => {
-        const res = await this.fetch(url, this._getFetchOptions({ method: "GET", fetchTimeout: requestTimeout })).catch(
-          (e) => {
-            if (e.name === "AbortError") {
-              throw new LangfuseFetchNetworkError("Fetch request timed out");
-            }
-            throw new LangfuseFetchNetworkError(e);
+        const res = await this.fetch(
+          url,
+          this._getFetchOptions({ method: "GET", fetchTimeout: requestTimeout ?? this.requestTimeout })
+        ).catch((e) => {
+          if (e.name === "AbortError") {
+            throw new LangfuseFetchNetworkError("Fetch request timed out");
           }
-        );
+          throw new LangfuseFetchNetworkError(e);
+        });
 
         if (res.status >= 500) {
           throw new LangfuseFetchHttpError(res, await res.text());

--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -250,7 +250,7 @@ abstract class LangfuseCoreStateless {
       retryDelay: options?.fetchRetryDelay ?? 3000,
       retryCheck: isLangfuseFetchError,
     };
-    this.requestTimeout = options?.requestTimeout ?? 10000; // 10 seconds
+    this.requestTimeout = options?.requestTimeout ?? 5000; // 5 seconds
 
     this.sdkIntegration = options?.sdkIntegration ?? "DEFAULT";
 
@@ -1184,7 +1184,7 @@ abstract class LangfuseCoreStateless {
         ...this.constructAuthorizationHeader(this.publicKey, this.secretKey),
       },
       body: p.body,
-      ...(p.fetchTimeout !== undefined ? { signal: AbortSignal.timeout(p.fetchTimeout) } : {}),
+      signal: AbortSignal.timeout(p.fetchTimeout ?? this.requestTimeout),
     };
 
     return fetchOptions;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update HTTP request timeout handling in Langfuse Core SDK to reduce default timeout and use `AbortSignal.timeout` for consistency.
> 
>   - **Behavior**:
>     - Reduce default HTTP request timeout from 10s to 5s in `LangfuseCoreStateless` constructor.
>     - Use `AbortSignal.timeout` for consistent timeout handling in `fetchWithRetry()` and `getPromptStateless()`.
>   - **Error Handling**:
>     - Throw `LangfuseFetchNetworkError` on timeout in `fetchWithRetry()` and `getPromptStateless()`.
>   - **Misc**:
>     - Remove conditional timeout checks in favor of `AbortSignal.timeout` in `fetchWithRetry()` and `getPromptStateless()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for fdf8231dabcbf19954111dfd5898f2df0553a2fa. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Updates HTTP request timeout handling in Langfuse Core SDK, reducing default timeout from 10s to 5s and implementing more consistent timeout behavior using AbortSignal.timeout API.

- Modified `langfuse-core/src/index.ts` to reduce default request timeout from 10s to 5s for better performance
- Implemented consistent timeout enforcement using AbortSignal.timeout API instead of conditional checks
- Improved reliability by ensuring timeouts are always applied across all HTTP client calls



<!-- /greptile_comment -->