### PR TITLE
fix(ai-sdk): skip image processing for URLs

### DIFF
--- a/packages/otel/src/MediaService.ts
+++ b/packages/otel/src/MediaService.ts
@@ -126,7 +126,11 @@ export class MediaService {
                     }
 
                     //ImagePart
-                    if (part["image"] != null && part["mediaType"] != null) {
+                    if (
+                      part["image"] != null &&
+                      part["mediaType"] != null &&
+                      !part["image"].startsWith("http") // skip URLs
+                    ) {
                       base64Content = part["image"];
                     }
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Skip image processing for URLs in `MediaService` to prevent unnecessary handling.
> 
>   - **Behavior**:
>     - In `MediaService`, skip processing images that are URLs in the `process()` method.
>     - Specifically, in the AI SDK media handling section, check if `part["image"]` starts with "http" and skip if true.
>   - **Files Affected**:
>     - `MediaService.ts` in the `packages/otel/src` directory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 015972da074645e8533c141cf1605b2fb0e3c75f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

Updated On: 2025-10-22 17:04:04 UTC

<h3>Summary</h3>

Fixed a bug where the AI SDK media processing attempted to process image URLs as base64 data, which would cause errors when calling `base64ToBytes()`.

**Key Changes:**
- Added condition to skip processing when `part["image"]` starts with "http"
- Image URLs are now left as-is in the span data instead of being processed as base64
- Only base64-encoded image data is now passed to `base64ToBytes()`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a targeted bug fix that adds a simple guard condition to prevent runtime errors. The logic is sound - URLs should not be processed as base64 data. The fix follows existing patterns in the codebase and doesn't introduce any breaking changes.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/otel/src/MediaService.ts | 5/5 | Added URL check to skip image processing for HTTP(S) URLs, preventing base64 decoding errors |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SDK as Vercel AI SDK
    participant MS as MediaService
    participant API as LangfuseAPI
    participant Storage as Media Storage

    SDK->>MS: process(span) with ImagePart
    MS->>MS: Check if part["image"] exists
    MS->>MS: Check if part["mediaType"] exists
    
    alt Image is URL (starts with "http")
        MS->>MS: Skip processing (new behavior)
        Note over MS: URL images are not uploaded,<br/>kept as-is in the span
    else Image is base64 data
        MS->>MS: Extract base64Content
        MS->>MS: base64ToBytes(base64Content)
        MS->>MS: Create LangfuseMedia object
        MS->>MS: Generate media tag
        MS->>API: Schedule upload
        MS->>MS: Replace base64 with media tag
        API->>Storage: Upload media content
    end
    
    MS->>SDK: Return processed span
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->