### PR TITLE
fix(otel): skip base64 decode for URL-based FilePart data in AI SDK
   media handling

### DIFF
--- a/packages/otel/src/MediaService.ts
+++ b/packages/otel/src/MediaService.ts
@@ -121,7 +121,12 @@ export class MediaService {
                   if (part["type"] === "file") {
                     let base64Content: string | null = null;
                     // FilePart
-                    if (part["data"] != null && part["mediaType"] != null) {
+                    if (
+                      part["data"] != null &&
+                      part["mediaType"] != null &&
+                      typeof part["data"] !== "object" && // skip URL instances
+                      !String(part["data"]).startsWith("http") // skip URL strings
+                    ) {
                       base64Content = part["data"];
                     }
 


### PR DESCRIPTION
## Summary                                              
                                                                                
  Fixes langfuse/langfuse#12268                                                 
                                                                                
  When using the Vercel AI SDK with URL-based file attachments, `FilePart.data` 
  can be a URL string rather than base64 content. The handler was               
  unconditionally treating it as base64, causing `InvalidCharacterError`
  warnings.

  The `ImagePart` handler already had this guard
  (`!part["image"].startsWith("http")`). This PR applies the same pattern to
  `FilePart`.

  ## Changes

  - `packages/otel/src/MediaService.ts`: Added URL checks for `FilePart.data`
  before base64 decode — skips both `URL` object instances and http/https
  strings
  EOF

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `InvalidCharacterError` by skipping base64 decode for URL-based `FilePart.data` in `MediaService.ts`.
> 
>   - **Behavior**:
>     - In `MediaService.ts`, skip base64 decoding for `FilePart.data` if it is a URL object or starts with "http".
>     - Fixes `InvalidCharacterError` warnings when handling URL-based file attachments in Vercel AI SDK.
>   - **Misc**:
>     - Aligns `FilePart` handling with existing `ImagePart` logic for URL checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-js&utm_source=github&utm_medium=referral)<sup> for b7e073c702c3fa0bad9f8d407aa6080ca6e15560. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

Fixes `InvalidCharacterError` by skipping base64 decode for URL-based `FilePart.data` in Vercel AI SDK integration.

- Added two guards before attempting base64 decode: checks for URL object instances (`typeof !== "object"`) and URL strings (`!startsWith("http")`)
- Aligns `FilePart` handling with existing `ImagePart` logic that already had URL string checks
- Prevents runtime errors when `FilePart.data` contains URLs instead of base64 content

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a targeted bug fix that adds defensive checks to prevent attempting base64 decode on URL data. The logic mirrors existing patterns in the codebase for `ImagePart` handling, and the two-layer check (object type + http prefix) ensures comprehensive URL detection.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/otel/src/MediaService.ts | Added URL checks before base64 decode for `FilePart.data` to prevent `InvalidCharacterError` when handling URL-based file attachments |

</details>



<sub>Last reviewed commit: b7e073c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->