### PR TITLE
fix: move logger.debug with JSON stringify under if debug

### DIFF
--- a/packages/client/src/score/index.ts
+++ b/packages/client/src/score/index.ts
@@ -5,6 +5,7 @@ import {
   generateUUID,
   ScoreBody,
   getGlobalLogger,
+  LogLevel,
   safeSetTimeout,
   IngestionResponse,
 } from "@langfuse/core";
@@ -93,10 +94,12 @@ export class ScoreManager {
     }
 
     this.eventQueue.push(scoreIngestionEvent);
-    this.logger.debug(
-      "Added score event to queue:\n",
-      JSON.stringify(scoreIngestionEvent, null, 2),
-    );
+    if (this.logger.isLevelEnabled(LogLevel.DEBUG)) {
+      this.logger.debug(
+        "Added score event to queue:\n",
+        JSON.stringify(scoreIngestionEvent, null, 2),
+      );
+    }
 
     if (this.eventQueue.length >= this.flushAtCount) {
       this.flushPromise = this.flush();

--- a/packages/core/src/logger/index.ts
+++ b/packages/core/src/logger/index.ts
@@ -163,6 +163,24 @@ export class Logger {
   getLevel(): LogLevel {
     return this.config.level;
   }
+
+  /**
+   * Checks if a given log level is enabled.
+   * Use this to guard expensive operations (like JSON.stringify) before debug logging.
+   *
+   * @param level - The log level to check
+   * @returns True if the level is enabled, false otherwise
+   *
+   * @example
+   * ```typescript
+   * if (logger.isLevelEnabled(LogLevel.DEBUG)) {
+   *   logger.debug('Expensive data:', JSON.stringify(largeObject));
+   * }
+   * ```
+   */
+  isLevelEnabled(level: LogLevel): boolean {
+    return this.shouldLog(level);
+  }
 }
 
 /**

--- a/packages/otel/src/span-processor.ts
+++ b/packages/otel/src/span-processor.ts
@@ -1,5 +1,6 @@
 import {
   Logger,
+  LogLevel,
   getGlobalLogger,
   LangfuseAPIClient,
   LANGFUSE_SDK_VERSION,
@@ -398,26 +399,28 @@ export class LangfuseSpanProcessor implements SpanProcessor {
     this.applyMaskInPlace(span);
     await this.mediaService.process(span);
 
-    this.logger.debug(
-      `Processed span:\n${JSON.stringify(
-        {
-          name: span.name,
-          traceId: span.spanContext().traceId,
-          spanId: span.spanContext().spanId,
-          parentSpanId: span.parentSpanContext?.spanId ?? null,
-          attributes: span.attributes,
-          startTime: new Date(hrTimeToMilliseconds(span.startTime)),
-          endTime: new Date(hrTimeToMilliseconds(span.endTime)),
-          durationMs: hrTimeToMilliseconds(span.duration),
-          kind: span.kind,
-          status: span.status,
-          resource: span.resource.attributes,
-          instrumentationScope: span.instrumentationScope,
-        },
-        null,
-        2,
-      )}`,
-    );
+    if (this.logger.isLevelEnabled(LogLevel.DEBUG)) {
+      this.logger.debug(
+        `Processed span:\n${JSON.stringify(
+          {
+            name: span.name,
+            traceId: span.spanContext().traceId,
+            spanId: span.spanContext().spanId,
+            parentSpanId: span.parentSpanContext?.spanId ?? null,
+            attributes: span.attributes,
+            startTime: new Date(hrTimeToMilliseconds(span.startTime)),
+            endTime: new Date(hrTimeToMilliseconds(span.endTime)),
+            durationMs: hrTimeToMilliseconds(span.duration),
+            kind: span.kind,
+            status: span.status,
+            resource: span.resource.attributes,
+            instrumentationScope: span.instrumentationScope,
+          },
+          null,
+          2,
+        )}`,
+      );
+    }
 
     this.processor.onEnd(span);
   }


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize logging by conditionally executing `JSON.stringify` in debug logs based on log level in `score/index.ts` and `span-processor.ts`.
> 
>   - **Behavior**:
>     - Move `logger.debug` calls with `JSON.stringify` under `if` condition checking `isLevelEnabled(LogLevel.DEBUG)` in `score/index.ts` and `span-processor.ts`.
>   - **Logger**:
>     - Add `isLevelEnabled(level: LogLevel): boolean` method to `Logger` class in `logger/index.ts` to check if a log level is enabled.
>   - **Misc**:
>     - Import `LogLevel` in `score/index.ts` and `span-processor.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 9074c705acb44a9428145bb540bd3684fd007f51. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Optimized debug logging performance by conditionally executing `JSON.stringify` operations only when DEBUG level logging is enabled.

- Added `isLevelEnabled(level: LogLevel)` method to the `Logger` class to expose log level checking for performance optimization
- Wrapped `JSON.stringify` calls in `score/index.ts` and `span-processor.ts` with `isLevelEnabled(LogLevel.DEBUG)` guards
- Prevents expensive serialization operations when debug logging is disabled, improving runtime performance in production environments

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are a well-implemented performance optimization with clear benefits and no logical errors. The new `isLevelEnabled()` method correctly delegates to the existing private `shouldLog()` method, maintaining consistency. All usages properly guard expensive `JSON.stringify` operations, and the implementation follows existing patterns in the codebase.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/src/logger/index.ts | Added `isLevelEnabled()` method to expose log level checking for performance optimization |
| packages/client/src/score/index.ts | Wrapped expensive `JSON.stringify` in debug log under `isLevelEnabled` check for performance |
| packages/otel/src/span-processor.ts | Wrapped expensive `JSON.stringify` in debug log under `isLevelEnabled` check for performance |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application Code
    participant SM as ScoreManager/SpanProcessor
    participant Logger as Logger Instance
    participant Console as Console Output

    App->>SM: create() or processEndedSpan()
    SM->>Logger: isLevelEnabled(LogLevel.DEBUG)
    Logger->>Logger: Check if DEBUG >= config.level
    
    alt DEBUG is enabled
        Logger-->>SM: true
        SM->>SM: Execute JSON.stringify(largeObject)
        SM->>Logger: debug(message, stringifiedData)
        Logger->>Logger: shouldLog(DEBUG)
        Logger->>Console: console.debug(formatted message)
    else DEBUG is disabled
        Logger-->>SM: false
        Note over SM: Skip JSON.stringify - performance saved!
        SM->>SM: Continue execution
    end
```

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->