### PR TITLE
fix(media): handle hostname check for GCS

### DIFF
--- a/packages/otel/src/MediaService.ts
+++ b/packages/otel/src/MediaService.ts
@@ -309,7 +309,8 @@ export class MediaService {
           parsedHostname = "";
         }
 
-        const isSelfHostedGcsBucket = parsedHostname === "storage.googleapis.com" ||
+        const isSelfHostedGcsBucket =
+          parsedHostname === "storage.googleapis.com" ||
           parsedHostname.endsWith(".storage.googleapis.com");
 
         const headers = isSelfHostedGcsBucket


### PR DESCRIPTION
Co-authored-by: Copilot Autofix powered by AI <62310815+github-advanced-security[bot]@users.noreply.github.com>
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes URL validation in `MediaService.ts` by parsing hostname instead of substring matching, but remains vulnerable to subdomain attacks.
> 
>   - **Security Fix**:
>     - In `MediaService.ts`, replace `uploadUrl.includes("storage.googleapis.com")` with `new URL(uploadUrl).hostname` for URL parsing.
>     - Add try-catch block to handle invalid URLs in `uploadWithBackoff()`.
>     - Hostname validation checks for `storage.googleapis.com` or subdomains, but remains vulnerable to subdomain attacks.
>   - **Behavior**:
>     - Determines headers for GCS or other cloud storage based on hostname check in `uploadWithBackoff()`.
>     - Logs errors for invalid URLs and upload failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 382d65427474e257da43e5dab3b233030cd3e1bd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed incomplete URL substring sanitization vulnerability by parsing the URL to extract hostname instead of checking the full URL string.

**Key Changes:**
- Replaced `uploadUrl.includes("storage.googleapis.com")` with proper URL parsing using `new URL(uploadUrl).hostname`
- Added try-catch block to handle invalid URLs gracefully
- Hostname check determines whether to send GCS-specific headers or generic cloud storage headers (S3/Azure)

**Issue Found:**
- The fix still uses `.includes()` on the hostname, which remains vulnerable to subdomain attacks. A malicious domain like `evil-storage.googleapis.com` would pass the check but isn't actually a GCS bucket.

<h3>Confidence Score: 3/5</h3>


- PR improves security but incomplete fix still allows subdomain-based attacks
- The change correctly addresses the original vulnerability by parsing URLs instead of substring matching, but the hostname validation using `.includes()` is still vulnerable to subdomain spoofing attacks like `evil-storage.googleapis.com`
- Pay close attention to `packages/otel/src/MediaService.ts` line 312 - the hostname validation logic needs strengthening

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/otel/src/MediaService.ts | 3/5 | Security fix improves URL validation by parsing hostname, but still vulnerable to subdomain attacks like `evil-storage.googleapis.com` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as MediaService
    participant API as Langfuse API
    participant Storage as Cloud Storage (GCS/S3/Azure)
    
    Client->>API: getUploadUrl(contentLength, contentType, sha256Hash)
    API-->>Client: {uploadUrl, mediaId}
    
    Note over Client: Parse uploadUrl to extract hostname
    Client->>Client: new URL(uploadUrl).hostname
    Client->>Client: Check if hostname includes "storage.googleapis.com"
    
    alt Self-hosted GCS bucket
        Client->>Storage: PUT with Content-Type header only
    else S3 or Azure
        Client->>Storage: PUT with Content-Type, x-amz-checksum-sha256, x-ms-blob-type headers
    end
    
    Storage-->>Client: Upload response (200/201)
    Client->>API: patch(mediaId, uploadStatus)
    API-->>Client: Success
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->