### PR TITLE
feat: add progress bar to experiments

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -41,6 +41,10 @@
     "@opentelemetry/api": "^1.9.0"
   },
   "devDependencies": {
-    "@types/mustache": "^4.2.6"
+    "@types/mustache": "^4.2.6",
+    "@types/progress": "^2.0.7"
+  },
+  "optionalDependencies": {
+    "progress": "^2.0.3"
   }
 }

--- a/packages/client/src/experiment/ExperimentManager.ts
+++ b/packages/client/src/experiment/ExperimentManager.ts
@@ -211,17 +211,23 @@ export class ExperimentManager {
       data.length > 0 &&
       (process.stderr?.isTTY === true || progressOption === true);
     if (canShowBar) {
-      const Progress = (await import("progress")).default as new (
-        format: string,
-        options: { total: number; stream: NodeJS.WritableStream },
-      ) => { tick: (n?: number) => void };
-      progressBar = new Progress(
-        "Experiment [:bar] :current/:total :percent :eta",
-        {
-          total: data.length,
-          stream: process.stderr,
-        },
-      );
+    if (canShowBar) {
+      try {
+        const Progress = (await import("progress")).default as new (
+          format: string,
+          options: { total: number; stream: NodeJS.WritableStream },
+        ) => { tick: (n?: number) => void };
+        progressBar = new Progress(
+          "Experiment [:bar] :current/:total :percent :eta",
+          {
+            total: data.length,
+            stream: process.stderr,
+          },
+        );
+      } catch (error) {
+        // Progress module not available, continue without progress bar
+      }
+    }
     }
 
     const itemResults: ExperimentItemResult<Input, ExpectedOutput, Metadata>[] =

--- a/packages/client/src/experiment/types.ts
+++ b/packages/client/src/experiment/types.ts
@@ -237,6 +237,14 @@ export type ExperimentParams<
    * Set lower values for expensive operations or rate-limited services.
    */
   maxConcurrency?: number;
+
+  /**
+   * Whether to show a terminal progress bar (tqdm-style) when running in Node with a TTY.
+   *
+   * Default: true when stderr is a TTY, false otherwise (e.g. browser, CI, piped output).
+   * Set to false to disable the bar.
+   */
+  progress?: boolean;
 };
 
 export type ExperimentItemResult<

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,10 +134,17 @@ importers:
       mustache:
         specifier: ^4.2.0
         version: 4.2.0
+    optionalDependencies:
+      progress:
+        specifier: ^2.0.3
+        version: 2.0.3
     devDependencies:
       '@types/mustache':
         specifier: ^4.2.6
         version: 4.2.6
+      '@types/progress':
+        specifier: ^2.0.7
+        version: 2.0.7
 
   packages/core:
     dependencies:
@@ -1115,6 +1122,9 @@ packages:
   '@types/parse-path@7.1.0':
     resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
     deprecated: This is a stub types definition. parse-path provides its own type definitions, so you do not need this installed.
+
+  '@types/progress@2.0.7':
+    resolution: {integrity: sha512-iadjw02vte8qWx7U0YM++EybBha2CQLPGu9iJ97whVgJUT5Zq9MjAPYUnbfRI2Kpehimf1QjFJYxD0t8nqzu5w==}
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
@@ -2832,6 +2842,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   protobufjs@7.5.3:
     resolution: {integrity: sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==}
     engines: {node: '>=12.0.0'}
@@ -4401,6 +4415,10 @@ snapshots:
   '@types/parse-path@7.1.0':
     dependencies:
       parse-path: 7.1.0
+
+  '@types/progress@2.0.7':
+    dependencies:
+      '@types/node': 24.7.2
 
   '@types/retry@0.12.0': {}
 
@@ -6311,6 +6329,9 @@ snapshots:
       fast-diff: 1.3.0
 
   prettier@3.6.2: {}
+
+  progress@2.0.3:
+    optional: true
 
   protobufjs@7.5.3:
     dependencies:

--- a/tests/e2e/experiments.e2e.test.ts
+++ b/tests/e2e/experiments.e2e.test.ts
@@ -370,6 +370,42 @@ describe("Langfuse Datasets E2E", () => {
     expect(result.datasetRunId).toBeUndefined();
   });
 
+  describe("Progress bar", () => {
+    it("should run experiment with progress: false (no bar)", async () => {
+      const result = await langfuse.experiment.run({
+        name: "Progress disabled",
+        description: "Experiment with progress bar disabled",
+        data: dataset.slice(0, 2),
+        task,
+        evaluators: [createEvaluatorFromAutoevals(Factuality)],
+        progress: false,
+      });
+
+      await testEnv.spanProcessor.forceFlush();
+      await waitForServerIngestion(1000);
+
+      expect(result.itemResults).toHaveLength(2);
+      expect(result.runName).toContain("Progress disabled");
+    });
+
+    it("should run experiment with progress: true (bar when TTY)", async () => {
+      const result = await langfuse.experiment.run({
+        name: "Progress enabled",
+        description: "Experiment with progress bar enabled",
+        data: dataset.slice(0, 2),
+        task,
+        evaluators: [createEvaluatorFromAutoevals(Factuality)],
+        progress: true,
+      });
+
+      await testEnv.spanProcessor.forceFlush();
+      await waitForServerIngestion(1000);
+
+      expect(result.itemResults).toHaveLength(2);
+      expect(result.runName).toContain("Progress enabled");
+    });
+  });
+
   // Error Handling Tests
   describe("Error Handling", () => {
     it("should handle evaluator failures gracefully", async () => {


### PR DESCRIPTION
## Problem

When running experiments with many items, developers have no feedback on progress or estimated time. A progress bar has been requested in [langfuse/langfuse#11718](https://github.com/orgs/langfuse/discussions/11718) so we can see:

- how many items have been processed
- percentage complete
- estimated time remaining

## Changes

- Progress bar: TTY-style progress bar for experiment runs in Node.js when stderr is a TTY (e.g. Experiment [:bar] :current/:total :percent :eta)
- progress option: `new experiment.run({ progress?: boolean })` to control behavior
- Optional dependency: progress is in `optionalDependencies` so it doesn’t block browser or edge usage. If the import fails, the experiment runs without the bar.
- Tests: E2E tests for progress: true and progress: false in `tests/e2e/experiments.e2e.test.ts`
<img width="1504" height="1114" alt="CleanShot 2026-02-12 at 20 08 22@2x" src="https://github.com/user-attachments/assets/d7c86e20-6608-4ff2-b056-1300c0d3ff68" />
 

## Release info Sub-libraries affected

### Bump level

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

- [ ] All of them
- [ ] langfuse
- [ ] langfuse-node

### Changelog notes

- experiment: Added optional progress bar for experiment runs in Node.js with a TTY. Use progress: true to show it even when not a TTY, or progress: false to disable it.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds optional TTY-style progress bar for experiment runs in Node.js with a `progress` option in `ExperimentParams` and tests for its functionality.
> 
>   - **Behavior**:
>     - Adds a TTY-style progress bar for experiment runs in Node.js when stderr is a TTY, using `progress` package.
>     - Introduces `progress` option in `ExperimentParams` to control progress bar visibility.
>     - Progress bar updates after each item completes in `ExperimentManager.run()`.
>   - **Dependencies**:
>     - Adds `progress` as an `optionalDependency` in `package.json`.
>     - Adds `@types/progress` as a `devDependency`.
>   - **Error Handling**:
>     - Implements try-catch for dynamic import of `progress` in `ExperimentManager.ts`.
>   - **Tests**:
>     - Adds E2E tests for progress bar enabled/disabled states in `experiments.e2e.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for 96c98f311c3d2f4bdf1f0d024afb1ea206a68d91. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an optional TTY-style progress bar for experiment runs in Node.js. The implementation uses the `progress` package as an optional dependency to avoid blocking browser or edge environments. The progress bar displays current/total items, percentage, and ETA during experiment execution.

**Critical Issues:**
- Duplicate `if (canShowBar)` statement on lines 213-214 creates a syntax error
- Extra closing brace on line 231 due to the duplicate if statement
- Dynamic import of `progress` module violates the project's style guideline requiring imports at module top

**Approach:**
- Progress bar defaults to showing when stderr is a TTY, can be controlled via `progress` option
- Optional dependency pattern ensures graceful degradation when module is unavailable
- Tests added for both enabled and disabled states

<h3>Confidence Score: 2/5</h3>

- This PR has critical syntax errors that will prevent it from compiling or running correctly
- The duplicate if statement and extra closing brace create syntax errors that must be fixed before merging. Additionally, the dynamic import pattern violates the project's style guidelines.
- Pay close attention to `packages/client/src/experiment/ExperimentManager.ts` - contains duplicate conditional and extra brace causing syntax errors

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/client/src/experiment/ExperimentManager.ts | Added progress bar with duplicate if statement and extra closing brace causing syntax errors; dynamic import violates style guide |
| packages/client/src/experiment/types.ts | Added `progress` parameter with clear documentation |
| packages/client/package.json | Added `progress` as optional dependency and `@types/progress` as dev dependency |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ExperimentManager
    participant ProgressBar
    participant Task

    User->>ExperimentManager: run(config with progress option)
    ExperimentManager->>ExperimentManager: Check progressOption & TTY
    alt canShowBar is true
        ExperimentManager->>ProgressBar: import("progress")
        ProgressBar-->>ExperimentManager: Progress constructor
        ExperimentManager->>ProgressBar: new Progress(format, options)
    end
    
    loop For each batch
        loop For each item in batch
            ExperimentManager->>Task: runItem(item)
            Task-->>ExperimentManager: result
            ExperimentManager->>ProgressBar: tick(1)
        end
    end
    
    ExperimentManager-->>User: ExperimentResult
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Move imports to the top of the module instead of placing them within functions or methods. ([source](https://app.greptile.com/review/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

<!-- /greptile_comment -->