### PR TITLE
fix(experiments): set maxConcurrency default to 50

### DIFF
--- a/packages/client/src/experiment/ExperimentManager.ts
+++ b/packages/client/src/experiment/ExperimentManager.ts
@@ -107,7 +107,7 @@ export class ExperimentManager {
    * @param config.task - Function that processes each data item and returns output
    * @param config.evaluators - Optional array of functions to evaluate each item's output
    * @param config.runEvaluators - Optional array of functions to evaluate the entire run
-   * @param config.maxConcurrency - Maximum number of concurrent task executions (default: Infinity)
+   * @param config.maxConcurrency - Maximum number of concurrent task executions (default: 50)
    *
    * @returns Promise that resolves to experiment results including:
    *   - runName: The experiment run name (either provided or generated)
@@ -176,7 +176,7 @@ export class ExperimentManager {
       runName: providedRunName,
       description,
       metadata,
-      maxConcurrency: batchSize = Infinity,
+      maxConcurrency: batchSize = 50,
       runEvaluators,
     } = config;
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default `maxConcurrency` from `Infinity` to `50` in `ExperimentManager` to limit concurrent task execution.
> 
>   - **Behavior**:
>     - Change default `maxConcurrency` from `Infinity` to `50` in `ExperimentManager` class in `ExperimentManager.ts`.
>     - Affects concurrent task execution limit in `run()` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 498ce555b6882ff2df3d3970307e0b538493e438. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

Updated On: 2025-10-22 12:18:22 UTC

<h3>Summary</h3>

Changed the default value of `maxConcurrency` parameter from `Infinity` to `50` in the `ExperimentManager.run()` method. This prevents potential resource exhaustion and API rate limiting issues when running experiments with large datasets.

**Key changes:**
- Updated default parameter value in method signature (line 179)
- Updated JSDoc documentation in `ExperimentManager.ts` (line 110)

**Impact:**
- Users who don't specify `maxConcurrency` will now process at most 50 items concurrently instead of unlimited
- Users can still override this by explicitly setting `maxConcurrency` to a higher value or `Infinity`
- The batching logic remains unchanged - data is sliced into batches and processed sequentially, with each batch running items in parallel

**Issue found:**
- Documentation in `packages/client/src/experiment/types.ts:234` still references the old default value ("default: Infinity") and needs to be updated to match

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk after fixing the documentation inconsistency
- The change is simple and well-tested (test suite includes concurrency tests). Score is 4/5 (not 5) because the documentation in types.ts needs to be updated to reflect the new default value, creating a temporary inconsistency between the implementation and type documentation
- The documentation in `packages/client/src/experiment/types.ts` needs to be updated to match the new default value

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/client/src/experiment/ExperimentManager.ts | 4/5 | Changed `maxConcurrency` default from Infinity to 50 to prevent resource exhaustion, but documentation in types.ts is outdated |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ExperimentManager
    participant TaskBatch
    participant DataItem

    User->>ExperimentManager: run(config)
    Note over ExperimentManager: maxConcurrency default: 50 (previously Infinity)
    ExperimentManager->>ExperimentManager: slice data into batches (size=50)
    
    loop For each batch
        ExperimentManager->>TaskBatch: Process batch (up to 50 items)
        par Parallel execution within batch
            TaskBatch->>DataItem: runItem(item1)
            TaskBatch->>DataItem: runItem(item2)
            TaskBatch->>DataItem: runItem(item3)
            Note over TaskBatch,DataItem: ... up to 50 concurrent items
        end
        TaskBatch-->>ExperimentManager: batch results
    end
    
    ExperimentManager->>ExperimentManager: Execute run evaluators
    ExperimentManager-->>User: ExperimentResult
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->