### PR TITLE
fix: send correct headers for self hosted gcs bucket media upload

### DIFF
--- a/packages/otel/src/MediaService.ts
+++ b/packages/otel/src/MediaService.ts
@@ -301,14 +301,22 @@ export class MediaService {
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       try {
+        const isSelfHostedGcsBucket = uploadUrl.includes(
+          "storage.googleapis.com",
+        );
+
+        const headers = isSelfHostedGcsBucket
+          ? { "Content-Type": contentType }
+          : {
+              "Content-Type": contentType,
+              "x-amz-checksum-sha256": contentSha256Hash,
+              "x-ms-blob-type": "BlockBlob",
+            };
+
         const uploadResponse = await fetch(uploadUrl, {
           method: "PUT",
           body: contentBytes,
-          headers: {
-            "Content-Type": contentType,
-            "x-amz-checksum-sha256": contentSha256Hash,
-            "x-ms-blob-type": "BlockBlob",
-          },
+          headers,
         });
 
         if (


### PR DESCRIPTION
## Problem

When using a self hosted deployment, uploading media to a GCS bucket fails as extra headers are added to the fetch request to the presigned URL. This causes signature validation to fail and GCS to reject the upload. This PR may resolve issues experienced by some users in https://github.com/langfuse/langfuse/issues/6504

## Changes

Extra headers are removed when a self-hosted deployment attempts to upload to GCS. This is a port of the changes from https://github.com/langfuse/langfuse-python/pull/1265 into the JS ecosystem

## Release info Sub-libraries affected

### Bump level

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

- [ ] All of them
- [ ] langfuse
- [x] @langfuse/otel

### Changelog notes

- Fixed media uploads to GCS on self-hosted deployments

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes media upload to GCS in self-hosted deployments by adjusting headers in `MediaService.ts`.
> 
>   - **Behavior**:
>     - Fixes media upload to GCS in self-hosted deployments by removing extra headers in `uploadWithBackoff()` in `MediaService.ts`.
>     - Checks if `uploadUrl` includes `storage.googleapis.com` to determine if it's a self-hosted GCS bucket.
>     - Sets headers to only include `Content-Type` for self-hosted GCS buckets, excluding `x-amz-checksum-sha256` and `x-ms-blob-type`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 00a80c6c27dfb81552deceeb4488684381646591. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed media uploads to GCS on self-hosted deployments by conditionally excluding AWS and Azure-specific headers from the presigned URL request.

- Detects GCS upload URLs by checking for `storage.googleapis.com` in the URL
- Sends only `Content-Type` header for GCS uploads (excluding `x-amz-checksum-sha256` and `x-ms-blob-type`)
- Maintains full header set for AWS S3 and Azure Blob Storage uploads
- Matches the fix previously implemented in langfuse-python #1265

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The fix is targeted, well-scoped, and directly addresses a documented issue. It mirrors the proven solution from langfuse-python, uses simple string matching for cloud provider detection, and preserves existing behavior for non-GCS deployments
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/otel/src/MediaService.ts | 5/5 | Conditionally excludes AWS/Azure headers for GCS uploads to fix signature validation failures |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as MediaService
    participant API as LangfuseAPIClient
    participant Storage as Cloud Storage (GCS/S3/Azure)
    
    Client->>API: getUploadUrl(media metadata)
    API-->>Client: uploadUrl, mediaId
    
    alt GCS URL (contains storage.googleapis.com)
        Client->>Storage: PUT with Content-Type only
        Note over Client,Storage: Excludes x-amz-checksum-sha256<br/>and x-ms-blob-type headers
    else AWS S3 or Azure Blob
        Client->>Storage: PUT with all headers
        Note over Client,Storage: Includes Content-Type,<br/>x-amz-checksum-sha256,<br/>x-ms-blob-type
    end
    
    Storage-->>Client: Upload response
    Client->>API: patch(mediaId, upload status)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->