### PR TITLE
fix(tracing): adapt CallbackHandler for langchain v1.1.x

### DIFF
--- a/packages/langchain/src/CallbackHandler.ts
+++ b/packages/langchain/src/CallbackHandler.ts
@@ -128,7 +128,7 @@ export class CallbackHandler extends BaseCallbackHandler {
           Array.isArray(inputs["messages"]) &&
           inputs["messages"].every((m: unknown) => m instanceof BaseMessage)
       ) {
-          finalInput = inputs["messages"].map((m: BaseMessage) => this.extractChatMessageContent(m))
+          finalInput = inputs["messages"].map((m: BaseMessage) => this.extractChatMessageContent(m));
       }
       else if (
         typeof inputs === "object" &&


### PR DESCRIPTION
## Problem

With the recent langchain release v1.1.0 the traces didn't capture Message contents in "Preview-Mode" anymore.
See https://github.com/langfuse/langfuse/issues/8711

## Changes

This adds a check for a `messages` property and produces the desired `role` attribute for rendering the trace preview correctly inside langfuse.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] langfuse
- [ ] langfuse-node

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for langchain v1.1.0

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for capturing message contents in `CallbackHandler` for langchain v1.1.0 by checking for `messages` property.
> 
>   - **Behavior**:
>     - Adds check for `messages` property in `CallbackHandler` in `CallbackHandler.ts` to capture message contents for langchain v1.1.0.
>     - Updates `handleChainStart()` and `handleChainEnd()` to process `messages` array if present.
>   - **Misc**:
>     - Patch-level update for `langfuse` library to support langchain v1.1.0.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for af51228d106642865689ae4f56d60bb8afd02b4c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds support for langchain v1.1.x by handling the new `messages` property in chain inputs and outputs, alongside the existing `input` property from v1.0.x.

- Added check for `inputs["messages"]` in `handleChainStart` to extract message content with proper role attributes
- Added check for `outputs["messages"]` in `handleChainEnd` to transform output messages
- Maintains backward compatibility with existing `input`/`output` property handling
- Minor syntax issue: missing semicolon on line 131

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk after fixing the missing semicolon
- The changes are straightforward and add backward-compatible support for langchain v1.1.x. The logic correctly mirrors the existing pattern for handling `input` arrays. Only minor syntax issue present (missing semicolon) that should be fixed before merging.
- No files require special attention after the semicolon fix

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/langchain/src/CallbackHandler.ts | 4/5 | Added support for langchain v1.1.x `messages` property in chain inputs/outputs; minor syntax issue with missing semicolon |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant LC as Langchain v1.1.x
    participant CH as CallbackHandler
    participant LF as Langfuse

    Note over LC,CH: Chain Start Event
    LC->>CH: handleChainStart(inputs)
    alt inputs has "input" property (v1.0.x)
        CH->>CH: Check inputs["input"] is BaseMessage[]
        CH->>CH: Map to extractChatMessageContent()
    else inputs has "messages" property (v1.1.x)
        CH->>CH: Check inputs["messages"] is BaseMessage[]
        CH->>CH: Map to extractChatMessageContent()
    else inputs has "content" property
        CH->>CH: Use inputs["content"] string
    end
    CH->>LF: Start OTEL span with finalInput

    Note over LC,CH: Chain End Event
    LC->>CH: handleChainEnd(outputs)
    alt outputs has "output" property
        CH->>CH: Use outputs["output"] string
    else outputs has "messages" property (v1.1.x)
        CH->>CH: Check outputs["messages"] is BaseMessage[]
        CH->>CH: Map to extractChatMessageContent()
    end
    CH->>LF: End OTEL span with finalOutput
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->