### PR TITLE
fix(openai): include Responses API instructions in captured input

### DIFF
--- a/packages/openai/src/parseOpenAI.test.ts
+++ b/packages/openai/src/parseOpenAI.test.ts
@@ -60,6 +60,17 @@ describe("parseInputArgs", () => {
       });
       expect(result.input).toBe("Hello!");
     });
+
+    it("should not merge instructions when messages is present (chat completions path wins)", () => {
+      const result = parseInputArgs({
+        model: "gpt-4o",
+        instructions: "You are a pirate.",
+        messages: [{ role: "user", content: "Hello!" }],
+      });
+      expect(result.input).toEqual({
+        messages: [{ role: "user", content: "Hello!" }],
+      });
+    });
   });
 
   describe("Chat Completions API: messages handling", () => {

--- a/packages/openai/src/parseOpenAI.test.ts
+++ b/packages/openai/src/parseOpenAI.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { parseInputArgs } from "./parseOpenAI";
+
+describe("parseInputArgs", () => {
+  describe("Responses API: instructions handling", () => {
+    it("should return input as-is when no instructions", () => {
+      const result = parseInputArgs({ model: "gpt-4o", input: "Hello!" });
+      expect(result.input).toBe("Hello!");
+    });
+
+    it("should merge string instructions + string input into message list", () => {
+      const result = parseInputArgs({
+        model: "gpt-4o",
+        instructions: "You are a pirate.",
+        input: "Hello!",
+      });
+      expect(result.input).toEqual([
+        { role: "system", content: "You are a pirate." },
+        { role: "user", content: "Hello!" },
+      ]);
+    });
+
+    it("should prepend instructions to array input", () => {
+      const result = parseInputArgs({
+        model: "gpt-4o",
+        instructions: "You are a pirate.",
+        input: [{ role: "user", content: "Hello!" }],
+      });
+      expect(result.input).toEqual([
+        { role: "system", content: "You are a pirate." },
+        { role: "user", content: "Hello!" },
+      ]);
+    });
+
+    it("should return { instructions } when input is not provided", () => {
+      const result = parseInputArgs({
+        model: "gpt-4o",
+        instructions: "You are a pirate.",
+      });
+      expect(result.input).toEqual({ instructions: "You are a pirate." });
+    });
+
+    it("should return { instructions, input } for non-string/non-array input", () => {
+      const result = parseInputArgs({
+        model: "gpt-4o",
+        instructions: "You are a pirate.",
+        input: { type: "custom", data: 123 },
+      });
+      expect(result.input).toEqual({
+        instructions: "You are a pirate.",
+        input: { type: "custom", data: 123 },
+      });
+    });
+
+    it("should ignore non-string instructions", () => {
+      const result = parseInputArgs({
+        model: "gpt-4o",
+        instructions: 123,
+        input: "Hello!",
+      });
+      expect(result.input).toBe("Hello!");
+    });
+  });
+
+  describe("Chat Completions API: messages handling", () => {
+    it("should capture messages as input", () => {
+      const result = parseInputArgs({
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "Hello!" }],
+      });
+      expect(result.input).toEqual({
+        messages: [{ role: "user", content: "Hello!" }],
+      });
+    });
+
+    it("should include tools in input when present", () => {
+      const result = parseInputArgs({
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "Hello!" }],
+        tools: [{ type: "function", function: { name: "test" } }],
+      });
+      expect(result.input).toEqual({
+        messages: [{ role: "user", content: "Hello!" }],
+        tools: [{ type: "function", function: { name: "test" } }],
+      });
+    });
+  });
+
+  describe("Completions API: prompt handling", () => {
+    it("should fall back to prompt when no input or messages", () => {
+      const result = parseInputArgs({
+        model: "gpt-3.5-turbo-instruct",
+        prompt: "Once upon a time",
+      });
+      expect(result.input).toBe("Once upon a time");
+    });
+  });
+});

--- a/packages/openai/src/parseOpenAI.ts
+++ b/packages/openai/src/parseOpenAI.ts
@@ -29,6 +29,25 @@ export const parseInputArgs = (
 
   let input: Record<string, any> | string = args.input;
 
+  // Responses API: merge `instructions` into input, mirroring how
+  // chat.completions captures system messages in the prompt.
+  // See: https://github.com/langfuse/langfuse/issues/9775
+  const instructions = args.instructions;
+  if (instructions && typeof instructions === "string") {
+    if (typeof input === "string") {
+      input = [
+        { role: "system", content: instructions },
+        { role: "user", content: input },
+      ];
+    } else if (Array.isArray(input)) {
+      input = [{ role: "system", content: instructions }, ...input];
+    } else if (!input) {
+      input = { instructions };
+    } else {
+      input = { instructions, input };
+    }
+  }
+
   if (
     args &&
     typeof args === "object" &&

--- a/packages/openai/src/parseOpenAI.ts
+++ b/packages/openai/src/parseOpenAI.ts
@@ -33,7 +33,7 @@ export const parseInputArgs = (
   // chat.completions captures system messages in the prompt.
   // See: https://github.com/langfuse/langfuse/issues/9775
   const instructions = args.instructions;
-  if (instructions && typeof instructions === "string") {
+  if (instructions && typeof instructions === "string" && !("messages" in args)) {
     if (typeof input === "string") {
       input = [
         { role: "system", content: instructions },


### PR DESCRIPTION
## Summary

When using the OpenAI Responses API with `observeOpenAI()`, the `instructions` parameter (system prompt) is not captured in the generation input. This PR fixes `parseInputArgs` to merge `instructions` into the input, mirroring how `chat.completions` captures system messages in the prompt.

This is the JS/TS equivalent of the Python SDK fix in [langfuse-python#1565](https://github.com/langfuse/langfuse-python/pull/1565).

## Changes

**`packages/openai/src/parseOpenAI.ts`** — 19 lines added to `parseInputArgs`:
- When `instructions` is present alongside `input` (string), merge into `[{role: system}, {role: user}]` message list
- When `instructions` is present alongside `input` (array), prepend `{role: system}` entry
- When only `instructions` is present (no input), return `{ instructions }`
- Non-string instructions are ignored (no-op)

**`packages/openai/src/parseOpenAI.test.ts`** — new unit test file:
- 9 tests covering all input combinations: string, array, missing, non-string instructions, chat completions, and completions API paths

## Behavior

| `instructions` | `input` | Before | After |
|---|---|---|---|
| `"You are a pirate."` | `"Hello!"` | `"Hello!"` | `[{role: "system", content: "You are a pirate."}, {role: "user", content: "Hello!"}]` |
| `"You are a pirate."` | `[{role: "user", content: "Hello!"}]` | `[{role: "user", ...}]` | `[{role: "system", content: "You are a pirate."}, {role: "user", ...}]` |
| `"You are a pirate."` | _(none)_ | `undefined` | `{instructions: "You are a pirate."}` |
| _(none)_ | `"Hello!"` | `"Hello!"` | `"Hello!"` (unchanged) |

## Test plan

- [x] 9 unit tests pass (`vitest run packages/openai/src/parseOpenAI.test.ts`)
- [x] Matches behavior of the merged Python SDK fix ([langfuse-python#1565](https://github.com/langfuse/langfuse-python/pull/1565))

Fixes https://github.com/langfuse/langfuse/issues/9775

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a gap in the OpenAI integration where the `instructions` parameter (system prompt) from the Responses API was silently dropped and never captured in Langfuse's generation input. The fix extends `parseInputArgs` in `parseOpenAI.ts` to detect and merge `instructions` into the `input` field — as a `[{role: "system"}, {role: "user"}]` message list for string/array inputs, or as a plain `{ instructions }` object when no `input` is provided — mirroring the existing behaviour for Chat Completions system messages.

Key points:
- The logic correctly handles all four input shape variants: string `input`, array `input`, absent `input`, and unknown-type `input`.
- The instructions block runs *before* the existing `messages`/`prompt` checks; if both `messages` and `instructions` are present (unusual but possible), the instructions-merged result is silently overwritten — adding a `!("messages" in args)` guard would make the precedence explicit.
- 9 new unit tests cover the main paths well, but a test for the `messages` + `instructions` combination is absent, leaving the interaction behaviour undocumented.

<h3>Confidence Score: 4/5</h3>

- Safe to merge; the fix is correct for all realistic Responses API use cases with only minor defensive hardening opportunities remaining.
- The core logic is sound and matches the intent of the Python SDK fix. The two concerns (lack of `messages` guard and missing edge-case test) are low-risk given that Responses API and Chat Completions API are always called on separate endpoints, making the overlap scenario unrealistic in production.
- No files require special attention; both changed files are self-contained and isolated to the parsing layer.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/openai/src/parseOpenAI.ts | Adds instructions-merge logic for the Responses API to `parseInputArgs`; logic is correct for all realistic API paths but lacks a guard against the `messages` block silently overwriting the merged input when both `messages` and `instructions` are present. |
| packages/openai/src/parseOpenAI.test.ts | New test file with 9 well-structured unit tests covering all documented input combinations; missing a test for the `instructions` + `messages` combination, which would lock in the expected precedence behavior. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[parseInputArgs called] --> B{instructions present\nand is string?}
    B -- No --> G
    B -- Yes --> C{typeof input}
    C -- string --> D["Merge: system msg + user msg array"]
    C -- array --> E["Prepend system msg to array"]
    C -- falsy --> F["input = instructions object"]
    C -- other object --> H["input = instructions + input object"]
    D --> G{messages in args?}
    E --> G
    F --> G
    H --> G
    G -- Yes --> I["input = messages block\nWARN: overwrites instructions merge"]
    G -- No --> J{input still falsy?}
    J -- Yes --> K["input = args.prompt"]
    J -- No --> L[Return model + input + modelParameters]
    I --> L
    K --> L
```

<sub>Last reviewed commit: ["fix(openai): include..."](https://github.com/langfuse/langfuse-js/commit/8f59f1d49e4757ed851c58dc84932cae991b65cc)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->