### PR TITLE
fix(openai): parse response usage

### DIFF
--- a/packages/openai/src/parseOpenAI.ts
+++ b/packages/openai/src/parseOpenAI.ts
@@ -137,9 +137,27 @@ export const parseUsageDetails = (
       output_tokens_details,
     } = completionUsage;
 
+    let finalInputTokens = input_tokens as number;
+    Object.keys(input_tokens_details ?? {}).forEach((key) => {
+      finalInputTokens = Math.max(
+        finalInputTokens -
+          input_tokens_details[key as keyof typeof input_tokens_details],
+        0,
+      );
+    });
+
+    let finalOutputTokens = output_tokens as number;
+    Object.keys(output_tokens_details ?? {}).forEach((key) => {
+      finalOutputTokens = Math.max(
+        finalOutputTokens -
+          output_tokens_details[key as keyof typeof output_tokens_details],
+        0,
+      );
+    });
+
     return {
-      input: input_tokens,
-      output: output_tokens,
+      input: finalInputTokens,
+      output: finalOutputTokens,
       total: total_tokens,
       ...Object.fromEntries(
         Object.entries(input_tokens_details ?? {}).map(([key, value]) => [


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes token calculation in `parseUsageDetails` in `parseOpenAI.ts` to ensure accurate token usage reporting by subtracting detailed token counts and preventing negative values.
> 
>   - **Behavior**:
>     - Fixes token calculation in `parseUsageDetails` in `parseOpenAI.ts` by subtracting detailed token counts from `input_tokens` and `output_tokens`.
>     - Ensures token counts do not go below zero using `Math.max()`.
>   - **Functions**:
>     - Modifies `parseUsageDetails` to handle `input_tokens_details` and `output_tokens_details` correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 3e3e24a8cd1eaabcd5084a5b0b351a587264b0c4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

## Greptile Summary

Updated On: 2025-09-19 12:49:24 UTC

This PR modifies the `parseUsageDetails` function in `packages/openai/src/parseOpenAI.ts` to handle OpenAI's response usage format more accurately. The change specifically addresses how token counts are calculated when using the newer `input_tokens`/`output_tokens` format versus the legacy `prompt_tokens`/`completion_tokens` format.

The key modification introduces subtraction logic for the `input_tokens`/`output_tokens` branch (lines 140-156), where detailed token breakdowns are subtracted from the main token counts before returning them as 'input' and 'output' fields. This suggests that OpenAI's newer API format includes overlapping counts where the main token count represents the sum of all components, including the detailed breakdowns, requiring subtraction to avoid double-counting.

However, this creates an asymmetric handling pattern between the two API response formats. The `prompt_tokens`/`completion_tokens` branch (lines 114-116) continues to return raw values without any subtraction, while the `input_tokens`/`output_tokens` branch now performs complex subtraction calculations. This divergent approach indicates the developer is responding to specific API behavior differences between OpenAI's legacy and newer response formats.

The function is part of the OpenAI integration layer that parses usage statistics from OpenAI API responses and transforms them into Langfuse's internal `UsageDetails` format, making accurate token counting critical for billing and analytics purposes.

## Confidence score: 2/5

- This PR introduces potentially risky asymmetric logic that could lead to inconsistent token counting across different OpenAI API response formats
- Score reflects concern about the complex subtraction logic and lack of documentation explaining why different formats require different handling approaches  
- The `parseUsageDetails` function requires careful attention due to the introduction of asymmetric token calculation logic that differs significantly between API response formats

<!-- /greptile_comment -->