### PR TITLE
feat: propagate trace attributes onto all child spans on update

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,8 +29,5 @@
   ],
   "devDependencies": {
     "@types/node": "^24.1.0"
-  },
-  "peerDependencies": {
-    "@opentelemetry/api": "^1.9.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,5 +29,8 @@
   ],
   "devDependencies": {
     "@types/node": "^24.1.0"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.9.0"
   }
 }

--- a/packages/core/src/context-keys.ts
+++ b/packages/core/src/context-keys.ts
@@ -1,0 +1,47 @@
+/**
+ * Context keys for Langfuse context propagation.
+ *
+ * These keys are used to store and retrieve trace-level values (userId, sessionId, metadata)
+ * from OpenTelemetry context. They are created as Symbols to ensure uniqueness and
+ * avoid conflicts with other context values.
+ *
+ * Note: These constants must be imported using the exact same reference to work correctly.
+ * Do not recreate them as strings - use the imported Symbol constants.
+ *
+ * @module context-keys
+ * @packageDocumentation
+ */
+
+import { createContextKey } from "@opentelemetry/api";
+
+/**
+ * Context key for storing user ID in OpenTelemetry context.
+ *
+ * Used by the tracing package's `withUser()`, `withContext()` functions and
+ * by the otel package's span processor for context propagation.
+ *
+ * @public
+ */
+export const LANGFUSE_CTX_USER_ID = createContextKey("langfuse.ctx.user.id");
+
+/**
+ * Context key for storing session ID in OpenTelemetry context.
+ *
+ * Used by the tracing package's `withSession()`, `withContext()` functions and
+ * by the otel package's span processor for context propagation.
+ *
+ * @public
+ */
+export const LANGFUSE_CTX_SESSION_ID = createContextKey(
+  "langfuse.ctx.session.id",
+);
+
+/**
+ * Context key for storing metadata in OpenTelemetry context.
+ *
+ * Used by the tracing package's `withMetadata()`, `withContext()` functions and
+ * by the otel package's span processor for context propagation.
+ *
+ * @public
+ */
+export const LANGFUSE_CTX_METADATA = createContextKey("langfuse.ctx.metadata");

--- a/packages/core/src/context-keys.ts
+++ b/packages/core/src/context-keys.ts
@@ -12,8 +12,6 @@
  * @packageDocumentation
  */
 
-import { createContextKey } from "@opentelemetry/api";
-
 /**
  * Context key for storing user ID in OpenTelemetry context.
  *
@@ -22,7 +20,7 @@ import { createContextKey } from "@opentelemetry/api";
  *
  * @public
  */
-export const LANGFUSE_CTX_USER_ID = createContextKey("langfuse.ctx.user.id");
+export const LANGFUSE_CTX_USER_ID = Symbol.for("langfuse.ctx.user.id");
 
 /**
  * Context key for storing session ID in OpenTelemetry context.
@@ -32,9 +30,7 @@ export const LANGFUSE_CTX_USER_ID = createContextKey("langfuse.ctx.user.id");
  *
  * @public
  */
-export const LANGFUSE_CTX_SESSION_ID = createContextKey(
-  "langfuse.ctx.session.id",
-);
+export const LANGFUSE_CTX_SESSION_ID = Symbol.for("langfuse.ctx.session.id");
 
 /**
  * Context key for storing metadata in OpenTelemetry context.
@@ -44,4 +40,4 @@ export const LANGFUSE_CTX_SESSION_ID = createContextKey(
  *
  * @public
  */
-export const LANGFUSE_CTX_METADATA = createContextKey("langfuse.ctx.metadata");
+export const LANGFUSE_CTX_METADATA = Symbol.for("langfuse.ctx.metadata");

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,3 +9,4 @@ export { LangfuseAPIClient } from "./api/Client.js";
 export * from "./utils.js";
 export * from "./types.js";
 export * from "./media.js";
+export * from "./context-keys.js";

--- a/packages/tracing/src/context.ts
+++ b/packages/tracing/src/context.ts
@@ -196,6 +196,7 @@ export function withSession<T>(
  * All observations created within the callback (and any nested callbacks) will
  * automatically inherit the specified metadata. Metadata keys are stored as individual
  * attributes with the `langfuse.metadata.` prefix.
+ * Try to keep metadata keys and values small to avoid a performance drag within your application.
  *
  * ## Context Scoping
  * - Context is scoped to the callback execution
@@ -205,7 +206,7 @@ export function withSession<T>(
  *
  * ## Cross-Service Propagation
  * Set `asBaggage: true` to propagate metadata across service boundaries via HTTP headers.
- * Only use this for non-sensitive metadata. Baggage has size limits (~200 chars per entry).
+ * Only use this for non-sensitive metadata.
  *
  * @param metadata - Key-value pairs of metadata to propagate to child spans
  * @param fn - Callback function to execute within the metadata context

--- a/packages/tracing/src/context.ts
+++ b/packages/tracing/src/context.ts
@@ -1,0 +1,443 @@
+/**
+ * Context propagation utilities for Langfuse tracing.
+ *
+ * This module provides functions for automatic propagation of trace attributes
+ * (userId, sessionId, metadata) from parent contexts to child spans using
+ * OpenTelemetry's context and baggage mechanisms.
+ *
+ * @module context
+ */
+
+import {
+  LANGFUSE_CTX_USER_ID,
+  LANGFUSE_CTX_SESSION_ID,
+  LANGFUSE_CTX_METADATA,
+} from "@langfuse/core";
+import { context, propagation, trace } from "@opentelemetry/api";
+
+/**
+ * Options for context propagation functions.
+ *
+ * @public
+ */
+export interface ContextPropagationOptions {
+  /**
+   * If true, stores the context value in OpenTelemetry baggage for cross-service propagation.
+   * When enabled, the value will be included in HTTP headers of outbound requests.
+   *
+   * **Security Warning**: Only use this for non-sensitive identifiers that are safe to
+   * transmit across service boundaries. Baggage values are transmitted in HTTP headers
+   * and may be visible to intermediaries.
+   *
+   * @defaultValue false
+   */
+  asBaggage?: boolean;
+}
+
+/**
+ * Executes a callback within a user context, propagating userId to all child spans.
+ *
+ * All observations created within the callback (and any nested callbacks) will
+ * automatically inherit the specified userId. This provides a cleaner alternative
+ * to manually setting userId on each span.
+ *
+ * ## Context Scoping
+ * - Context is scoped to the callback execution
+ * - Nested `withUser()` calls will override the userId for their scope
+ * - Context is automatically cleaned up when the callback completes
+ * - Works correctly with async/await and Promise chains
+ *
+ * ## Cross-Service Propagation
+ * Set `asBaggage: true` to propagate the userId across service boundaries via HTTP headers.
+ * Only use this for non-sensitive user identifiers.
+ *
+ * @param userId - The user identifier to propagate to child spans
+ * @param fn - Callback function to execute within the user context
+ * @param options - Optional configuration for baggage propagation
+ * @returns The return value of the callback function
+ *
+ * @example
+ * ```typescript
+ * import { withUser, startObservation } from '@langfuse/tracing';
+ *
+ * // All spans created within this block will have userId='user-123'
+ * withUser('user-123', () => {
+ *   const span = startObservation('operation');
+ *   const child = span.startObservation('child-operation');
+ *   child.end();
+ *   span.end();
+ * });
+ *
+ * // Async usage
+ * await withUser('user-123', async () => {
+ *   const result = await someAsyncOperation();
+ *   return result;
+ * });
+ *
+ * // Cross-service propagation (use with caution)
+ * withUser('public-user-id', () => {
+ *   // userId will be propagated in HTTP headers
+ *   fetch('https://api.example.com/data');
+ * }, { asBaggage: true });
+ * ```
+ *
+ * @public
+ */
+export function withUser<T>(
+  userId: string,
+  fn: () => T,
+  options?: ContextPropagationOptions,
+): T {
+  let newContext = context.active().setValue(LANGFUSE_CTX_USER_ID, userId);
+
+  // Set attribute on currently active span if exists
+  const currentSpan = trace.getActiveSpan();
+  if (currentSpan?.isRecording()) {
+    currentSpan.setAttribute("user.id", userId);
+  }
+
+  // Optionally set baggage for cross-service propagation
+  if (options?.asBaggage) {
+    const bag =
+      propagation.getBaggage(newContext) || propagation.createBaggage();
+    const updatedBag = bag.setEntry("user.id", { value: userId });
+    newContext = propagation.setBaggage(newContext, updatedBag);
+  }
+
+  return context.with(newContext, fn);
+}
+
+/**
+ * Executes a callback within a session context, propagating sessionId to all child spans.
+ *
+ * All observations created within the callback (and any nested callbacks) will
+ * automatically inherit the specified sessionId. This provides a cleaner alternative
+ * to manually setting sessionId on each span.
+ *
+ * ## Context Scoping
+ * - Context is scoped to the callback execution
+ * - Nested `withSession()` calls will override the sessionId for their scope
+ * - Context is automatically cleaned up when the callback completes
+ * - Works correctly with async/await and Promise chains
+ *
+ * ## Cross-Service Propagation
+ * Set `asBaggage: true` to propagate the sessionId across service boundaries via HTTP headers.
+ * Only use this for non-sensitive session identifiers.
+ *
+ * @param sessionId - The session identifier to propagate to child spans
+ * @param fn - Callback function to execute within the session context
+ * @param options - Optional configuration for baggage propagation
+ * @returns The return value of the callback function
+ *
+ * @example
+ * ```typescript
+ * import { withSession, startObservation } from '@langfuse/tracing';
+ *
+ * // All spans created within this block will have sessionId='session-456'
+ * withSession('session-456', () => {
+ *   const span = startObservation('operation');
+ *   const child = span.startObservation('child-operation');
+ *   child.end();
+ *   span.end();
+ * });
+ *
+ * // Async usage
+ * await withSession('session-456', async () => {
+ *   const result = await someAsyncOperation();
+ *   return result;
+ * });
+ *
+ * // Cross-service propagation
+ * withSession('public-session-id', () => {
+ *   fetch('https://api.example.com/data');
+ * }, { asBaggage: true });
+ * ```
+ *
+ * @public
+ */
+export function withSession<T>(
+  sessionId: string,
+  fn: () => T,
+  options?: ContextPropagationOptions,
+): T {
+  let newContext = context
+    .active()
+    .setValue(LANGFUSE_CTX_SESSION_ID, sessionId);
+
+  // Set attribute on currently active span if exists
+  const currentSpan = trace.getActiveSpan();
+  if (currentSpan?.isRecording()) {
+    currentSpan.setAttribute("session.id", sessionId);
+  }
+
+  // Optionally set baggage for cross-service propagation
+  if (options?.asBaggage) {
+    const bag =
+      propagation.getBaggage(newContext) || propagation.createBaggage();
+    const updatedBag = bag.setEntry("session.id", { value: sessionId });
+    newContext = propagation.setBaggage(newContext, updatedBag);
+  }
+
+  return context.with(newContext, fn);
+}
+
+/**
+ * Executes a callback within a metadata context, propagating metadata to all child spans.
+ *
+ * All observations created within the callback (and any nested callbacks) will
+ * automatically inherit the specified metadata. Metadata keys are stored as individual
+ * attributes with the `langfuse.metadata.` prefix.
+ *
+ * ## Context Scoping
+ * - Context is scoped to the callback execution
+ * - Nested `withMetadata()` calls will replace metadata for their scope (not merge)
+ * - Context is automatically cleaned up when the callback completes
+ * - Works correctly with async/await and Promise chains
+ *
+ * ## Cross-Service Propagation
+ * Set `asBaggage: true` to propagate metadata across service boundaries via HTTP headers.
+ * Only use this for non-sensitive metadata. Baggage has size limits (~200 chars per entry).
+ *
+ * @param metadata - Key-value pairs of metadata to propagate to child spans
+ * @param fn - Callback function to execute within the metadata context
+ * @param options - Optional configuration for baggage propagation
+ * @returns The return value of the callback function
+ *
+ * @example
+ * ```typescript
+ * import { withMetadata, startObservation } from '@langfuse/tracing';
+ *
+ * // All spans will have these metadata attributes
+ * withMetadata({ experiment: 'A', version: '1.0' }, () => {
+ *   const span = startObservation('operation');
+ *   // span will have metadata.experiment='A', metadata.version='1.0'
+ *   span.end();
+ * });
+ *
+ * // Async usage
+ * await withMetadata({ feature: 'new-ui', region: 'us-east' }, async () => {
+ *   const result = await someAsyncOperation();
+ *   return result;
+ * });
+ *
+ * // Nested contexts (inner overrides outer)
+ * withMetadata({ env: 'prod' }, () => {
+ *   withMetadata({ env: 'staging' }, () => {
+ *     // This scope has env='staging'
+ *   });
+ *   // This scope has env='prod'
+ * });
+ * ```
+ *
+ * @public
+ */
+export function withMetadata<T>(
+  metadata: Record<string, unknown>,
+  fn: () => T,
+  options?: ContextPropagationOptions,
+): T {
+  if (!metadata || Object.keys(metadata).length === 0) {
+    // No metadata to set, just execute the function
+    return fn();
+  }
+
+  let newContext = context.active().setValue(LANGFUSE_CTX_METADATA, metadata);
+
+  // Set attributes on currently active span if exists
+  const currentSpan = trace.getActiveSpan();
+  if (currentSpan?.isRecording()) {
+    for (const [key, value] of Object.entries(metadata)) {
+      const attrKey = `langfuse.metadata.${key}`;
+      // Convert value to appropriate type for span attribute
+      const attrValue =
+        typeof value === "object" && value !== null
+          ? JSON.stringify(value)
+          : value;
+      currentSpan.setAttribute(attrKey, attrValue as string | number | boolean);
+    }
+  }
+
+  // Optionally set baggage for cross-service propagation
+  if (options?.asBaggage) {
+    let bag = propagation.getBaggage(newContext) || propagation.createBaggage();
+    for (const [key, value] of Object.entries(metadata)) {
+      // Convert value to string and truncate if needed for baggage size limits
+      let strValue = String(value);
+      if (strValue.length > 200) {
+        strValue = strValue.slice(0, 200);
+      }
+
+      bag = bag.setEntry(`langfuse.metadata.${key}`, { value: strValue });
+    }
+    newContext = propagation.setBaggage(newContext, bag);
+  }
+
+  return context.with(newContext, fn);
+}
+
+/**
+ * Configuration for combined context propagation.
+ *
+ * @public
+ */
+export interface ContextConfig {
+  /**
+   * User identifier to propagate to child spans.
+   */
+  userId?: string;
+
+  /**
+   * Session identifier to propagate to child spans.
+   */
+  sessionId?: string;
+
+  /**
+   * Metadata key-value pairs to propagate to child spans.
+   */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Executes a callback with multiple context values set at once.
+ *
+ * This is a convenience function that combines `withUser()`, `withSession()`, and
+ * `withMetadata()` into a single call. All observations created within the callback
+ * will automatically inherit the specified context values.
+ *
+ * ## Context Scoping
+ * - All context values are scoped to the callback execution
+ * - Nested `withContext()` calls can override individual values
+ * - Context is automatically cleaned up when the callback completes
+ * - Works correctly with async/await and Promise chains
+ *
+ * ## Cross-Service Propagation
+ * Set `asBaggage: true` to propagate all context values across service boundaries.
+ * Only use this for non-sensitive identifiers.
+ *
+ * @param config - Configuration object with userId, sessionId, and/or metadata
+ * @param fn - Callback function to execute within the context
+ * @param options - Optional configuration for baggage propagation
+ * @returns The return value of the callback function
+ *
+ * @example
+ * ```typescript
+ * import { withContext, startObservation } from '@langfuse/tracing';
+ *
+ * // Set all context values at once
+ * withContext(
+ *   {
+ *     userId: 'user-123',
+ *     sessionId: 'session-456',
+ *     metadata: { experiment: 'A', version: '1.0' }
+ *   },
+ *   () => {
+ *     const span = startObservation('operation');
+ *     // span has userId, sessionId, and metadata
+ *     span.end();
+ *   }
+ * );
+ *
+ * // Async usage
+ * const result = await withContext(
+ *   { userId: 'user-123', sessionId: 'session-456' },
+ *   async () => {
+ *     return await someAsyncOperation();
+ *   }
+ * );
+ *
+ * // Partial context values
+ * withContext({ userId: 'user-123' }, () => {
+ *   // Only userId is set, no sessionId or metadata
+ * });
+ * ```
+ *
+ * @public
+ */
+export function withContext<T>(
+  config: ContextConfig,
+  fn: () => T,
+  options?: ContextPropagationOptions,
+): T {
+  let newContext = context.active();
+
+  // Set userId if provided
+  if (config.userId !== undefined) {
+    newContext = newContext.setValue(LANGFUSE_CTX_USER_ID, config.userId);
+
+    // Set attribute on currently active span
+    const currentSpan = trace.getActiveSpan();
+    if (currentSpan?.isRecording()) {
+      currentSpan.setAttribute("user.id", config.userId);
+    }
+
+    // Set baggage if requested
+    if (options?.asBaggage) {
+      const bag =
+        propagation.getBaggage(newContext) || propagation.createBaggage();
+      const updatedBag = bag.setEntry("user.id", { value: config.userId });
+      newContext = propagation.setBaggage(newContext, updatedBag);
+    }
+  }
+
+  // Set sessionId if provided
+  if (config.sessionId !== undefined) {
+    newContext = newContext.setValue(LANGFUSE_CTX_SESSION_ID, config.sessionId);
+
+    // Set attribute on currently active span
+    const currentSpan = trace.getActiveSpan();
+    if (currentSpan?.isRecording()) {
+      currentSpan.setAttribute("session.id", config.sessionId);
+    }
+
+    // Set baggage if requested
+    if (options?.asBaggage) {
+      const bag =
+        propagation.getBaggage(newContext) || propagation.createBaggage();
+      const updatedBag = bag.setEntry("session.id", {
+        value: config.sessionId,
+      });
+      newContext = propagation.setBaggage(newContext, updatedBag);
+    }
+  }
+
+  // Set metadata if provided
+  if (
+    config.metadata !== undefined &&
+    Object.keys(config.metadata).length > 0
+  ) {
+    newContext = newContext.setValue(LANGFUSE_CTX_METADATA, config.metadata);
+
+    // Set attributes on currently active span
+    const currentSpan = trace.getActiveSpan();
+    if (currentSpan?.isRecording()) {
+      for (const [key, value] of Object.entries(config.metadata)) {
+        const attrKey = `langfuse.metadata.${key}`;
+        const attrValue =
+          typeof value === "object" && value !== null
+            ? JSON.stringify(value)
+            : value;
+        currentSpan.setAttribute(
+          attrKey,
+          attrValue as string | number | boolean,
+        );
+      }
+    }
+
+    // Set baggage if requested
+    if (options?.asBaggage) {
+      let bag =
+        propagation.getBaggage(newContext) || propagation.createBaggage();
+      for (const [key, value] of Object.entries(config.metadata)) {
+        let strValue = String(value);
+        if (strValue.length > 200) {
+          strValue = strValue.slice(0, 200);
+        }
+
+        bag = bag.setEntry(`langfuse.metadata.${key}`, { value: strValue });
+      }
+      newContext = propagation.setBaggage(newContext, bag);
+    }
+  }
+
+  return context.with(newContext, fn);
+}

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -138,9 +138,7 @@ function createOtelSpan(params: {
  * @returns The created context (either with span context or active context)
  * @internal
  */
-function createParentContext(
-  parentSpanContext?: SpanContext,
-): Context | undefined {
+function createParentContext(parentSpanContext?: SpanContext): Context {
   if (!parentSpanContext) {
     // Use current active context to preserve context propagation values
     // (userId, sessionId, metadata set by withUser/withSession/withMetadata)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> This PR adds context propagation for trace attributes using OpenTelemetry, automating attribute propagation to child spans and deprecating manual trace updates.
> 
>   - **Behavior**:
>     - Introduces context propagation for `userId`, `sessionId`, and `metadata` using OpenTelemetry in `span-processor.ts`.
>     - Deprecates `updateActiveTrace()` in favor of new context propagation methods.
>   - **Functions**:
>     - Adds `withUser`, `withSession`, `withMetadata`, `withContext` in `context.ts` for automatic attribute propagation.
>     - Updates `LangfuseBaseObservation` with instance methods for context propagation.
>   - **Files**:
>     - New `context-keys.ts` for defining OpenTelemetry context keys.
>     - Updates `spanWrapper.ts` to include new context methods.
>     - Comprehensive tests added in `tracing.integration.test.ts` for context propagation scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 3411e7dcb81961608e5b5468e85c4dfe70087d3c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

Updated On: 2025-10-01 06:42:22 UTC

<h3>Summary</h3>
This PR introduces comprehensive context propagation functionality for Langfuse trace attributes (`userId`, `sessionId`, `metadata`) that automatically flow from parent to child spans without manual intervention. The implementation leverages OpenTelemetry's context and baggage mechanisms to ensure trace-level attributes are consistently applied across all nested operations.

The core changes include:

1. **New Context Keys Infrastructure**: A new `context-keys.ts` file in the core package defines OpenTelemetry context keys (`LANGFUSE_CTX_USER_ID`, `LANGFUSE_CTX_SESSION_ID`, `LANGFUSE_CTX_METADATA`) that serve as the foundation for context propagation across packages.

2. **Context Propagation Functions**: Four new functions (`withUser`, `withSession`, `withMetadata`, `withContext`) in the tracing package enable developers to set trace attributes that automatically propagate to child spans within a callback scope. These functions support both local propagation via OpenTelemetry context and cross-service propagation via baggage.

3. **Instance Methods on Observations**: The observation wrapper classes now include instance methods that wrap the standalone context functions, providing a more fluent API for developers working with observation instances.

4. **Automatic Span Processing**: The OpenTelemetry span processor now automatically reads propagated context values and applies them as span attributes during span creation, ensuring consistent trace metadata across all child spans.

5. **Deprecation Path**: The existing `updateActiveTrace()` method is deprecated in favor of the new context propagation approach, with comprehensive migration guidance provided.

This change fundamentally improves the developer experience by eliminating the need to manually set trace attributes on every span, while following OpenTelemetry best practices for context propagation. The implementation includes proper error handling, type safety, security considerations for cross-service propagation, and comprehensive test coverage.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| packages/core/src/context-keys.ts | 5/5 | New file defining OpenTelemetry context keys for trace attribute propagation |
| packages/core/src/index.ts | 5/5 | Added export for context-keys module to expose shared constants |
| packages/core/package.json | 4/5 | Added `@opentelemetry/api` as peer dependency for context key creation |
| packages/tracing/src/context.ts | 4/5 | New comprehensive context propagation utilities with proper error handling |
| packages/tracing/src/spanWrapper.ts | 4/5 | Added context propagation instance methods and deprecated updateTrace |
| packages/tracing/src/index.ts | 4/5 | Modified parent context creation and deprecated updateActiveTrace function |
| packages/otel/src/span-processor.ts | 4/5 | Added automatic context attribute propagation during span creation |
| tests/integration/tracing.integration.test.ts | 5/5 | Comprehensive test coverage for all context propagation scenarios |

</details>

## Confidence score: 4/5

- This PR introduces significant new functionality with proper testing but involves complex context propagation logic that could have edge cases
- Score reflects thorough implementation with good error handling and comprehensive tests, but the complexity of context propagation across multiple packages introduces some risk
- Pay close attention to the span processor changes and context propagation logic, especially the metadata flattening and baggage size limits

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SpanProcessor as "LangfuseSpanProcessor"
    participant Context as "OpenTelemetry Context"
    participant Span as "OpenTelemetry Span"

    User->>SpanProcessor: onStart(span, parentContext)
    Note over SpanProcessor: Add environment and release attributes
    SpanProcessor->>SpanProcessor: propagateContextAttributes(span, parentContext)
    SpanProcessor->>Context: getValue(LANGFUSE_CTX_USER_ID)
    Context-->>SpanProcessor: userId or undefined
    SpanProcessor->>Context: getValue(LANGFUSE_CTX_SESSION_ID)
    Context-->>SpanProcessor: sessionId or undefined
    SpanProcessor->>Context: getValue(LANGFUSE_CTX_METADATA)
    Context-->>SpanProcessor: metadata object or undefined
    
    alt userId exists
        SpanProcessor->>Span: setAttribute(TRACE_USER_ID, userId)
    end
    
    alt sessionId exists
        SpanProcessor->>Span: setAttribute(TRACE_SESSION_ID, sessionId)
    end
    
    alt metadata exists
        loop for each metadata key
            SpanProcessor->>Span: setAttribute("langfuse.metadata.{key}", value)
        end
    end
    
    SpanProcessor->>SpanProcessor: processor.onStart(span, parentContext)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->