### PR TITLE
fix(openai): handle usage parsing for legacy completion usage

### DIFF
--- a/packages/openai/src/parseOpenAI.ts
+++ b/packages/openai/src/parseOpenAI.ts
@@ -111,22 +111,36 @@ export const parseUsageDetails = (
       prompt_tokens_details,
     } = completionUsage;
 
+    const flatPromptTokensDetails = Object.fromEntries(
+      Object.entries(prompt_tokens_details ?? {}).map(([key, value]) => [
+        `input_${key}`,
+        value as number,
+      ]),
+    );
+
+    const flatCompletionTokensDetails = Object.fromEntries(
+      Object.entries(completion_tokens_details ?? {}).map(([key, value]) => [
+        `output_${key}`,
+        value as number,
+      ]),
+    );
+
+    let finalInputTokens = prompt_tokens as number;
+    Object.values(flatPromptTokensDetails).forEach((value) => {
+      finalInputTokens = Math.max(finalInputTokens - value, 0);
+    });
+
+    let finalOutputTokens = completion_tokens as number;
+    Object.values(flatCompletionTokensDetails).forEach((value) => {
+      finalOutputTokens = Math.max(finalOutputTokens - value, 0);
+    });
+
     return {
-      input: prompt_tokens,
-      output: completion_tokens,
+      input: finalInputTokens,
+      output: finalOutputTokens,
       total: total_tokens,
-      ...Object.fromEntries(
-        Object.entries(prompt_tokens_details ?? {}).map(([key, value]) => [
-          `input_${key}`,
-          value as number,
-        ]),
-      ),
-      ...Object.fromEntries(
-        Object.entries(completion_tokens_details ?? {}).map(([key, value]) => [
-          `output_${key}`,
-          value as number,
-        ]),
-      ),
+      ...flatPromptTokensDetails,
+      ...flatCompletionTokensDetails,
     };
   } else if ("input_tokens" in completionUsage) {
     const {


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhances `parseUsageDetails` in `parseOpenAI.ts` to correctly handle legacy completion usage by flattening token details and adjusting token counts.
> 
>   - **Behavior**:
>     - Adjusts `parseUsageDetails` in `parseOpenAI.ts` to handle legacy completion usage by flattening `prompt_tokens_details` and `completion_tokens_details`.
>     - Calculates `finalInputTokens` and `finalOutputTokens` by subtracting detailed token counts from total tokens.
>   - **Misc**:
>     - Refactors token detail extraction into `flatPromptTokensDetails` and `flatCompletionTokensDetails` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 399ecf6f5b4895c58a1680ae06c8533f03a50858. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes usage parsing for the legacy OpenAI completion format (`prompt_tokens`/`completion_tokens`) by subtracting detailed token breakdowns from the base token counts, making it consistent with the already-implemented behavior for the newer Response API format (`input_tokens`/`output_tokens`).

- The `parseUsageDetails` function now correctly extracts "base" input/output tokens by subtracting detailed token counts (e.g., `cached_tokens`, `reasoning_tokens`) from the total `prompt_tokens`/`completion_tokens`
- Uses `Math.max(..., 0)` to prevent negative values, matching the existing pattern in the `input_tokens` branch
- The detailed token breakdown is still included in the return object with `input_` and `output_` prefixes

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it fixes a consistency issue in usage parsing with a straightforward implementation
- The change is minimal and follows an existing, well-established pattern already present in the same function for the Response API format. The logic is correct and the implementation is consistent with the existing code.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/openai/src/parseOpenAI.ts | 5/5 | Adds token detail subtraction logic to the legacy completion usage branch (`prompt_tokens` format), making it consistent with the newer Response API branch (`input_tokens` format). The change correctly subtracts detailed token counts from base totals with floor of 0. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant OAI as OpenAI API
    participant Parse as parseUsageDetails
    participant LF as Langfuse

    OAI->>Parse: CompletionUsage {prompt_tokens, completion_tokens, *_details}
    
    alt Legacy format (prompt_tokens)
        Parse->>Parse: Extract prompt_tokens_details → flatPromptTokensDetails
        Parse->>Parse: Extract completion_tokens_details → flatCompletionTokensDetails
        Parse->>Parse: finalInputTokens = prompt_tokens - Σ(prompt_details)
        Parse->>Parse: finalOutputTokens = completion_tokens - Σ(completion_details)
    else Response API format (input_tokens)
        Parse->>Parse: finalInputTokens = input_tokens - Σ(input_details)
        Parse->>Parse: finalOutputTokens = output_tokens - Σ(output_details)
    end
    
    Parse->>LF: {input, output, total, input_*, output_*}
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->