### PR TITLE
fix(otel): allow async mask functions

### DIFF
--- a/packages/otel/src/span-processor.ts
+++ b/packages/otel/src/span-processor.ts
@@ -29,11 +29,11 @@ import { isDefaultExportSpan } from "./span-filter.js";
  *
  * @param params - Object containing the data to be masked
  * @param params.data - The data that should be masked
- * @returns The masked data (can be of any type)
+ * @returns The masked data, or a promise resolving to it
  *
  * @example
  * ```typescript
- * const maskFunction: MaskFunction = ({ data }) => {
+ * const maskFunction: MaskFunction = async ({ data }) => {
  *   if (typeof data === 'string') {
  *     return data.replace(/password=\w+/g, 'password=***');
  *   }
@@ -43,7 +43,7 @@ import { isDefaultExportSpan } from "./span-filter.js";
  *
  * @public
  */
-export type MaskFunction = (params: { data: any }) => any;
+export type MaskFunction = (params: { data: any }) => any | Promise<any>;
 
 /**
  * Function type for determining whether a span should be exported to Langfuse.
@@ -414,7 +414,7 @@ export class LangfuseSpanProcessor implements SpanProcessor {
       return;
     }
 
-    this.applyMaskInPlace(span);
+    await this.applyMaskInPlace(span);
     await this.mediaService.process(span);
 
     if (this.logger.isLevelEnabled(LogLevel.DEBUG)) {
@@ -442,7 +442,7 @@ export class LangfuseSpanProcessor implements SpanProcessor {
 
     this.processor.onEnd(span);
   }
-  private applyMaskInPlace(span: ReadableSpan): void {
+  private async applyMaskInPlace(span: ReadableSpan): Promise<void> {
     const maskCandidates = [
       LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
       LangfuseOtelSpanAttributes.TRACE_INPUT,
@@ -454,18 +454,18 @@ export class LangfuseSpanProcessor implements SpanProcessor {
 
     for (const maskCandidate of maskCandidates) {
       if (maskCandidate in span.attributes) {
-        span.attributes[maskCandidate] = this.applyMask(
+        span.attributes[maskCandidate] = await this.applyMask(
           span.attributes[maskCandidate],
         );
       }
     }
   }
 
-  private applyMask<T>(data: T): T | string {
+  private async applyMask<T>(data: T): Promise<T | string> {
     if (!this.mask) return data;
 
     try {
-      return this.mask({ data });
+      return await this.mask({ data });
     } catch (err) {
       this.logger.warn(
         `Applying mask function failed due to error, fully masking property. Error: ${err}`,

--- a/tests/integration/span-processor.integration.test.ts
+++ b/tests/integration/span-processor.integration.test.ts
@@ -11,6 +11,7 @@ import { SpanAssertions } from "./helpers/assertions.js";
 import {
   setupTestEnvironment,
   teardownTestEnvironment,
+  waitFor,
   waitForSpanExport,
   type TestEnvironment,
 } from "./helpers/testSetup.js";
@@ -67,6 +68,47 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       );
     });
 
+    it("should apply async mask function to span attributes", async () => {
+      await teardownTestEnvironment(testEnv);
+
+      testEnv = await setupTestEnvironment({
+        spanProcessorConfig: {
+          mask: async ({ data }) => {
+            await waitFor(50);
+
+            if (typeof data === "string") {
+              return data.replace(/secret/g, "***");
+            }
+
+            return data;
+          },
+        },
+      });
+      assertions = new SpanAssertions(testEnv.mockExporter);
+
+      const span = startObservation("async-masked-span", {
+        input: { message: "This contains secret information" },
+        output: { response: "No secret here" },
+      });
+      span.end();
+
+      await waitFor(10);
+      expect(testEnv.mockExporter.getSpanCount()).toBe(0);
+
+      await waitForSpanExport(testEnv.mockExporter, 1);
+
+      assertions.expectSpanAttributeContains(
+        "async-masked-span",
+        "langfuse.observation.input",
+        "This contains *** information",
+      );
+      assertions.expectSpanAttributeContains(
+        "async-masked-span",
+        "langfuse.observation.output",
+        "No *** here",
+      );
+    });
+
     it("should handle mask function errors gracefully", async () => {
       await teardownTestEnvironment(testEnv);
 
@@ -88,6 +130,33 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
 
       assertions.expectSpanAttribute(
         "error-mask-span",
+        "langfuse.observation.input",
+        "<fully masked due to failed mask function>",
+      );
+    });
+
+    it("should handle async mask function errors gracefully", async () => {
+      await teardownTestEnvironment(testEnv);
+
+      testEnv = await setupTestEnvironment({
+        spanProcessorConfig: {
+          mask: async () => {
+            await waitFor(10);
+            throw new Error("Async mask function error");
+          },
+        },
+      });
+      assertions = new SpanAssertions(testEnv.mockExporter);
+
+      const span = startObservation("async-error-mask-span", {
+        input: { message: "test message" },
+      });
+      span.end();
+
+      await waitForSpanExport(testEnv.mockExporter, 1);
+
+      assertions.expectSpanAttribute(
+        "async-error-mask-span",
         "langfuse.observation.input",
         "<fully masked due to failed mask function>",
       );


### PR DESCRIPTION
## Summary
- allow @langfuse/otel mask functions to return promises as well as sync values
- await masking before media processing and export while keeping existing sync behavior unchanged
- add integration coverage for async masking success and async masking failure

## Testing
- pnpm --filter @langfuse/core --filter @langfuse/tracing --filter @langfuse/otel build
- pnpm vitest run --project integration tests/integration/span-processor.integration.test.ts

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR extends `LangfuseSpanProcessor` to support async `MaskFunction` implementations by making `applyMask` and `applyMaskInPlace` async and awaiting them before media processing and span export, while preserving all existing synchronous behaviour. Two new integration tests cover the async-success and async-error paths.

**Key changes:**
- `applyMask<T>` now returns `Promise<T | string>` and `await`s the mask function, so rejected promises are caught by the same `try/catch` that already handled synchronous errors.
- `applyMaskInPlace` is now `async` and sequentially `await`s each masked attribute before moving on.
- `processEndedSpan` gains a single `await this.applyMaskInPlace(span)` call; the surrounding async machinery (`pendingEndedSpans`, `forceFlush`, `shutdown`) was already in place and requires no changes.
- The `MaskFunction` return type annotation was updated to `any | Promise<any>`, but due to TypeScript's `any`-absorption rule this is semantically equivalent to the original `any`; a stricter union type (e.g. `unknown | Promise<unknown>`) would properly express the intent.
- The new async-success integration test contains a hardcoded 10 ms timing assertion to verify deferred export, which may be flaky on slow CI runners.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; the async plumbing is correct and error handling is preserved, with only minor type-annotation and test-flakiness concerns.
- The runtime changes are minimal and well-contained: `applyMask` already used try/catch, `processEndedSpan` was already async, and `await mask({data})` correctly handles both sync returns and Promise rejections. The only notable issues are a no-op TypeScript type annotation (`any | Promise<any>` == `any`) and a time-dependent test assertion that could be flaky in CI.
- No files require special attention beyond the minor style notes on `packages/otel/src/span-processor.ts` (type annotation) and `tests/integration/span-processor.integration.test.ts` (timing assertion).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/otel/src/span-processor.ts | Made `applyMask` and `applyMaskInPlace` async and awaited them in `processEndedSpan`; runtime behaviour is correct but the `MaskFunction` return type `any | Promise<any>` is semantically unchanged from `any` due to TypeScript's `any`-absorption rule. |
| tests/integration/span-processor.integration.test.ts | Adds two integration tests for async mask success and async mask error paths; the success test contains a time-dependent assertion (`waitFor(10)` → `getSpanCount() === 0`) that could be flaky on slow machines. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SDK as OpenTelemetry SDK
    participant LSP as LangfuseSpanProcessor
    participant AMP as applyMaskInPlace (async)
    participant AM as applyMask (async)
    participant MF as MaskFunction (sync or async)
    participant MS as MediaService
    participant BSP as BatchSpanProcessor

    SDK->>LSP: onEnd(span)
    LSP->>LSP: processEndedSpanPromise = processEndedSpan(span)
    LSP->>LSP: pendingEndedSpans.add(promise)
    Note over LSP: returns immediately (sync)

    LSP->>+AMP: await applyMaskInPlace(span)
    loop for each maskCandidate attribute
        AMP->>+AM: await applyMask(data)
        AM->>+MF: await mask({ data })
        alt mask returns sync value
            MF-->>AM: value
        else mask returns Promise
            MF-->>AM: Promise<value>
        else mask throws / rejects
            MF-->>AM: error
            AM-->>AMP: "<fully masked due to failed mask function>"
        end
        AM-->>-AMP: masked value
        AMP->>AMP: span.attributes[candidate] = masked value
    end
    AMP-->>-LSP: void

    LSP->>+MS: await mediaService.process(span)
    MS-->>-LSP: void

    LSP->>BSP: processor.onEnd(span)
```

<sub>Last reviewed commit: 028655e</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->