### PR TITLE
Support supplying client in Langchain callback handler constructor

### DIFF
--- a/langfuse-langchain/src/callback.ts
+++ b/langfuse-langchain/src/callback.ts
@@ -40,12 +40,16 @@ type RootParams = {
   root: LangfuseTraceClient | LangfuseSpanClient;
 };
 
+type ClientParams = {
+  client: Langfuse;
+};
+
 type KeyParams = {
   publicKey?: string;
   secretKey?: string;
 } & LangfuseOptions;
 
-type ConstructorParams = (RootParams | KeyParams) & {
+type ConstructorParams = (RootParams | ClientParams | KeyParams) & {
   userId?: string; // added to all traces
   version?: string; // added to all traces and observations
   sessionId?: string; // added to all traces
@@ -82,6 +86,12 @@ export class CallbackHandler extends BaseCallbackHandler {
       this.rootProvided = true;
       this.updateRoot = params.updateRoot ?? false;
       this.metadata = params.metadata;
+    } else if (params && "client" in params) {
+      this.langfuse = params.client;
+      this.sessionId = params.sessionId;
+      this.userId = params.userId;
+      this.metadata = params.metadata;
+      this.tags = params.tags;
     } else {
       this.langfuse = new Langfuse({
         ...params,


### PR DESCRIPTION
## Problem

We have a global Langfuse SDK that we instantiate and flush at shutdown to ensure traces are sent.  With the current CallbackHandler setup we cannot pass in that Langfuse SDK which means we can't guarantee that all traces are flushed.  If we pass in a root to provide access to that client, the traces in Langfuse aren't correctly named.

## Changes

Add support for a Langfuse client in the constructor.

## Release info Sub-libraries affected

### Bump level

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

langfuse-langchain

### Changelog notes

- Added support for Langfuse client in Langchain CallbackHandler

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for passing a Langfuse client in CallbackHandler constructor for improved trace management.
> 
>   - **Behavior**:
>     - Added support for passing a `Langfuse` client in `CallbackHandler` constructor in `callback.ts`.
>     - Allows using an existing Langfuse client for trace management, ensuring all traces are flushed.
>   - **Tests**:
>     - Added test `create trace for callback with client parameter` in `langfuse-integration-langchain.spec.ts` to verify new client parameter functionality.
>   - **Misc**:
>     - Updated `ConstructorParams` type to include `ClientParams` in `callback.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for c06d02c83bfd802197cd4f4b6a77daaad54fc5ec. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Added support for passing a Langfuse client directly to the Langchain CallbackHandler constructor, enabling better control over trace lifecycle and proper flushing at shutdown.

- Modified `langfuse-langchain/src/callback.ts` to accept client parameter in constructor while maintaining backward compatibility
- Added new test in `integration-test/langfuse-integration-langchain.spec.ts` to verify client parameter functionality
- Ensures traces are properly named when using global SDK instance
- Improves trace flushing reliability for applications using a shared Langfuse client



<!-- /greptile_comment -->