### PR TITLE
feat(tracing): add observation types

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,6 +38,7 @@ export default [
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-unnecessary-type-constraint": "error",
       "prettier/prettier": "error",
+      "no-redeclare": "off",
       // Import sorting rules
       "import/order": [
         "error",

--- a/packages/openai/src/traceMethod.ts
+++ b/packages/openai/src/traceMethod.ts
@@ -1,4 +1,4 @@
-import { LangfuseGeneration, startGeneration } from "@langfuse/tracing";
+import { LangfuseGeneration, startObservation } from "@langfuse/tracing";
 import type OpenAI from "openai";
 
 import {
@@ -69,7 +69,7 @@ const wrapMethod = <T extends GenericMethod>(
         : undefined,
   };
 
-  const generation = startGeneration(
+  const generation = startObservation(
     config?.generationName ?? "OpenAI-completion",
     {
       model,
@@ -78,7 +78,10 @@ const wrapMethod = <T extends GenericMethod>(
       prompt: config?.langfusePrompt,
       metadata: finalMetadata,
     },
-    { parentSpanContext: config?.parentSpanContext },
+    {
+      asType: "generation",
+      parentSpanContext: config?.parentSpanContext,
+    },
   ).updateTrace({
     userId: config?.userId,
     sessionId: config?.sessionId,

--- a/packages/tracing/src/spanWrapper.ts
+++ b/packages/tracing/src/spanWrapper.ts
@@ -14,7 +14,7 @@ import {
   LangfuseTraceAttributes,
 } from "./types.js";
 
-import { createEvent, startGeneration, startSpan } from "./index.js";
+import { startObservation } from "./index.js";
 
 /**
  * Union type representing any Langfuse observation wrapper.
@@ -162,7 +162,7 @@ export class LangfuseSpan extends LangfuseSpanWrapper {
     name: string,
     attributes?: LangfuseSpanAttributes,
   ): LangfuseSpan {
-    return startSpan(name, attributes, {
+    return startObservation(name, attributes, {
       parentSpanContext: this.otelSpan.spanContext(),
     });
   }
@@ -187,7 +187,8 @@ export class LangfuseSpan extends LangfuseSpanWrapper {
     name: string,
     attributes?: LangfuseGenerationAttributes,
   ): LangfuseGeneration {
-    return startGeneration(name, attributes, {
+    return startObservation(name, attributes || {}, {
+      asType: "generation",
       parentSpanContext: this.otelSpan.spanContext(),
     });
   }
@@ -213,7 +214,8 @@ export class LangfuseSpan extends LangfuseSpanWrapper {
     name: string,
     attributes?: LangfuseEventAttributes,
   ): LangfuseEvent {
-    return createEvent(name, attributes, {
+    return startObservation(name, attributes || {}, {
+      asType: "event",
       parentSpanContext: this.otelSpan.spanContext(),
     });
   }
@@ -293,7 +295,8 @@ export class LangfuseGeneration extends LangfuseSpanWrapper {
     name: string,
     attributes?: LangfuseEventAttributes,
   ): LangfuseEvent {
-    return createEvent(name, attributes, {
+    return startObservation(name, attributes || {}, {
+      asType: "event",
       parentSpanContext: this.otelSpan.spanContext(),
     });
   }

--- a/tests/e2e/datasets.e2e.test.ts
+++ b/tests/e2e/datasets.e2e.test.ts
@@ -3,7 +3,7 @@ import { LangfuseClient } from "@langfuse/client";
 import { PromptTemplate } from "@langchain/core/prompts";
 import { StringOutputParser } from "@langchain/core/output_parsers";
 import { ChatOpenAI } from "@langchain/openai";
-import { startSpan, startGeneration } from "@langfuse/tracing";
+import { startObservation } from "@langfuse/tracing";
 import { nanoid } from "nanoid";
 
 describe("Langfuse Datasets E2E", () => {
@@ -60,10 +60,14 @@ describe("Langfuse Datasets E2E", () => {
       });
 
       // Create a generation using the tracing SDK for linking
-      const generation = startGeneration("test-observation", {
-        input: "generation input",
-        model: "gpt-3.5-turbo",
-      });
+      const generation = startObservation(
+        "test-observation",
+        {
+          input: "generation input",
+          model: "gpt-3.5-turbo",
+        },
+        { asType: "generation" },
+      );
       generation.update({ output: "generation output" });
       generation.end();
 
@@ -252,7 +256,7 @@ describe("Langfuse Datasets E2E", () => {
       });
 
       // Create trace and generation using the tracing SDK
-      const span = startSpan("test-trace-" + datasetName, {
+      const span = startObservation("test-trace-" + datasetName, {
         input: "input",
         output: "Hello world traced",
       });
@@ -338,7 +342,7 @@ describe("Langfuse Datasets E2E", () => {
       });
 
       // Create base trace and generation using tracing SDK
-      const span = startSpan("test-trace-" + datasetName, {
+      const span = startObservation("test-trace-" + datasetName, {
         input: "input",
         output: "Hello world traced",
       });
@@ -447,7 +451,7 @@ describe("Langfuse Datasets E2E", () => {
 
       for (const item of dataset.items) {
         // Create trace for this run using tracing SDK
-        const span = startSpan("langchain-execution", {
+        const span = startObservation("langchain-execution", {
           input: { country: item.input },
           metadata: { chainType: "capital-lookup" },
         });

--- a/tests/e2e/langchain.e3e.test.ts
+++ b/tests/e2e/langchain.e3e.test.ts
@@ -7,7 +7,7 @@ import {
   type ServerTestEnvironment,
 } from "./helpers/serverSetup.js";
 import { nanoid } from "nanoid";
-import { startActiveSpan } from "@langfuse/tracing";
+import { startActiveObservation } from "@langfuse/tracing";
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatPromptTemplate } from "@langchain/core/prompts";
 import { CallbackHandler } from "@langfuse/langchain";
@@ -291,7 +291,7 @@ describe("Langchain integration E2E tests", () => {
     const chain = prompt.pipe(llm);
 
     // Create a parent span manually first
-    const [result, traceId] = await startActiveSpan(
+    const [result, traceId] = await startActiveObservation(
       testConfig.parentSpanName,
       async (span) => {
         span.update({

--- a/tests/e2e/media.e2e.test.ts
+++ b/tests/e2e/media.e2e.test.ts
@@ -1,6 +1,6 @@
 import { LangfuseClient } from "@langfuse/client";
 import { resetGlobalLogger, LangfuseMedia } from "@langfuse/core";
-import { startSpan } from "@langfuse/tracing";
+import { startObservation } from "@langfuse/tracing";
 import { nanoid } from "nanoid";
 import { describe, it, expect, beforeEach, afterEach, beforeAll } from "vitest";
 
@@ -90,7 +90,7 @@ describe("Media E2E Tests", () => {
       }).base64DataUri;
 
       // Create span with LangfuseMedia in metadata (should use toJSON to convert to media reference)
-      const span = startSpan(spanName, {
+      const span = startObservation(spanName, {
         input: {
           operation: "media processing test",
           audioData: base64DataUri,
@@ -196,7 +196,7 @@ describe("Media E2E Tests", () => {
 
       // Additional test: Create a second span with the same media to verify consistency
       const span2Name = `media-reuse-span-${testId}`;
-      const span2 = startSpan(span2Name, {
+      const span2 = startObservation(span2Name, {
         input: {
           operation: "media reuse test",
           audioData: base64DataUri, // Same data URI should produce same reference
@@ -268,7 +268,7 @@ describe("Media E2E Tests", () => {
           const resolvedAudioData = resolvedSpanObs.input.audioData;
 
           const span3Name = `media-resolved-reuse-span-${testId}`;
-          const span3 = startSpan(span3Name, {
+          const span3 = startObservation(span3Name, {
             input: {
               operation: "media resolved reuse test",
               audioData: new LangfuseMedia({
@@ -333,7 +333,7 @@ describe("Media E2E Tests", () => {
       });
 
       // Create span with LangfuseMedia in metadata (should use toJSON to convert to media reference)
-      const span = startSpan(spanName, {
+      const span = startObservation(spanName, {
         input: {
           operation: "media processing test",
           audioData: media,
@@ -439,7 +439,7 @@ describe("Media E2E Tests", () => {
 
       // Additional test: Create a second span with the same media to verify consistency
       const span2Name = `media-reuse-span-${testId}`;
-      const span2 = startSpan(span2Name, {
+      const span2 = startObservation(span2Name, {
         input: {
           operation: "media reuse test",
           audioData: media, // Same data URI should produce same reference
@@ -511,7 +511,7 @@ describe("Media E2E Tests", () => {
           const resolvedAudioData = resolvedSpanObs.input.audioData;
 
           const span3Name = `media-resolved-reuse-span-${testId}`;
-          const span3 = startSpan(span3Name, {
+          const span3 = startObservation(span3Name, {
             input: {
               operation: "media resolved reuse test",
               audioData: new LangfuseMedia({

--- a/tests/e2e/openai.e2e.test.ts
+++ b/tests/e2e/openai.e2e.test.ts
@@ -10,7 +10,7 @@ import {
   type ServerTestEnvironment,
 } from "./helpers/serverSetup.js";
 import { nanoid } from "nanoid";
-import { startActiveSpan } from "@langfuse/tracing";
+import { startActiveObservation } from "@langfuse/tracing";
 
 describe("OpenAI integration E2E tests", () => {
   let langfuseClient: LangfuseClient;
@@ -88,20 +88,23 @@ describe("OpenAI integration E2E tests", () => {
   it("should trace nested OpenAI Chat Completion Create ", async () => {
     const wrappedOpenAI = observeOpenAI(new OpenAI());
 
-    const [result, traceId] = await startActiveSpan("parent", async (span) => {
-      return [
-        await wrappedOpenAI.chat.completions.create({
-          model: "gpt-4o",
-          messages: [
-            {
-              role: "user",
-              content: "whassup",
-            },
-          ],
-        }),
-        span.traceId,
-      ] as const;
-    });
+    const [result, traceId] = await startActiveObservation(
+      "parent",
+      async (span) => {
+        return [
+          await wrappedOpenAI.chat.completions.create({
+            model: "gpt-4o",
+            messages: [
+              {
+                role: "user",
+                content: "whassup",
+              },
+            ],
+          }),
+          span.traceId,
+        ] as const;
+      },
+    );
 
     console.log(result);
 

--- a/tests/e2e/scores.e2e.test.ts
+++ b/tests/e2e/scores.e2e.test.ts
@@ -10,7 +10,7 @@ import {
 import { trace } from "@opentelemetry/api";
 import { LangfuseClient } from "@langfuse/client";
 import { resetGlobalLogger } from "@langfuse/core";
-import { startSpan, startGeneration } from "@langfuse/tracing";
+import { startObservation } from "@langfuse/tracing";
 import {
   setupServerTestEnvironment,
   teardownServerTestEnvironment,
@@ -177,7 +177,7 @@ describe("LangfuseClient Score E2E Tests", () => {
       const spanName = `e2e-span-${Date.now()}`;
 
       // Create a span and verify its context
-      const span = startSpan(spanName, {
+      const span = startObservation(spanName, {
         input: { query: "test span scoring" },
         metadata: { testType: "span-integration" },
       });
@@ -244,7 +244,7 @@ describe("LangfuseClient Score E2E Tests", () => {
       const parentSpanName = `e2e-parent-${Date.now()}`;
       const activeSpanName = `e2e-active-${Date.now()}`;
 
-      const parentSpan = startSpan(parentSpanName);
+      const parentSpan = startObservation(parentSpanName);
 
       let activeSpanId: string = "";
       let activeTraceId: string = "";
@@ -336,7 +336,7 @@ describe("LangfuseClient Score E2E Tests", () => {
       const spanName = `e2e-observation-span-${Date.now()}`;
 
       // Create a span
-      const span = startSpan(spanName, {
+      const span = startObservation(spanName, {
         input: { query: "test observation scoring" },
         metadata: { testType: "observation-scoring" },
       });
@@ -382,7 +382,7 @@ describe("LangfuseClient Score E2E Tests", () => {
       const spanName = `e2e-trace-span-${Date.now()}`;
 
       // Create a span
-      const span = startSpan(spanName, {
+      const span = startObservation(spanName, {
         input: { query: "test trace scoring" },
         metadata: { testType: "trace-scoring" },
       });
@@ -425,7 +425,7 @@ describe("LangfuseClient Score E2E Tests", () => {
       const parentSpanName = `e2e-parent-span-${Date.now()}`;
       const activeSpanName = `e2e-active-span-${Date.now()}`;
 
-      const parentSpan = startSpan(parentSpanName);
+      const parentSpan = startObservation(parentSpanName);
 
       let activeSpanId: string = "";
       let activeTraceId: string = "";
@@ -470,7 +470,7 @@ describe("LangfuseClient Score E2E Tests", () => {
       const parentSpanName = `e2e-parent-trace-${Date.now()}`;
       const activeSpanName = `e2e-active-trace-span-${Date.now()}`;
 
-      const parentSpan = startSpan(parentSpanName);
+      const parentSpan = startObservation(parentSpanName);
 
       let activeTraceId: string = "";
 
@@ -514,11 +514,15 @@ describe("LangfuseClient Score E2E Tests", () => {
       const generationName = `e2e-generation-${Date.now()}`;
 
       // Create a generation
-      const generation = startGeneration(generationName, {
-        model: "gpt-4",
-        input: { messages: [{ role: "user", content: "Test generation" }] },
-        metadata: { testType: "generation-scoring" },
-      });
+      const generation = startObservation(
+        generationName,
+        {
+          model: "gpt-4",
+          input: { messages: [{ role: "user", content: "Test generation" }] },
+          metadata: { testType: "generation-scoring" },
+        },
+        { asType: "generation" },
+      );
 
       const { spanId, traceId } = generation.otelSpan.spanContext();
 
@@ -589,7 +593,7 @@ describe("LangfuseClient Score E2E Tests", () => {
       const baseTime = Date.now();
 
       // Create nested span structure using proper parent-child relationships
-      const rootSpan = startSpan(`root-span-${baseTime}`);
+      const rootSpan = startObservation(`root-span-${baseTime}`);
       const childSpan = rootSpan.startSpan(`child-span-${baseTime}`);
       const grandchildSpan = childSpan.startSpan(`grandchild-span-${baseTime}`);
 

--- a/tests/e2e/tracing.e2e.test.ts
+++ b/tests/e2e/tracing.e2e.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, beforeEach, afterEach } from "vitest";
 import {
-  startSpan,
-  startActiveSpan,
-  startActiveGeneration,
+  startObservation,
+  startActiveObservation,
   observe,
 } from "@langfuse/tracing";
 import {
@@ -34,7 +33,7 @@ describe("Server Export E2E Tests", () => {
     const generationName = `nested-llm-call-${testId}`;
 
     // Create a parent span with trace metadata
-    const parentSpan = startSpan(parentSpanName, {
+    const parentSpan = startObservation(parentSpanName, {
       input: { operation: "E2E test operation" },
       metadata: { testType: "e2e", timestamp: Date.now() },
     });
@@ -148,77 +147,81 @@ describe("Server Export E2E Tests", () => {
     console.log(`📈 Observations: ${trace.observations.length}`);
   });
 
-  it("should export startActiveSpan with nested startActiveGeneration to Langfuse server", async () => {
+  it("should export startActiveObservation with nested startActiveObservation generation to Langfuse server", async () => {
     const testId = nanoid(8);
     const traceName = `e2e-active-span-trace-${testId}`;
     const parentSpanName = `active-parent-operation-${testId}`;
     const generationName = `nested-active-generation-${testId}`;
 
-    // Use startActiveSpan with automatic context management
-    const result = await startActiveSpan(parentSpanName, async (parentSpan) => {
-      // Set trace attributes
-      parentSpan.updateTrace({
-        name: traceName,
-        userId: "active-user-789",
-        sessionId: "active-session-012",
-        tags: ["active", "e2e"],
-        metadata: { testType: "activeSpan", framework: "vitest" },
-      });
+    // Use startActiveObservation with automatic context management
+    const result = await startActiveObservation(
+      parentSpanName,
+      async (parentSpan) => {
+        // Set trace attributes
+        parentSpan.updateTrace({
+          name: traceName,
+          userId: "active-user-789",
+          sessionId: "active-session-012",
+          tags: ["active", "e2e"],
+          metadata: { testType: "activeSpan", framework: "vitest" },
+        });
 
-      // Update parent span
-      parentSpan.update({
-        input: { workflow: "active span testing" },
-        metadata: { step: "parent", priority: "high" },
-      });
+        // Update parent span
+        parentSpan.update({
+          input: { workflow: "active span testing" },
+          metadata: { step: "parent", priority: "high" },
+        });
 
-      // Use startActiveGeneration within the active span context
-      const generationResult = await startActiveGeneration(
-        generationName,
-        async (generation) => {
-          // This generation should automatically be nested under the active span
-          generation.update({
-            model: "gpt-3.5-turbo",
-            input: {
-              messages: [
-                { role: "system", content: "You are a helpful assistant" },
-                { role: "user", content: "Explain active spans" },
-              ],
-            },
-            metadata: { temperature: 0.5, maxTokens: 150 },
-          });
+        // Use startActiveObservation with generation type within the active span context
+        const generationResult = await startActiveObservation(
+          generationName,
+          async (generation) => {
+            // This generation should automatically be nested under the active span
+            generation.update({
+              model: "gpt-3.5-turbo",
+              input: {
+                messages: [
+                  { role: "system", content: "You are a helpful assistant" },
+                  { role: "user", content: "Explain active spans" },
+                ],
+              },
+              metadata: { temperature: 0.5, maxTokens: 150 },
+            });
 
-          // Simulate some processing
-          await new Promise((resolve) => setTimeout(resolve, 10));
+            // Simulate some processing
+            await new Promise((resolve) => setTimeout(resolve, 10));
 
-          // Update with response
-          generation.update({
-            output: {
-              role: "assistant",
-              content: "Active spans provide automatic context management...",
-            },
-            usageDetails: {
-              prompt_tokens: 25,
-              completion_tokens: 35,
-              total_tokens: 60,
-            },
-            level: "DEFAULT",
-          });
+            // Update with response
+            generation.update({
+              output: {
+                role: "assistant",
+                content: "Active spans provide automatic context management...",
+              },
+              usageDetails: {
+                prompt_tokens: 25,
+                completion_tokens: 35,
+                total_tokens: 60,
+              },
+              level: "DEFAULT",
+            });
 
-          return "generation-completed";
-        },
-      );
+            return "generation-completed";
+          },
+          { asType: "generation" },
+        );
 
-      // Update parent span with final results
-      parentSpan.update({
-        output: {
-          workflow: "completed",
-          generationResult,
-          totalOperations: 1,
-        },
-      });
+        // Update parent span with final results
+        parentSpan.update({
+          output: {
+            workflow: "completed",
+            generationResult,
+            totalOperations: 1,
+          },
+        });
 
-      return "parent-operation-completed";
-    });
+        return "parent-operation-completed";
+      },
+    );
 
     // Force flush and wait for ingestion
     await testEnv.spanProcessor.forceFlush();
@@ -293,8 +296,8 @@ describe("Server Export E2E Tests", () => {
         // This function will be automatically wrapped in a span
         console.log(`Processing prompt: ${prompt}`);
 
-        // Use startActiveGeneration within the observed function
-        const response = await startActiveGeneration(
+        // Use startActiveObservation with generation type within the observed function
+        const response = await startActiveObservation(
           internalGenerationName,
           async (generation) => {
             generation.update({
@@ -328,10 +331,11 @@ describe("Server Export E2E Tests", () => {
 
             return result;
           },
+          { asType: "generation" },
         );
 
         // Use manual span creation within observed function
-        const processingSpan = startSpan(postProcessingName, {
+        const processingSpan = startObservation(postProcessingName, {
           input: { response },
           metadata: { stage: "post-processing" },
         });
@@ -359,7 +363,7 @@ describe("Server Export E2E Tests", () => {
     );
 
     // Use the observed function within an active span context
-    const workflowResult = await startActiveSpan(
+    const workflowResult = await startActiveObservation(
       coordinatorSpanName,
       async (coordinatorSpan) => {
         coordinatorSpan.updateTrace({
@@ -529,7 +533,7 @@ describe("Server Export E2E Tests", () => {
     await testEnv.shutdown();
     testEnv = await setupServerTestEnvironment();
 
-    const workflowResult = await startActiveSpan(
+    const workflowResult = await startActiveObservation(
       coordinatorSpanName,
       async (coordinatorSpan) => {
         coordinatorSpan.updateTrace({
@@ -581,10 +585,11 @@ describe("Server Export E2E Tests", () => {
             level: "DEFAULT",
             statusMessage: "Workflow startup event triggered",
           },
+          { asType: "event" },
         );
 
         // Create a generation with media content
-        const mediaGeneration = await startActiveGeneration(
+        const mediaGeneration = await startActiveObservation(
           visionGenerationName,
           async (generation) => {
             generation.update({
@@ -638,6 +643,7 @@ describe("Server Export E2E Tests", () => {
                 level: "DEFAULT",
                 statusMessage: "Multimedia analysis completed successfully",
               },
+              { asType: "event" },
             );
 
             generation.update({
@@ -701,10 +707,11 @@ Both media items were successfully processed. The image is a minimal transparent
 
             return "media-analysis-completed";
           },
+          { asType: "generation" },
         );
 
         // Create a span with file processing simulation
-        const fileProcessingSpan = startSpan(fileProcessingName, {
+        const fileProcessingSpan = startObservation(fileProcessingName, {
           input: {
             files: [
               {
@@ -767,6 +774,7 @@ Both media items were successfully processed. The image is a minimal transparent
             level: "DEFAULT",
             statusMessage: "Started processing document.pdf",
           },
+          { asType: "event" },
         );
 
         // Simulate file processing
@@ -794,6 +802,7 @@ Both media items were successfully processed. The image is a minimal transparent
             level: "DEFAULT",
             statusMessage: "File processing completed successfully",
           },
+          { asType: "event" },
         );
 
         fileProcessingSpan.update({
@@ -860,6 +869,7 @@ Both media items were successfully processed. The image is a minimal transparent
             level: "DEFAULT",
             statusMessage: "Comprehensive workflow completed successfully",
           },
+          { asType: "event" },
         );
 
         // Update trace output

--- a/tests/e2e/vercel-ai-sdk.e2e.test.ts
+++ b/tests/e2e/vercel-ai-sdk.e2e.test.ts
@@ -3,7 +3,7 @@ import fs from "fs/promises";
 
 import { openai } from "@ai-sdk/openai";
 import { LangfuseClient } from "@langfuse/client";
-import { startActiveSpan } from "@langfuse/tracing";
+import { startActiveObservation } from "@langfuse/tracing";
 import {
   embed,
   generateObject,
@@ -72,25 +72,28 @@ describe("Vercel AI SDK integration E2E tests", () => {
       tags,
     } = testParams;
 
-    const [result, span] = await startActiveSpan(functionId, async (span) => {
-      const result = await generateText({
-        model: openai(modelName),
-        maxOutputTokens: maxTokens,
-        prompt,
-        experimental_telemetry: {
-          isEnabled: true,
-          functionId,
-          metadata: {
-            userId,
-            sessionId,
-            tags,
-            ...metadata,
+    const [result, span] = await startActiveObservation(
+      functionId,
+      async (span) => {
+        const result = await generateText({
+          model: openai(modelName),
+          maxOutputTokens: maxTokens,
+          prompt,
+          experimental_telemetry: {
+            isEnabled: true,
+            functionId,
+            metadata: {
+              userId,
+              sessionId,
+              tags,
+              ...metadata,
+            },
           },
-        },
-      });
+        });
 
-      return [result, span] as const;
-    });
+        return [result, span] as const;
+      },
+    );
 
     await testEnv.spanProcessor.forceFlush();
     await waitForServerIngestion(2000);
@@ -153,28 +156,31 @@ describe("Vercel AI SDK integration E2E tests", () => {
       tags,
     } = testParams;
 
-    const [result, span] = await startActiveSpan(functionId, async (span) => {
-      const result = await generateText({
-        model: openai(modelName),
-        maxOutputTokens: maxTokens,
-        prompt,
-        tools: {
-          weather: weatherTool,
-        },
-        experimental_telemetry: {
-          isEnabled: true,
-          functionId,
-          metadata: {
-            userId,
-            sessionId,
-            tags,
-            ...metadata,
+    const [result, span] = await startActiveObservation(
+      functionId,
+      async (span) => {
+        const result = await generateText({
+          model: openai(modelName),
+          maxOutputTokens: maxTokens,
+          prompt,
+          tools: {
+            weather: weatherTool,
           },
-        },
-      });
+          experimental_telemetry: {
+            isEnabled: true,
+            functionId,
+            metadata: {
+              userId,
+              sessionId,
+              tags,
+              ...metadata,
+            },
+          },
+        });
 
-      return [result, span] as const;
-    });
+        return [result, span] as const;
+      },
+    );
 
     await testEnv.spanProcessor.forceFlush();
     await waitForServerIngestion(2000);
@@ -237,31 +243,34 @@ describe("Vercel AI SDK integration E2E tests", () => {
       tags,
     } = testParams;
 
-    const [result, span] = await startActiveSpan(functionId, async (span) => {
-      const stream = streamText({
-        model: openai(modelName),
-        maxOutputTokens: maxTokens,
-        prompt,
-        experimental_telemetry: {
-          isEnabled: true,
-          functionId,
-          metadata: {
-            userId,
-            sessionId,
-            tags,
-            ...metadata,
+    const [result, span] = await startActiveObservation(
+      functionId,
+      async (span) => {
+        const stream = streamText({
+          model: openai(modelName),
+          maxOutputTokens: maxTokens,
+          prompt,
+          experimental_telemetry: {
+            isEnabled: true,
+            functionId,
+            metadata: {
+              userId,
+              sessionId,
+              tags,
+              ...metadata,
+            },
           },
-        },
-      });
+        });
 
-      let result = "";
+        let result = "";
 
-      for await (const chunk of stream.textStream) {
-        result += chunk;
-      }
+        for await (const chunk of stream.textStream) {
+          result += chunk;
+        }
 
-      return [result, span] as const;
-    });
+        return [result, span] as const;
+      },
+    );
 
     await testEnv.spanProcessor.forceFlush();
     await waitForServerIngestion(2000);
@@ -326,36 +335,39 @@ describe("Vercel AI SDK integration E2E tests", () => {
       tags,
     } = testParams;
 
-    const [result, span] = await startActiveSpan(functionId, async (span) => {
-      const result = await generateObject({
-        model: openai(modelName),
-        schema: z.object({
-          recipe: z.object({
-            name: z.string(),
-            ingredients: z.array(
-              z.object({
-                name: z.string(),
-                amount: z.string(),
-              }),
-            ),
-            steps: z.array(z.string()),
+    const [result, span] = await startActiveObservation(
+      functionId,
+      async (span) => {
+        const result = await generateObject({
+          model: openai(modelName),
+          schema: z.object({
+            recipe: z.object({
+              name: z.string(),
+              ingredients: z.array(
+                z.object({
+                  name: z.string(),
+                  amount: z.string(),
+                }),
+              ),
+              steps: z.array(z.string()),
+            }),
           }),
-        }),
-        prompt,
-        experimental_telemetry: {
-          isEnabled: true,
-          functionId,
-          metadata: {
-            userId,
-            sessionId,
-            tags,
-            ...metadata,
+          prompt,
+          experimental_telemetry: {
+            isEnabled: true,
+            functionId,
+            metadata: {
+              userId,
+              sessionId,
+              tags,
+              ...metadata,
+            },
           },
-        },
-      });
+        });
 
-      return [result, span] as const;
-    });
+        return [result, span] as const;
+      },
+    );
 
     await testEnv.spanProcessor.forceFlush();
     await waitForServerIngestion(2000);
@@ -411,7 +423,7 @@ describe("Vercel AI SDK integration E2E tests", () => {
     const { modelName, prompt, functionId, userId, sessionId, metadata, tags } =
       testParams;
 
-    const [currentObject, span] = await startActiveSpan(
+    const [currentObject, span] = await startActiveObservation(
       functionId,
       async (span) => {
         const { partialObjectStream } = streamObject({
@@ -500,24 +512,27 @@ describe("Vercel AI SDK integration E2E tests", () => {
     const { modelName, functionId, userId, sessionId, metadata, tags } =
       testParams;
 
-    const [result, span] = await startActiveSpan(functionId, async (span) => {
-      const result = await embed({
-        model: openai.embedding(modelName),
-        value: "sunny day at the beach",
-        experimental_telemetry: {
-          isEnabled: true,
-          functionId,
-          metadata: {
-            userId,
-            sessionId,
-            tags,
-            ...metadata,
+    const [result, span] = await startActiveObservation(
+      functionId,
+      async (span) => {
+        const result = await embed({
+          model: openai.embedding(modelName),
+          value: "sunny day at the beach",
+          experimental_telemetry: {
+            isEnabled: true,
+            functionId,
+            metadata: {
+              userId,
+              sessionId,
+              tags,
+              ...metadata,
+            },
           },
-        },
-      });
+        });
 
-      return [result, span] as const;
-    });
+        return [result, span] as const;
+      },
+    );
 
     await testEnv.spanProcessor.forceFlush();
     await waitForServerIngestion(2000);
@@ -582,32 +597,35 @@ describe("Vercel AI SDK integration E2E tests", () => {
       tags,
     } = testParams;
 
-    const [result, span] = await startActiveSpan(functionId, async (span) => {
-      const stream = streamText({
-        model: openai(modelName),
-        maxOutputTokens: maxTokens,
-        prompt,
-        experimental_telemetry: {
-          isEnabled: true,
-          functionId,
-          metadata: {
-            langfusePrompt: fetchedPrompt.toJSON(),
-            userId,
-            sessionId,
-            tags,
-            ...metadata,
-          } as any,
-        },
-      });
+    const [result, span] = await startActiveObservation(
+      functionId,
+      async (span) => {
+        const stream = streamText({
+          model: openai(modelName),
+          maxOutputTokens: maxTokens,
+          prompt,
+          experimental_telemetry: {
+            isEnabled: true,
+            functionId,
+            metadata: {
+              langfusePrompt: fetchedPrompt.toJSON(),
+              userId,
+              sessionId,
+              tags,
+              ...metadata,
+            } as any,
+          },
+        });
 
-      let result = "";
+        let result = "";
 
-      for await (const chunk of stream.textStream) {
-        result += chunk;
-      }
+        for await (const chunk of stream.textStream) {
+          result += chunk;
+        }
 
-      return [result, span] as const;
-    });
+        return [result, span] as const;
+      },
+    );
 
     await testEnv.spanProcessor.forceFlush();
     await waitForServerIngestion(2000);
@@ -651,7 +669,7 @@ describe("Vercel AI SDK integration E2E tests", () => {
     const attachmentPath = "tests/static/bitcoin.pdf";
     const attachment = await fs.readFile(attachmentPath);
 
-    const [result, span] = await startActiveSpan(
+    const [result, span] = await startActiveObservation(
       "generateText",
       async (span) => {
         const result = await generateText({
@@ -719,7 +737,7 @@ describe("Vercel AI SDK integration E2E tests", () => {
     const imagePath = "tests/static/puton.jpg";
     const image = await fs.readFile(imagePath);
 
-    const [result, span] = await startActiveSpan(
+    const [result, span] = await startActiveObservation(
       "generateText",
       async (span) => {
         const result = await generateText({

--- a/tests/integration/scores.integration.test.ts
+++ b/tests/integration/scores.integration.test.ts
@@ -14,7 +14,7 @@ import {
   IngestionEvent,
   resetGlobalLogger,
 } from "@langfuse/core";
-import { startSpan } from "@langfuse/tracing";
+import { startObservation } from "@langfuse/tracing";
 import {
   setupTestEnvironment,
   teardownTestEnvironment,
@@ -150,7 +150,7 @@ describe("ScoreManager Integration Tests", () => {
   describe("Span-based Scoring", () => {
     it("should score an observation with span context", async () => {
       const scoreManager = createScoreManager(mockAPIClient);
-      const span = startSpan("test-operation");
+      const span = startObservation("test-operation");
       const { spanId, traceId } = span.otelSpan.spanContext();
 
       scoreManager.observation(span, {
@@ -171,7 +171,7 @@ describe("ScoreManager Integration Tests", () => {
 
     it("should score a trace with span context", async () => {
       const scoreManager = createScoreManager(mockAPIClient);
-      const span = startSpan("test-operation");
+      const span = startObservation("test-operation");
       const { traceId } = span.otelSpan.spanContext();
 
       scoreManager.trace(span, {
@@ -192,7 +192,7 @@ describe("ScoreManager Integration Tests", () => {
 
     it("should score active observation in context", async () => {
       const scoreManager = createScoreManager(mockAPIClient);
-      const span = startSpan("test-operation");
+      const span = startObservation("test-operation");
 
       await trace
         .getTracer("test")
@@ -220,7 +220,7 @@ describe("ScoreManager Integration Tests", () => {
 
     it("should score active trace in context", async () => {
       const scoreManager = createScoreManager(mockAPIClient);
-      const span = startSpan("test-operation");
+      const span = startObservation("test-operation");
 
       await trace
         .getTracer("test")

--- a/tests/integration/span-processor.integration.test.ts
+++ b/tests/integration/span-processor.integration.test.ts
@@ -1,4 +1,4 @@
-import { startSpan } from "@langfuse/tracing";
+import { startObservation } from "@langfuse/tracing";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import { SpanAssertions } from "./helpers/assertions.js";
@@ -38,7 +38,7 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       });
       assertions = new SpanAssertions(testEnv.mockExporter);
 
-      const span = startSpan("masked-span", {
+      const span = startObservation("masked-span", {
         input: { message: "This contains secret information" },
         output: { response: "No secret here" },
       });
@@ -70,7 +70,7 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       });
       assertions = new SpanAssertions(testEnv.mockExporter);
 
-      const span = startSpan("error-mask-span", {
+      const span = startObservation("error-mask-span", {
         input: { message: "test message" },
       });
       span.end();
@@ -90,7 +90,7 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       const base64Image =
         "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
 
-      const span = startSpan("media-span", {
+      const span = startObservation("media-span", {
         input: {
           message: "Here is an image:",
           image: base64Image,
@@ -120,7 +120,7 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       const image2 =
         "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwA9/9k=";
 
-      const span = startSpan("multi-media-span", {
+      const span = startObservation("multi-media-span", {
         input: {
           images: [image1, image2],
         },
@@ -158,7 +158,7 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       assertions = new SpanAssertions(testEnv.mockExporter);
 
       // Create first span
-      const span1 = startSpan("batch-span-1");
+      const span1 = startObservation("batch-span-1");
       span1.end();
 
       // Should not export yet
@@ -166,7 +166,7 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       expect(testEnv.mockExporter.getSpanCount()).toBe(0);
 
       // Create second span - should trigger batch export
-      const span2 = startSpan("batch-span-2");
+      const span2 = startObservation("batch-span-2");
       span2.end();
 
       await waitForSpanExport(testEnv.mockExporter, 2);
@@ -187,7 +187,7 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       assertions = new SpanAssertions(testEnv.mockExporter);
 
       // Create single span
-      const span = startSpan("force-flush-span");
+      const span = startObservation("force-flush-span");
       span.end();
 
       // Should not export yet due to high batch size
@@ -213,7 +213,7 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       });
       assertions = new SpanAssertions(testEnv.mockExporter);
 
-      const span = startSpan("failed-export-span");
+      const span = startObservation("failed-export-span");
       span.end();
 
       // Wait for export attempt
@@ -234,7 +234,7 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       });
       assertions = new SpanAssertions(testEnv.mockExporter);
 
-      const span = startSpan("slow-export-span");
+      const span = startObservation("slow-export-span");
       span.end();
 
       await waitForSpanExport(testEnv.mockExporter, 1, 1000);
@@ -257,7 +257,7 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       });
       assertions = new SpanAssertions(testEnv.mockExporter);
 
-      const allowedSpan = startSpan("allowed-span", {
+      const allowedSpan = startObservation("allowed-span", {
         input: { message: "This should be exported" },
       });
       allowedSpan.end();
@@ -280,7 +280,7 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       });
       assertions = new SpanAssertions(testEnv.mockExporter);
 
-      const blockedSpan = startSpan("blocked-span", {
+      const blockedSpan = startObservation("blocked-span", {
         input: { message: "This should not be exported" },
       });
       blockedSpan.end();
@@ -305,12 +305,12 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       assertions = new SpanAssertions(testEnv.mockExporter);
 
       // Create premium user span
-      const premiumSpan = startSpan("premium-user-span");
+      const premiumSpan = startObservation("premium-user-span");
       premiumSpan.otelSpan.setAttributes({ "user.type": "premium" });
       premiumSpan.end();
 
       // Create free user span
-      const freeSpan = startSpan("free-user-span");
+      const freeSpan = startObservation("free-user-span");
       freeSpan.otelSpan.setAttributes({ "user.type": "free" });
       freeSpan.end();
 
@@ -335,11 +335,11 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       assertions = new SpanAssertions(testEnv.mockExporter);
 
       // Create short duration span
-      const shortSpan = startSpan("short-span");
+      const shortSpan = startObservation("short-span");
       shortSpan.end(); // Immediate end = very short duration
 
       // Create long duration span
-      const longSpan = startSpan("long-span");
+      const longSpan = startObservation("long-span");
       await new Promise((resolve) => setTimeout(resolve, 150)); // Wait 150ms
       longSpan.end();
 
@@ -367,17 +367,17 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       assertions = new SpanAssertions(testEnv.mockExporter);
 
       // Should be exported (not internal + has export flag)
-      const exportedSpan = startSpan("user-action");
+      const exportedSpan = startObservation("user-action");
       exportedSpan.otelSpan.setAttributes({ export: "true" });
       exportedSpan.end();
 
       // Should not be exported (internal)
-      const internalSpan = startSpan("internal-process");
+      const internalSpan = startObservation("internal-process");
       internalSpan.otelSpan.setAttributes({ export: "true" });
       internalSpan.end();
 
       // Should not be exported (no export flag)
-      const noFlagSpan = startSpan("user-action-2");
+      const noFlagSpan = startObservation("user-action-2");
       noFlagSpan.end();
 
       await waitForSpanExport(testEnv.mockExporter, 1);
@@ -404,11 +404,11 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       assertions = new SpanAssertions(testEnv.mockExporter);
 
       // This span should cause an error in the filter function
-      const errorSpan = startSpan("error-span");
+      const errorSpan = startObservation("error-span");
       errorSpan.end();
 
       // This span should work normally
-      const normalSpan = startSpan("normal-span");
+      const normalSpan = startObservation("normal-span");
       normalSpan.end();
 
       await waitForSpanExport(testEnv.mockExporter, 1);
@@ -423,7 +423,7 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
 
     it("should not call shouldExportSpan when not configured", async () => {
       // Using default testEnv without shouldExportSpan
-      const span = startSpan("default-span");
+      const span = startObservation("default-span");
       span.end();
 
       await waitForSpanExport(testEnv.mockExporter, 1);
@@ -445,9 +445,9 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       assertions = new SpanAssertions(testEnv.mockExporter);
 
       // Create spans but don't trigger flush
-      const span1 = startSpan("shutdown-span-1");
+      const span1 = startObservation("shutdown-span-1");
       span1.end();
-      const span2 = startSpan("shutdown-span-2");
+      const span2 = startObservation("shutdown-span-2");
       span2.end();
 
       // Should not export yet
@@ -466,11 +466,11 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
   describe("Export Mode Selection", () => {
     it("should use BatchSpanProcessor by default", async () => {
       // Default testEnv uses batched mode
-      const span1 = startSpan("default-batch-1");
+      const span1 = startObservation("default-batch-1");
       span1.end();
 
       // Should not export immediately due to batching (default flushAt is 1 in tests)
-      const span2 = startSpan("default-batch-2");
+      const span2 = startObservation("default-batch-2");
       span2.end();
 
       await waitForSpanExport(testEnv.mockExporter, 2);
@@ -492,14 +492,14 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       assertions = new SpanAssertions(testEnv.mockExporter);
 
       // First span should not export yet
-      const span1 = startSpan("batched-span-1");
+      const span1 = startObservation("batched-span-1");
       span1.end();
 
       await new Promise((resolve) => setTimeout(resolve, 100));
       expect(testEnv.mockExporter.getSpanCount()).toBe(0);
 
       // Second span should trigger batch export
-      const span2 = startSpan("batched-span-2");
+      const span2 = startObservation("batched-span-2");
       span2.end();
 
       await waitForSpanExport(testEnv.mockExporter, 2);
@@ -521,14 +521,14 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       assertions = new SpanAssertions(testEnv.mockExporter);
 
       // Each span should export immediately regardless of flushAt
-      const span1 = startSpan("immediate-span-1");
+      const span1 = startObservation("immediate-span-1");
       span1.end();
 
       await waitForSpanExport(testEnv.mockExporter, 1);
       assertions.expectSpanCount(1);
       assertions.expectSpanWithName("immediate-span-1");
 
-      const span2 = startSpan("immediate-span-2");
+      const span2 = startObservation("immediate-span-2");
       span2.end();
 
       await waitForSpanExport(testEnv.mockExporter, 2);
@@ -548,7 +548,7 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       });
       assertions = new SpanAssertions(testEnv.mockExporter);
 
-      const span = startSpan("immediate-test");
+      const span = startObservation("immediate-test");
       span.end();
 
       // Should export almost immediately
@@ -570,7 +570,7 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       assertions = new SpanAssertions(testEnv.mockExporter);
 
       // Should still export immediately despite batch config
-      const span = startSpan("ignore-batch-config");
+      const span = startObservation("ignore-batch-config");
       span.end();
 
       await waitForSpanExport(testEnv.mockExporter, 1, 200);
@@ -590,16 +590,16 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       assertions = new SpanAssertions(testEnv.mockExporter);
 
       // Create two spans - should not export yet
-      const span1 = startSpan("batch-1");
+      const span1 = startObservation("batch-1");
       span1.end();
-      const span2 = startSpan("batch-2");
+      const span2 = startObservation("batch-2");
       span2.end();
 
       await new Promise((resolve) => setTimeout(resolve, 100));
       expect(testEnv.mockExporter.getSpanCount()).toBe(0);
 
       // Third span should trigger batch export
-      const span3 = startSpan("batch-3");
+      const span3 = startObservation("batch-3");
       span3.end();
 
       await waitForSpanExport(testEnv.mockExporter, 3);
@@ -618,7 +618,7 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
         },
       });
 
-      const span1 = startSpan("batch-force-flush");
+      const span1 = startObservation("batch-force-flush");
       span1.end();
 
       // Should not export yet
@@ -637,7 +637,7 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
         },
       });
 
-      const span2 = startSpan("immediate-force-flush");
+      const span2 = startObservation("immediate-force-flush");
       span2.end();
 
       await waitForSpanExport(testEnv.mockExporter, 1);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Consolidates span, generation, and event creation into `startObservation` with `asType` option, updating tests and disabling `no-redeclare` rule.
> 
>   - **Behavior**:
>     - Consolidates `startSpan`, `startGeneration`, and `createEvent` into `startObservation` in `index.ts`.
>     - Introduces `asType` option to specify observation type (span, generation, event).
>     - Updates `CallbackHandler` in `CallbackHandler.ts` to use `startObservation`.
>   - **Tests**:
>     - Updates tests in `scores.integration.test.ts`, `span-processor.integration.test.ts`, and `tracing.integration.test.ts` to use `startObservation`.
>     - Adds tests for new `asType` functionality and error handling.
>   - **Misc**:
>     - Disables `no-redeclare` rule in `eslint.config.mjs`.
>     - Removes `startSpan`, `startGeneration`, and `createEvent` functions from `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 7a71665190d08f66af805b7ff87d38d34b5dfe01. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->