### PR TITLE
fix(serializer): do not serialize string primitives

### DIFF
--- a/packages/tracing/src/attributes.ts
+++ b/packages/tracing/src/attributes.ts
@@ -247,6 +247,8 @@ export function createEventAttributes({
  */
 function _serialize(obj: unknown): string | undefined {
   try {
+    if (typeof obj === "string") return obj;
+
     return obj != null ? JSON.stringify(obj) : undefined;
   } catch {
     return "<failed to serialize>";

--- a/tests/integration/span-processor.integration.test.ts
+++ b/tests/integration/span-processor.integration.test.ts
@@ -1,12 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { startSpan } from "@langfuse/tracing";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { SpanAssertions } from "./helpers/assertions.js";
 import {
   setupTestEnvironment,
   teardownTestEnvironment,
   waitForSpanExport,
   type TestEnvironment,
 } from "./helpers/testSetup.js";
-import { SpanAssertions } from "./helpers/assertions.js";
 
 describe("LangfuseSpanProcessor E2E Tests", () => {
   let testEnv: TestEnvironment;

--- a/tests/integration/tracing.integration.test.ts
+++ b/tests/integration/tracing.integration.test.ts
@@ -3999,7 +3999,7 @@ describe("Tracing Methods Interoperability E2E Tests", () => {
         assertions.expectSpanAttribute(
           "testFunc",
           LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT,
-          '"processed: test input"',
+          "processed: test input",
         );
       });
     });


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `_serialize()` to return string primitives directly, updating test expectations accordingly.
> 
>   - **Behavior**:
>     - `_serialize()` in `attributes.ts` now returns string primitives directly without JSON serialization.
>   - **Tests**:
>     - Update `tracing.integration.test.ts` to expect unquoted string in `expectSpanAttribute()` for `OBSERVATION_OUTPUT`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 418c8fba6604b28743e9328fe18292d576628978. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

This PR fixes a serialization issue in the OpenTelemetry tracing system where string primitives were being unnecessarily JSON-serialized, causing them to be wrapped in extra quotes. The core change is in the `_serialize` helper function in `packages/tracing/src/attributes.ts`, which now includes an early return for string types to prevent double-serialization.

Previously, when a function returned a simple string like "hello world", the tracing system would JSON.stringify it, resulting in `"hello world"` (with quotes) being stored as the span attribute. Since OpenTelemetry attributes are already stored as strings, this created an unnecessary layer of quote wrapping. The fix ensures strings pass through unchanged while other data types (objects, arrays) continue to be JSON-serialized as expected.

The change integrates seamlessly with the existing tracing infrastructure. The `_serialize` function is used throughout the attributes module to process input/output data and other span attributes, making this a foundational improvement that affects all string data flowing through the tracing system. The fix maintains backward compatibility for non-string types while providing cleaner, more intuitive behavior for string primitives.

The test changes reflect the new expected behavior: the integration test now expects plain strings rather than JSON-serialized strings in span output attributes. Additionally, minor import organization improvements were made to maintain code quality standards.

## Confidence score: 5/5

- This PR is extremely safe to merge with minimal risk of introducing bugs or breaking changes
- Score reflects a simple, well-targeted fix with clear test validation and no complex logic changes
- No files require special attention as the changes are straightforward and well-tested

<!-- /greptile_comment -->