### PR TITLE
fix(langchain-azure): add error message on refusal

### DIFF
--- a/langfuse-langchain/src/callback.ts
+++ b/langfuse-langchain/src/callback.ts
@@ -715,11 +715,21 @@ export class CallbackHandler extends BaseCallbackHandler {
     try {
       this._log(`LLM error ${err} with ID: ${runId}`);
 
+      // Azure has the refusal status for harmful messages in the error property
+      // This would not be logged as the error message is only a generic message
+      // that there has been a refusal
+      let azureRefusalError = "";
+      if (typeof err == "object" && "error" in err) {
+        try {
+          azureRefusalError = "\n" + JSON.stringify(err["error"], null, 2);
+        } catch {}
+      }
+
       this.langfuse._updateGeneration({
         id: runId,
         traceId: this.traceId,
         level: "ERROR",
-        statusMessage: err.toString(),
+        statusMessage: err.toString() + azureRefusalError,
         endTime: new Date(),
         version: this.version,
       });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance Azure refusal error logging in `handleLLMError()` in `callback.ts` by appending detailed error information to the status message.
> 
>   - **Behavior**:
>     - In `handleLLMError()` in `callback.ts`, appends Azure refusal error details to `statusMessage` if present in the error object.
>     - Logs the Azure refusal error as a JSON string for better clarity.
>   - **Misc**:
>     - Adds a check for `error` property in the error object to identify Azure refusal errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 2fdc53f66f52e044defa5b4663722a885cf6054d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Enhanced error handling for Azure OpenAI content filter refusals in the Langchain integration by preserving detailed error information from Azure's refusal responses.

- Modified `langfuse-langchain/src/callback.ts` to extract and include Azure's detailed content filter refusal messages instead of only logging the generic error



<!-- /greptile_comment -->