### PR TITLE
Adapt for ai SDK version 5.0.0

### DIFF
--- a/langfuse-vercel/src/LangfuseExporter.ts
+++ b/langfuse-vercel/src/LangfuseExporter.ts
@@ -330,9 +330,11 @@ export class LangfuseExporter implements SpanExporter {
       ? [...chatMessages, ...(Array.isArray(tools) ? tools : [])]
       : "ai.prompt" in attributes
         ? attributes["ai.prompt"]
-        : "ai.toolCall.args" in attributes
-          ? attributes["ai.toolCall.args"]
-          : undefined;
+        : "ai.toolCall.input" in attributes
+          ? attributes["ai.toolCall.input"]
+          : "ai.toolCall.args" in attributes // Legacy support for ai SDK versions < 5.0.0
+            ? attributes["ai.toolCall.args"]
+            : undefined;
   }
 
   private parseOutput(span: ReadableSpan): (typeof span.attributes)[0] | undefined {
@@ -342,17 +344,19 @@ export class LangfuseExporter implements SpanExporter {
       ? attributes["ai.response.text"]
       : "ai.result.text" in attributes // Legacy support for ai SDK versions < 4.0.0
         ? attributes["ai.result.text"]
-        : "ai.toolCall.result" in attributes
-          ? attributes["ai.toolCall.result"]
-          : "ai.response.object" in attributes
-            ? attributes["ai.response.object"]
-            : "ai.result.object" in attributes // Legacy support for ai SDK versions < 4.0.0
-              ? attributes["ai.result.object"]
-              : "ai.response.toolCalls" in attributes
-                ? attributes["ai.response.toolCalls"]
-                : "ai.result.toolCalls" in attributes // Legacy support for ai SDK versions < 4.0.0
-                  ? attributes["ai.result.toolCalls"]
-                  : undefined;
+        : "ai.toolCall.output" in attributes
+          ? attributes["ai.toolCall.output"]
+          : "ai.toolCall.result" in attributes // Legacy support for ai SDK versions < 5.0.0
+            ? attributes["ai.toolCall.result"]
+            : "ai.response.object" in attributes
+              ? attributes["ai.response.object"]
+              : "ai.result.object" in attributes // Legacy support for ai SDK versions < 4.0.0
+                ? attributes["ai.result.object"]
+                : "ai.response.toolCalls" in attributes
+                  ? attributes["ai.response.toolCalls"]
+                  : "ai.result.toolCalls" in attributes // Legacy support for ai SDK versions < 4.0.0
+                    ? attributes["ai.result.toolCalls"]
+                    : undefined;
   }
 
   private parseTraceId(spans: ReadableSpan[]): string | undefined {


### PR DESCRIPTION
corresponding change: https://github.com/vercel/ai/commit/63f9e9b45b2e6a3b53fe9097c817cbd7fd3882a4
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adapt `LangfuseExporter` to support ai SDK v5.0.0 by updating input/output parsing while maintaining legacy support.
> 
>   - **Behavior**:
>     - Update `parseInput()` in `LangfuseExporter.ts` to check `ai.toolCall.input` before `ai.toolCall.args` for SDK v5.0.0 compatibility.
>     - Update `parseOutput()` in `LangfuseExporter.ts` to check `ai.toolCall.output` before `ai.toolCall.result` for SDK v5.0.0 compatibility.
>   - **Legacy Support**:
>     - Maintain support for `ai.toolCall.args` and `ai.toolCall.result` for SDK versions < 5.0.0 in `LangfuseExporter.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for dc1aed5f6e95c1d44a20523d0d6982cd028c9eb1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

This PR adapts the Langfuse Vercel AI SDK Integration to support version 5.0.0 of the Vercel AI SDK while maintaining backward compatibility with older versions. The changes focus on updating the `LangfuseExporter` class within the `langfuse-vercel` package to handle changes in the AI SDK's API structure.

Specifically, the AI SDK v5.0.0 introduced breaking changes where tool call properties were renamed:
- `ai.toolCall.args` → `ai.toolCall.input`
- `ai.toolCall.result` → `ai.toolCall.output`

The modifications update the `parseInput()` and `parseOutput()` methods in `LangfuseExporter.ts` to check for the new property names first (for v5.0.0+ compatibility) while maintaining fallback support for the legacy property names. This ensures that the Langfuse integration continues to work with both new and existing AI SDK implementations.

The `LangfuseExporter` class is responsible for exporting spans related to AI SDK operations and uses a singleton pattern for managing the Langfuse instance. These changes ensure that tool call data is correctly extracted regardless of which version of the AI SDK is being used, maintaining the observability capabilities that Langfuse provides for AI applications.

## Confidence score: 4/5

- This appears to be a safe backward-compatible change that adds support for a new SDK version while maintaining legacy support.
- The score reflects confidence in the approach but acknowledges that without seeing the actual code changes, there may be implementation details that need verification.
- The `langfuse-vercel/src/LangfuseExporter.ts` file needs attention to verify the implementation correctly handles both property naming conventions and includes proper error handling.

<!-- /greptile_comment -->