### PR TITLE
feat(openai): expose observation and trace IDs from observeOpenAI

### DIFF
--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -1,2 +1,3 @@
 export { observeOpenAI } from "./observeOpenAI.js";
 export * from "./types.js";
+export type { WithLangfuseIds } from "./langfuseIds.js";

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -1,3 +1,31 @@
 export { observeOpenAI } from "./observeOpenAI.js";
 export * from "./types.js";
 export type { WithLangfuseIds } from "./langfuseIds.js";
+
+/**
+ * Module augmentation for OpenAI SDK response types.
+ *
+ * When `observeOpenAI` wraps a client, all response objects are augmented
+ * with Langfuse observation and trace IDs at runtime. These declarations
+ * make TypeScript aware of those properties so consumers don't need casts.
+ *
+ * The properties are marked optional because the base OpenAI types are also
+ * used without `observeOpenAI`.
+ */
+declare module "openai/resources/chat/completions/completions" {
+  interface ChatCompletion {
+    /** Langfuse observation ID — present when the client is wrapped with `observeOpenAI` */
+    langfuseObservationId?: string;
+    /** Langfuse trace ID — present when the client is wrapped with `observeOpenAI` */
+    langfuseTraceId?: string;
+  }
+}
+
+declare module "openai/resources/responses/responses" {
+  interface Response {
+    /** Langfuse observation ID — present when the client is wrapped with `observeOpenAI` */
+    langfuseObservationId?: string;
+    /** Langfuse trace ID — present when the client is wrapped with `observeOpenAI` */
+    langfuseTraceId?: string;
+  }
+}

--- a/packages/openai/src/langfuseIds.ts
+++ b/packages/openai/src/langfuseIds.ts
@@ -1,0 +1,41 @@
+import type { LangfuseGeneration } from "@langfuse/tracing";
+
+/**
+ * Extends a response object with Langfuse observation and trace IDs.
+ *
+ * @public
+ */
+export type WithLangfuseIds<T> = T & {
+  /** The Langfuse observation ID for this generation */
+  langfuseObservationId: string;
+  /** The Langfuse trace ID for this generation */
+  langfuseTraceId: string;
+};
+
+/**
+ * Attaches Langfuse observation and trace IDs to a response object as non-enumerable properties.
+ *
+ * The properties are non-enumerable so they don't appear in JSON.stringify output
+ * or for-in loops, but are directly accessible on the response object.
+ *
+ * @internal
+ */
+export function attachLangfuseIds<T>(
+  result: T,
+  generation: LangfuseGeneration,
+): asserts result is T & WithLangfuseIds<T> {
+  if (result && typeof result === "object") {
+    Object.defineProperty(result, "langfuseObservationId", {
+      value: generation.id,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+    Object.defineProperty(result, "langfuseTraceId", {
+      value: generation.traceId,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+  }
+}

--- a/packages/openai/src/langfuseIds.ts
+++ b/packages/openai/src/langfuseIds.ts
@@ -25,17 +25,23 @@ export function attachLangfuseIds<T>(
   generation: LangfuseGeneration,
 ): asserts result is T & WithLangfuseIds<T> {
   if (result && typeof result === "object") {
-    Object.defineProperty(result, "langfuseObservationId", {
-      value: generation.id,
-      enumerable: false,
-      writable: false,
-      configurable: false,
-    });
-    Object.defineProperty(result, "langfuseTraceId", {
-      value: generation.traceId,
-      enumerable: false,
-      writable: false,
-      configurable: false,
-    });
+    try {
+      Object.defineProperty(result, "langfuseObservationId", {
+        value: generation.id,
+        enumerable: false,
+        writable: false,
+        configurable: false,
+      });
+      Object.defineProperty(result, "langfuseTraceId", {
+        value: generation.traceId,
+        enumerable: false,
+        writable: false,
+        configurable: false,
+      });
+    } catch {
+      // In practice this never happens: OpenAI SDK responses are plain objects
+      // from JSON parsing (never frozen/sealed), and this function is only called
+      // once per response. Guard kept for defensive robustness.
+    }
   }
 }

--- a/packages/openai/src/traceMethod.ts
+++ b/packages/openai/src/traceMethod.ts
@@ -5,6 +5,7 @@ import {
 } from "@langfuse/tracing";
 import type OpenAI from "openai";
 
+import { attachLangfuseIds } from "./langfuseIds.js";
 import {
   getToolCallOutput,
   parseChunk,
@@ -128,6 +129,8 @@ const wrapMethod = <T extends GenericMethod>(
                   metadata: metadataFromResponse,
                 })
                 .end();
+
+              attachLangfuseIds(result, generation);
 
               return result;
             })
@@ -258,5 +261,8 @@ function wrapAsyncIterable<R>(
       .end();
   }
 
-  return tracedOutputGenerator() as R;
+  const generator = tracedOutputGenerator();
+  attachLangfuseIds(generator, generation);
+
+  return generator as R;
 }


### PR DESCRIPTION
## Summary

- After an `observeOpenAI`-wrapped call completes, the observation ID and trace ID are now attached to the response object as non-enumerable properties
- Exports a `WithLangfuseIds<T>` utility type for TypeScript consumers
- Works for both non-streaming (Promise) and streaming (AsyncIterable) responses

## Usage

```typescript
import { observeOpenAI } from '@langfuse/openai';

const openai = observeOpenAI(new OpenAI());
const response = await openai.chat.completions.create({
  model: 'gpt-4',
  messages: [{ role: 'user', content: 'Hello!' }],
});

// Access the IDs directly on the response
response.langfuseObservationId // the generation's observation ID
response.langfuseTraceId       // the parent trace ID

// Use them to attach scores via the Langfuse API
await langfuseClient.score.create({
  traceId: response.langfuseTraceId,
  observationId: response.langfuseObservationId,
  name: 'user-feedback',
  value: 'positive',
  dataType: 'CATEGORICAL',
});
```

For TypeScript, a `WithLangfuseIds<T>` utility type is exported:

```typescript
import type { WithLangfuseIds } from '@langfuse/openai';
```

## Motivation

Currently there is no way to retrieve the observation/generation ID created by `observeOpenAI`. The integration internally uses `startObservation` and calls `.end()` before returning, so the observation object is never exposed. This makes it impossible to programmatically attach scores to specific generations (e.g., for user feedback loops).

The only workaround is replacing `observeOpenAI` with manual `startActiveObservation({ asType: 'generation' })` calls + `generation.update()`, which duplicates all the input/output/usage parsing that `observeOpenAI` already handles.

## Implementation

- IDs are attached via `Object.defineProperty` with `enumerable: false`, so they don't appear in `JSON.stringify` output or `for-in` loops
- The `attachLangfuseIds` helper is called after the generation is updated and ended, in both the Promise and streaming paths

Closes langfuse/langfuse#12389

## Test plan

- [ ] Existing E2E tests continue to pass
- [ ] `response.langfuseObservationId` is accessible after a non-streaming call
- [ ] `response.langfuseTraceId` is accessible after a non-streaming call
- [ ] Streaming responses also carry the IDs on the generator object
- [ ] IDs do not appear in `JSON.stringify(response)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR exposes Langfuse observation and trace IDs directly on `observeOpenAI` responses, addressing a long-standing gap where users had no programmatic way to attach scores to specific generations. The implementation adds a small new module (`langfuseIds.ts`) with a `WithLangfuseIds<T>` utility type and an `attachLangfuseIds` helper that stamps non-enumerable properties onto response objects and stream generators using `Object.defineProperty`.

**Key changes:**
- `packages/openai/src/langfuseIds.ts` — new module exporting `WithLangfuseIds<T>` and `attachLangfuseIds`
- `packages/openai/src/traceMethod.ts` — calls `attachLangfuseIds` in both the non-streaming (`.then()`) and streaming (`wrapAsyncIterable`) paths
- `packages/openai/src/index.ts` — re-exports `WithLangfuseIds<T>` as a public type

**Issues found:**
- `Object.defineProperty` is called without a `try/catch`. If the target object is frozen, sealed, or non-extensible (or if this function is ever called twice on the same object, since `configurable: false`), a `TypeError` will propagate to the user — potentially rejecting their awaited promise for an unrelated-looking reason.
- The `asserts result is T & WithLangfuseIds<T>` assertion is unconditional at the type level, but the property definitions are conditional on `result` being a non-null object. When the guard fails, TypeScript still narrows the type as if the IDs were present, creating a soundness gap.
- For streaming responses, `langfuseObservationId` / `langfuseTraceId` are readable immediately on the generator, but the underlying generation is only `.end()`-ed after the stream is fully iterated. This should be documented so consumers know not to immediately fire Langfuse API calls (e.g. `score.create`) right after starting the stream.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for the happy path, but the missing `try/catch` around `Object.defineProperty` is a latent runtime failure risk on non-extensible objects.
- The core logic is sound and the IDs are correctly captured from the OTEL span context at creation time. However, the unguarded `Object.defineProperty` with `configurable: false` can throw a `TypeError` that propagates to users in edge cases (frozen objects, double-call, etc.), and the `asserts` type soundness gap could cause hard-to-debug issues if the helper is reused beyond its current call-sites.
- Pay close attention to `packages/openai/src/langfuseIds.ts` — specifically the `Object.defineProperty` error handling and the unconditional `asserts` type assertion.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/openai/src/langfuseIds.ts | New helper module: defines `WithLangfuseIds<T>` utility type and `attachLangfuseIds` function; has two concerns — `Object.defineProperty` can throw on non-extensible/frozen objects without a try-catch, and the `asserts` signature creates a type-soundness gap when the guard fails. |
| packages/openai/src/traceMethod.ts | Integrates `attachLangfuseIds` into both the Promise (non-streaming) and async-iterable (streaming) paths; timing for the streaming case is correct since OTEL span IDs are determined at span creation, but worth documenting that the generation may not be flushed when IDs are first readable. |
| packages/openai/src/index.ts | Exports `WithLangfuseIds<T>` as a type-only export; minimal, correct change. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant wrapMethod
    participant tracedMethod as OpenAI SDK Method
    participant wrapAsyncIterable
    participant attachLangfuseIds
    participant LangfuseGeneration

    Caller->>wrapMethod: call (e.g. chat.completions.create)
    wrapMethod->>LangfuseGeneration: startObservation() → generation (id, traceId set from OTEL span)
    wrapMethod->>tracedMethod: execute original method

    alt Non-streaming (Promise)
        tracedMethod-->>wrapMethod: Promise<ChatCompletion>
        wrapMethod->>wrapMethod: .then(result => ...)
        wrapMethod->>LangfuseGeneration: generation.update().end()
        wrapMethod->>attachLangfuseIds: attachLangfuseIds(result, generation)
        Note over attachLangfuseIds: Object.defineProperty(result, "langfuseObservationId", ...)<br/>Object.defineProperty(result, "langfuseTraceId", ...)
        wrapMethod-->>Caller: Promise<ChatCompletion & WithLangfuseIds>
    else Streaming (AsyncIterable)
        tracedMethod-->>wrapMethod: AsyncIterable (stream)
        wrapMethod->>wrapAsyncIterable: wrapAsyncIterable(stream, generation)
        wrapAsyncIterable->>wrapAsyncIterable: create tracedOutputGenerator()
        wrapAsyncIterable->>attachLangfuseIds: attachLangfuseIds(generator, generation)
        Note over attachLangfuseIds: IDs attached before stream is iterated
        wrapAsyncIterable-->>Caller: generator (with langfuseObservationId, langfuseTraceId)
        loop Iterate stream
            Caller->>wrapAsyncIterable: for await chunk
            wrapAsyncIterable-->>Caller: yield rawChunk
        end
        wrapAsyncIterable->>LangfuseGeneration: generation.update().end()
        Note over Caller: IDs readable immediately,<br/>but generation only flushed after full iteration
    end
```

<sub>Last reviewed commit: 41e6e12</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->