### PR TITLE
fix(message-placeholders): use plain text langchain format for placeh…

### DIFF
--- a/packages/client/src/prompt/promptClients.ts
+++ b/packages/client/src/prompt/promptClients.ts
@@ -452,11 +452,14 @@ export class ChatPromptClient extends BasePromptClient {
             JSON.stringify(placeholderValue),
           );
         } else {
-          // Convert unresolved placeholder to Langchain MessagesPlaceholder
-          messagesWithPlaceholdersReplaced.push({
-            variableName: item.name,
-            optional: false,
-          });
+          // Convert unresolved placeholder to Langchain MessagesPlaceholder format
+          // see: https://js.langchain.com/docs/concepts/prompt_templates/#messagesplaceholder
+          // we convert it to the format without using the class explicitly. Therefore, we
+          // don't have to import langchain as a dependency.
+          messagesWithPlaceholdersReplaced.push([
+            "placeholder",
+            `{${item.name}}`,
+          ]);
         }
       } else if (
         "role" in item &&

--- a/tests/e2e/prompts.e2e.test.ts
+++ b/tests/e2e/prompts.e2e.test.ts
@@ -1254,7 +1254,6 @@ describe("Langfuse Prompts E2E", () => {
 
           const client = new ChatPromptClient(mockPrompt);
 
-          // This is what the user is trying to do - should work but currently fails
           const langchainPrompt = ChatPromptTemplate.fromMessages(
             client.getLangchainPrompt(),
           );


### PR DESCRIPTION
fixes https://github.com/langfuse/langfuse/issues/9097
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> `ChatPromptClient` now uses a plain text format for unresolved placeholders compatible with LangChain, with updated tests to verify this behavior.
> 
>   - **Behavior**:
>     - `ChatPromptClient` in `promptClients.ts` now converts unresolved placeholders to a plain text format compatible with LangChain, avoiding direct dependency on LangChain.
>     - Updates `getLangchainPrompt()` to return placeholders as tuples like `["placeholder", "{name}"]`.
>   - **Tests**:
>     - Updates `prompts.e2e.test.ts` to verify new placeholder format in `getLangchainPrompt()`.
>     - Adds test to ensure compatibility with `ChatPromptTemplate.fromMessages()` for unresolved placeholders.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for cf67c43c22d68e8309182d0ccb5b96b5270b9d28. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

Updated On: 2025-09-16 14:27:48 UTC

This PR fixes the format of unresolved message placeholders when converting Langfuse chat prompts to LangChain format. The core change addresses compatibility issues between Langfuse's `getLangchainPrompt()` method and LangChain's `ChatPromptTemplate.fromMessages()` functionality.

**What Changed:**
The PR modifies how unresolved placeholders are represented in the LangChain format conversion. Previously, placeholders were returned as objects with `variableName` and `optional` properties:
```typescript
{
  variableName: item.name,
  optional: false
}
```

Now they are returned as simple tuples matching LangChain's native format:
```typescript
["placeholder", `{${item.name}}`]
```

**Integration with Codebase:**
This change is part of the prompt management system in the `packages/client/src/prompt/promptClients.ts` file, specifically within the `ChatPromptClient.getLangchainPrompt()` method. The fix ensures that when users call this method to get LangChain-compatible prompts, the output can be directly consumed by LangChain's `ChatPromptTemplate.fromMessages()` without requiring additional transformation logic.

The change maintains Langfuse's independence from LangChain as a direct dependency while ensuring proper interoperability. The E2E tests were updated to reflect this new tuple format and include a new test case that verifies direct compatibility with `ChatPromptTemplate.fromMessages()`.

**PR Description Notes:**
- The PR description is minimal, containing only a link to the GitHub issue being fixed

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it fixes a clear compatibility issue without breaking existing functionality
- Score reflects well-targeted changes that address a specific integration problem with comprehensive test coverage
- Pay close attention to the test files to ensure the new tuple format is correctly validated across all scenarios

### Context used:
**Rule -** Open a GitHub issue or discussion first before submitting PRs to explain the rationale and necessity of the proposed changes, as required by the contributing guide. ([link](https://app.greptile.com/review/custom-context?memory=f66422d7-e71a-47d4-928b-df849c888300))

<!-- /greptile_comment -->