### PR TITLE
fix(langchain-azure): add refusal error to trace

### DIFF
--- a/langfuse-langchain/src/callback.ts
+++ b/langfuse-langchain/src/callback.ts
@@ -721,7 +721,7 @@ export class CallbackHandler extends BaseCallbackHandler {
       let azureRefusalError = "";
       if (typeof err == "object" && "error" in err) {
         try {
-          azureRefusalError = "\n" + JSON.stringify(err["error"], null, 2);
+          azureRefusalError = "\n\nError details:\n" + JSON.stringify(err["error"], null, 2);
         } catch {}
       }
 
@@ -733,7 +733,7 @@ export class CallbackHandler extends BaseCallbackHandler {
         endTime: new Date(),
         version: this.version,
       });
-      this.updateTrace(runId, parentRunId, err.toString());
+      this.updateTrace(runId, parentRunId, err.toString() + azureRefusalError);
     } catch (e) {
       this._log(e);
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `handleLLMError` in `callback.ts` to include Azure refusal error details in trace updates.
> 
>   - **Behavior**:
>     - In `callback.ts`, `handleLLMError` now appends Azure refusal error details to the trace update if present in the error object.
>     - The error message is enhanced with `\n\nError details:\n` followed by the JSON stringified error details.
>   - **Misc**:
>     - Minor string formatting change in `handleLLMError` to improve error detail readability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for b8755595a55b36d4015a2c759600f3d627b8f587. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

## Greptile Summary

**Disclaimer**: Experimental PR review
---
Enhances Azure OpenAI refusal error handling in the Langchain integration by improving error message formatting and readability.

- Modified `langfuse-langchain/src/callback.ts` to add clearer formatting for Azure refusal errors with 'Error details:' header and proper spacing
- Improves both generation update and trace update error outputs for better debugging



<!-- /greptile_comment -->