### PR TITLE
Generate OTEL compatible IDs

### DIFF
--- a/langfuse-core/src/index.ts
+++ b/langfuse-core/src/index.ts
@@ -313,7 +313,7 @@ abstract class LangfuseCoreStateless {
   protected traceStateless(body: CreateLangfuseTraceBody): string {
     const { id: bodyId, timestamp: bodyTimestamp, release: bodyRelease, ...rest } = body;
 
-    const id = bodyId ?? generateUUID();
+    const id = bodyId ?? generateUUID().replace(/-/g, "");
     const release = bodyRelease ?? this.release;
 
     const parsedBody: CreateLangfuseTraceBody = {


### PR DESCRIPTION
## Problem
[Described here](https://github.com/orgs/langfuse/discussions/7311). langfuse-js generates UUIDs for trace ids. That's not a valid [OTEL traceId](https://opentelemetry.io/docs/specs/otel/trace/api/#retrieving-the-traceid-and-spanid).

```
Retrieving the TraceId and SpanId
The API MUST allow retrieving the TraceId and SpanId in the following forms:

Hex - returns the lowercase hex encoded TraceId (result MUST be a 32-hex-character lowercase string) or SpanId (result MUST be a 16-hex-character lowercase string).
Binary - returns the binary representation of the TraceId (result MUST be a 16-byte array) or SpanId (result MUST be an 8-byte array).
The API SHOULD NOT expose details about how they are internally stored.
```

## Changes

I just converted the UUID into 32hex with 122 bits **for trace ID only**.

The only technical consideration is that UUID4 reserves a few bits for version/variant info (6 bits total), so it's not 100% random. But OpenTelemetry only requires the 64 least significant bits to be uniformly random for sampling decisions, so the 122 bits of randomness from UUID4 would be more than sufficient.

**This PR is likely not ENOUGH, and some other conversions might have to be done as well to make it compatible with now-OTEL python SDK**.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them
- [ ] langfuse
- [ ] langfuse-node

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Generate OTEL-compatible traceId 


<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Updates trace ID generation in `langfuse-core/src/index.ts` to comply with OpenTelemetry specifications by converting UUIDs to 32-character lowercase hex strings.

- Modified `traceStateless` method to generate OTEL-compatible trace IDs (32-hex-character strings) instead of standard UUIDs
- Maintains 122 bits of randomness from UUID v4, exceeding OTEL's requirement of 64 random bits for sampling
- Change is focused only on trace ID generation, leaving span/observation IDs unchanged
- Note: Additional changes may be needed for full OTEL Python SDK compatibility



<!-- /greptile_comment -->