### PR TITLE
chore: update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,8 @@
-Copyright (c) 2023 Finto Technologies GmbH
+MIT License
 
+This repository is licensed under the MIT License. Portions of this codebase are derived from posthog/posthog-js-lite by PostHog, which is also licensed under the MIT License.
+
+Copyright (c) 2023-2026 Langfuse GmbH
 Copyright (c) 2022 PostHog (part of Hiberly Inc)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Improve attribution by adding sentence to clarify that portions of this project are derived from posthog/posthog-js-lite.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `LICENSE` to clarify code derivation from `posthog/posthog-js-lite` and update copyright holder.
> 
>   - **License Update**:
>     - Adds a sentence to `LICENSE` clarifying that portions of the codebase are derived from `posthog/posthog-js-lite` by PostHog.
>     - Updates copyright holder to `Langfuse GmbH` for 2023-2026.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 9a5078f321228a42dd72cc6915353901d75c7cfd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>


This PR improves the LICENSE file by adding explicit MIT License identification and a clear attribution statement for code derived from `posthog/posthog-js-lite`. The copyright holder has been updated from "Finto Technologies GmbH" to "Langfuse GmbH" with an extended date range of 2023-2026.

- Added "MIT License" header for clarity
- Added attribution sentence for PostHog-derived code
- Updated copyright holder to Langfuse GmbH
- Extended copyright years to 2023-2026
- Retained PostHog copyright notice

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk - it only improves legal attribution
- This is a documentation-only change to the LICENSE file that improves legal clarity and attribution without affecting any code functionality
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| LICENSE | Updated LICENSE to clarify MIT license and add attribution for PostHog-derived code, updated copyright to Langfuse GmbH 2023-2026 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Author as PR Author
    participant LICENSE as LICENSE File
    participant Repo as Repository
    
    Author->>LICENSE: Add "MIT License" header
    Author->>LICENSE: Add attribution statement for PostHog
    Author->>LICENSE: Update copyright: Finto Technologies → Langfuse GmbH
    Author->>LICENSE: Update copyright years: 2023 → 2023-2026
    LICENSE->>Repo: Improved legal clarity and attribution
    Repo->>Repo: Maintains dual copyright notices
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->