### PR TITLE
fix(core): support fetch option

### DIFF
--- a/packages/client/src/LangfuseClient.ts
+++ b/packages/client/src/LangfuseClient.ts
@@ -49,6 +49,24 @@ export interface LangfuseClientParams {
    * Additional HTTP headers to include with API requests.
    */
   additionalHeaders?: Record<string, string>;
+
+  /**
+   * Custom fetch function to use for HTTP requests.
+   * Useful for testing, proxying, or customizing request behavior.
+   *
+   * @example
+   * ```typescript
+   * const customFetch = async (url, init) => {
+   *   console.log('Making request to:', url);
+   *   return fetch(url, init);
+   * };
+   *
+   * const langfuse = new LangfuseClient({
+   *   fetch: customFetch
+   * });
+   * ```
+   */
+  fetch?: typeof fetch;
 }
 
 /**
@@ -284,6 +302,7 @@ export class LangfuseClient {
       xLangfuseSdkName: "javascript",
       environment: "", // noop as baseUrl is set
       headers: params?.additionalHeaders,
+      fetch: params?.fetch,
     });
 
     logger.debug("Initialized LangfuseClient with params:", {

--- a/packages/core/src/api/Client.ts
+++ b/packages/core/src/api/Client.ts
@@ -49,6 +49,8 @@ export declare namespace LangfuseAPIClient {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {

--- a/packages/core/src/api/api/resources/annotationQueues/client/Client.ts
+++ b/packages/core/src/api/api/resources/annotationQueues/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace AnnotationQueues {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -131,6 +133,7 @@ export class AnnotationQueues {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -259,6 +262,7 @@ export class AnnotationQueues {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -380,6 +384,7 @@ export class AnnotationQueues {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -521,6 +526,7 @@ export class AnnotationQueues {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -645,6 +651,7 @@ export class AnnotationQueues {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -776,6 +783,7 @@ export class AnnotationQueues {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -908,6 +916,7 @@ export class AnnotationQueues {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -1034,6 +1043,7 @@ export class AnnotationQueues {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -1165,6 +1175,7 @@ export class AnnotationQueues {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -1296,6 +1307,7 @@ export class AnnotationQueues {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/blobStorageIntegrations/client/Client.ts
+++ b/packages/core/src/api/api/resources/blobStorageIntegrations/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace BlobStorageIntegrations {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -117,6 +119,7 @@ export class BlobStorageIntegrations {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -256,6 +259,7 @@ export class BlobStorageIntegrations {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -379,6 +383,7 @@ export class BlobStorageIntegrations {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/comments/client/Client.ts
+++ b/packages/core/src/api/api/resources/comments/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace Comments {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -127,6 +129,7 @@ export class Comments {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -273,6 +276,7 @@ export class Comments {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -394,6 +398,7 @@ export class Comments {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/datasetItems/client/Client.ts
+++ b/packages/core/src/api/api/resources/datasetItems/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace DatasetItems {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -130,6 +132,7 @@ export class DatasetItems {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -249,6 +252,7 @@ export class DatasetItems {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -396,6 +400,7 @@ export class DatasetItems {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -517,6 +522,7 @@ export class DatasetItems {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/datasetRunItems/client/Client.ts
+++ b/packages/core/src/api/api/resources/datasetRunItems/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace DatasetRunItems {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -128,6 +130,7 @@ export class DatasetRunItems {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -267,6 +270,7 @@ export class DatasetRunItems {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/datasets/client/Client.ts
+++ b/packages/core/src/api/api/resources/datasets/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace Datasets {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -131,6 +133,7 @@ export class Datasets {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -252,6 +255,7 @@ export class Datasets {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -382,6 +386,7 @@ export class Datasets {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -506,6 +511,7 @@ export class Datasets {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -630,6 +636,7 @@ export class Datasets {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -767,6 +774,7 @@ export class Datasets {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/health/client/Client.ts
+++ b/packages/core/src/api/api/resources/health/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace Health {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -114,6 +116,7 @@ export class Health {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/ingestion/client/Client.ts
+++ b/packages/core/src/api/api/resources/ingestion/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace Ingestion {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -187,6 +189,7 @@ export class Ingestion {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/llmConnections/client/Client.ts
+++ b/packages/core/src/api/api/resources/llmConnections/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace LlmConnections {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -131,6 +133,7 @@ export class LlmConnections {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -264,6 +267,7 @@ export class LlmConnections {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/media/client/Client.ts
+++ b/packages/core/src/api/api/resources/media/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace Media {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -118,6 +120,7 @@ export class Media {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -250,6 +253,7 @@ export class Media {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return { data: undefined, rawResponse: _response.rawResponse };
@@ -378,6 +382,7 @@ export class Media {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/metrics/client/Client.ts
+++ b/packages/core/src/api/api/resources/metrics/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace Metrics {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -130,6 +132,7 @@ export class Metrics {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/metricsV2/client/Client.ts
+++ b/packages/core/src/api/api/resources/metricsV2/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace MetricsV2 {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -226,6 +228,7 @@ export class MetricsV2 {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/models/client/Client.ts
+++ b/packages/core/src/api/api/resources/models/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace Models {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -132,6 +134,7 @@ export class Models {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -266,6 +269,7 @@ export class Models {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -385,6 +389,7 @@ export class Models {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -506,6 +511,7 @@ export class Models {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return { data: undefined, rawResponse: _response.rawResponse };

--- a/packages/core/src/api/api/resources/observations/client/Client.ts
+++ b/packages/core/src/api/api/resources/observations/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace Observations {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -118,6 +120,7 @@ export class Observations {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -316,6 +319,7 @@ export class Observations {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/observationsV2/client/Client.ts
+++ b/packages/core/src/api/api/resources/observationsV2/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace ObservationsV2 {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -231,6 +233,7 @@ export class ObservationsV2 {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/opentelemetry/client/Client.ts
+++ b/packages/core/src/api/api/resources/opentelemetry/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace Opentelemetry {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -173,6 +175,7 @@ export class Opentelemetry {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/organizations/client/Client.ts
+++ b/packages/core/src/api/api/resources/organizations/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace Organizations {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -115,6 +117,7 @@ export class Organizations {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -242,6 +245,7 @@ export class Organizations {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -368,6 +372,7 @@ export class Organizations {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -489,6 +494,7 @@ export class Organizations {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -619,6 +625,7 @@ export class Organizations {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -748,6 +755,7 @@ export class Organizations {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -866,6 +874,7 @@ export class Organizations {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -984,6 +993,7 @@ export class Organizations {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/projects/client/Client.ts
+++ b/packages/core/src/api/api/resources/projects/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace Projects {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -113,6 +115,7 @@ export class Projects {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -241,6 +244,7 @@ export class Projects {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -372,6 +376,7 @@ export class Projects {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -493,6 +498,7 @@ export class Projects {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -614,6 +620,7 @@ export class Projects {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -745,6 +752,7 @@ export class Projects {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -869,6 +877,7 @@ export class Projects {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/promptVersion/client/Client.ts
+++ b/packages/core/src/api/api/resources/promptVersion/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace PromptVersion {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -130,6 +132,7 @@ export class PromptVersion {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/prompts/client/Client.ts
+++ b/packages/core/src/api/api/resources/prompts/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace Prompts {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -135,6 +137,7 @@ export class Prompts {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -290,6 +293,7 @@ export class Prompts {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -430,6 +434,7 @@ export class Prompts {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -567,6 +572,7 @@ export class Prompts {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return { data: undefined, rawResponse: _response.rawResponse };

--- a/packages/core/src/api/api/resources/scim/client/Client.ts
+++ b/packages/core/src/api/api/resources/scim/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace Scim {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -115,6 +117,7 @@ export class Scim {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -233,6 +236,7 @@ export class Scim {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -351,6 +355,7 @@ export class Scim {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -489,6 +494,7 @@ export class Scim {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -621,6 +627,7 @@ export class Scim {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -742,6 +749,7 @@ export class Scim {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -863,6 +871,7 @@ export class Scim {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/score/client/Client.ts
+++ b/packages/core/src/api/api/resources/score/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace Score {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -135,6 +137,7 @@ export class Score {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -256,6 +259,7 @@ export class Score {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return { data: undefined, rawResponse: _response.rawResponse };

--- a/packages/core/src/api/api/resources/scoreConfigs/client/Client.ts
+++ b/packages/core/src/api/api/resources/scoreConfigs/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace ScoreConfigs {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -128,6 +130,7 @@ export class ScoreConfigs {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -262,6 +265,7 @@ export class ScoreConfigs {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -383,6 +387,7 @@ export class ScoreConfigs {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -517,6 +522,7 @@ export class ScoreConfigs {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/scoreV2/client/Client.ts
+++ b/packages/core/src/api/api/resources/scoreV2/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace ScoreV2 {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -227,6 +229,7 @@ export class ScoreV2 {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -348,6 +351,7 @@ export class ScoreV2 {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/sessions/client/Client.ts
+++ b/packages/core/src/api/api/resources/sessions/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace Sessions {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -147,6 +149,7 @@ export class Sessions {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -268,6 +271,7 @@ export class Sessions {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/api/resources/trace/client/Client.ts
+++ b/packages/core/src/api/api/resources/trace/client/Client.ts
@@ -28,6 +28,8 @@ export declare namespace Trace {
       string,
       string | core.Supplier<string | null | undefined> | null | undefined
     >;
+    /** Custom fetch function to use for HTTP requests */
+    fetch?: typeof fetch;
   }
 
   export interface RequestOptions {
@@ -118,6 +120,7 @@ export class Trace {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -239,6 +242,7 @@ export class Trace {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -444,6 +448,7 @@ export class Trace {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {
@@ -570,6 +575,7 @@ export class Trace {
           : 60000,
       maxRetries: requestOptions?.maxRetries,
       abortSignal: requestOptions?.abortSignal,
+      fetch: this._options.fetch,
     });
     if (_response.ok) {
       return {

--- a/packages/core/src/api/core/fetcher/Fetcher.ts
+++ b/packages/core/src/api/core/fetcher/Fetcher.ts
@@ -43,6 +43,7 @@ export declare namespace Fetcher {
       | "arrayBuffer"
       | "binary-response";
     duplex?: "half";
+    fetch?: typeof fetch;
   }
 
   export type Error =
@@ -105,7 +106,7 @@ export async function fetcherImpl<R = unknown>(
     body: args.body,
     type: args.requestType === "json" ? "json" : "other",
   });
-  const fetchFn = await getFetchFn();
+  const fetchFn = args.fetch ?? (await getFetchFn());
 
   try {
     const response = await requestWithRetries(


### PR DESCRIPTION
## Problem

Self-hosted developers need to customize HTTP request behavior for testing, proxying, logging, or using custom fetch implementations (e.g., in specific environments or with custom headers/interceptors). Currently, there's no way to inject a custom fetch function into the Langfuse client.

## Changes

Added support for custom fetch functions throughout the Langfuse SDK:

1. New fetch option in LangfuseClientParams: Users can now pass a custom fetch function when initializing LangfuseClient
2. Type-safe implementation: Added fetch?: typeof fetch to all Options interfaces across the codebase without using any casts
3. Propagation through the stack: The custom fetch function is properly passed from LangfuseClient → LangfuseAPIClient → all 26 resource clients → core.fetcher

Example usage:
```
const customFetch = async (input, init) => {
  console.log('Making request to:', input);
  return fetch(input, init);
};

const langfuse = new LangfuseClient({
  publicKey: "pk_...",
  secretKey: "sk_...",
  fetch: customFetch,
});
```

## Release info Sub-libraries affected

### Bump level

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

- [ ] All of them
- [ ] langfuse
- [ ] langfuse-node

### Changelog notes

- Added support for custom fetch functions via the fetch option in LangfuseClientParams, enabling request customization for testing, proxying, and logging use cases

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>


This PR adds support for custom `fetch` functions throughout the Langfuse SDK, enabling users to inject custom HTTP request behavior for testing, proxying, logging, or using alternative fetch implementations.

**Key changes:**
- Added `fetch?: typeof fetch` option to `LangfuseClientParams` interface with clear documentation and example usage
- Properly propagated the custom fetch function through the entire call chain: `LangfuseClient` → `LangfuseAPIClient` → all 26 resource clients → `core.fetcher`
- Implemented type-safe fallback logic in `Fetcher.ts`: uses custom fetch if provided, otherwise falls back to `getFetchFn()`
- Maintained consistency across all resource clients with identical implementation pattern

**Implementation quality:**
- Type safety is maintained throughout with `typeof fetch` (no `any` casts)
- All 26 resource clients were updated uniformly
- The feature is additive and backward compatible (optional parameter)
- Documentation includes practical example showing the use case

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The implementation is clean, type-safe, and follows a consistent pattern across all 29 files. The change is purely additive (optional parameter), maintains backward compatibility, and uses proper TypeScript typing with `typeof fetch`. All 26 resource clients were updated uniformly with the same pattern, showing thorough and systematic implementation. The fallback logic is simple and correct.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/client/src/LangfuseClient.ts | Added fetch option to LangfuseClientParams interface with proper documentation and passed it to LangfuseAPIClient constructor |
| packages/core/src/api/Client.ts | Added fetch option to LangfuseAPIClient.Options interface with documentation, properly typed as typeof fetch |
| packages/core/src/api/core/fetcher/Fetcher.ts | Added fetch option to Fetcher.Args interface and implemented fallback logic to use custom fetch or default getFetchFn() |
| packages/core/src/api/api/resources/health/client/Client.ts | Added fetch option to Health.Options interface and propagated this._options.fetch to core.fetcher calls |
| packages/core/src/api/api/resources/prompts/client/Client.ts | Added fetch option to Prompts.Options interface and propagated to all 4 method calls (list, get, create, update) |
| packages/core/src/api/api/resources/ingestion/client/Client.ts | Added fetch option to Ingestion.Options interface and propagated to batch method's core.fetcher call |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant LangfuseClient
    participant LangfuseAPIClient
    participant ResourceClient
    participant Fetcher
    participant CustomFetch

    User->>LangfuseClient: new LangfuseClient({fetch: customFetch})
    LangfuseClient->>LangfuseAPIClient: new LangfuseAPIClient({fetch: customFetch})
    LangfuseAPIClient->>LangfuseAPIClient: Store fetch in _options
    
    User->>LangfuseClient: api.prompts.list()
    LangfuseClient->>ResourceClient: prompts.list()
    ResourceClient->>Fetcher: core.fetcher({fetch: this._options.fetch})
    
    alt Custom fetch provided
        Fetcher->>CustomFetch: Use args.fetch
        CustomFetch-->>Fetcher: Response
    else No custom fetch
        Fetcher->>Fetcher: Use getFetchFn() (default)
        Fetcher-->>Fetcher: Response
    end
    
    Fetcher-->>ResourceClient: API Response
    ResourceClient-->>LangfuseClient: Data
    LangfuseClient-->>User: Result
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->