### PR TITLE
fix: support non-string content in message placeholders

### DIFF
--- a/langfuse-core/src/prompts/promptClients.ts
+++ b/langfuse-core/src/prompts/promptClients.ts
@@ -235,7 +235,7 @@ export class ChatPromptClient extends BasePromptClient {
     }
 
     return messagesWithPlaceholdersReplaced.map((item) => {
-      if (typeof item === "object" && item !== null && "role" in item && "content" in item) {
+      if (typeof item === "object" && item !== null && "role" in item && "content" in item && typeof item.content === "string") {
         return {
           ...item,
           content: mustache.render(item.content, variables ?? {}),


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

We are replacing message placeholders with messages containing images, which breaks the mustache rendering.

```
TypeError: Invalid template! Template should be a "string" but "array" was given as the first argument for mustache#render(template, view, partials)
    at render (/node_modules/mustache/mustache.mjs:747:11)
    at item (/node_modules/langfuse-core/src/prompts/promptClients.ts:241:29)
    at Array.map (<anonymous>)
    at compile (/node_modules/langfuse-core/src/prompts/promptClients.ts:237:45)
```

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them
- [ ] langfuse
- [ ] langfuse-node

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Fixed message placeholder replacements with non-string `content`

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `TypeError` in `ChatPromptClient.compile()` by ensuring `content` is a string before mustache rendering, handling non-string content gracefully.
> 
>   - **Behavior**:
>     - Fixes `TypeError` in `ChatPromptClient.compile()` by ensuring `content` is a string before rendering with mustache.
>     - Handles non-string `content` in message placeholders gracefully.
>   - **Misc**:
>     - Affects all libraries, marked as a patch-level change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 0a0321efd75ca5ff7a5d725cb8efb9c126024768. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

Updated On: 2025-09-01 09:12:49 UTC

This PR fixes a critical bug in the prompt client system where mustache template rendering would fail when processing ChatMessage content that isn't a string. The issue occurred when trying to use message placeholders with multimodal content (like messages containing images), where the `content` field contains arrays or objects instead of plain strings.

The fix is implemented in `langfuse-core/src/prompts/promptClients.ts` by adding a type guard that checks `typeof item.content === "string"` before applying mustache rendering. This ensures that only string content goes through template processing, while complex content structures (arrays, objects with image data, etc.) are left untouched.

This change aligns with modern AI applications that use multimodal content in chat messages, where the content field can contain structured data beyond simple text. The solution maintains backward compatibility for existing string-based prompts while enabling support for more complex message formats without breaking the rendering pipeline.

**PR Description Notes:**
- The "Changes" section in the PR description is empty and should describe what was actually modified
- Consider opening a GitHub issue first to discuss the rationale for this change as required by the contributing guidelines

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it addresses a specific runtime error without changing core functionality
- Score reflects a targeted fix with clear error reproduction and minimal code changes that preserve existing behavior
- Pay close attention to `langfuse-core/src/prompts/promptClients.ts` to ensure the type checking logic is sound

### Context used:
**Rule -** Open a GitHub issue or discussion first before submitting PRs to explain the rationale and necessity of the proposed changes, as required by the contributing guide. ([link](https://app.greptile.com/review/custom-context?memory=f66422d7-e71a-47d4-928b-df849c888300))

<!-- /greptile_comment -->