### PR TITLE
ci(GitHub actions): pin GitHub actions, configure dependabot alerts for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,17 @@ updates:
       prefix: chore
       prefix-development: chore
       include: scope
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   #this in combination makes dependabot to ignore all dependencies found in the examples folder
   - package-ecosystem: "npm"
     directory: "/examples"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
-        with:
-          version: 9.5.0
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 20
@@ -43,8 +41,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
-        with:
-          version: 9.5.0
 
       - name: Clone langfuse server
         run: |
@@ -123,8 +119,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
-        with:
-          version: 9.5.0
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 20
+          node-version: 24 # https://github.com/langfuse/langfuse/blob/main/package.json#L8
 
       - name: Run langfuse server
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
       LANGFUSE_PUBLIC_KEY: "pk-lf-1234567890"
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 9.5.0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 20
       - run: pnpm install
@@ -41,8 +41,8 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 9.5.0
 
@@ -51,14 +51,14 @@ jobs:
           git clone https://github.com/langfuse/langfuse.git ./langfuse-server
 
       - name: Cache langfuse server dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: ./langfuse-server/node_modules
           key: |
             langfuse-server-${{ hashFiles('./langfuse-server/package-lock.json') }}
             langfuse-server-
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 20
 
@@ -121,11 +121,11 @@ jobs:
     timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 9.5.0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 20
 

--- a/.github/workflows/claude-review-maintainer-prs.yml
+++ b/.github/workflows/claude-review-maintainer-prs.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Check author permission and existing review request
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const owner = context.repo.owner;
@@ -57,7 +57,7 @@ jobs:
 
       - name: Add Claude review comment
         if: steps.check.outputs.should_comment == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             await github.rest.issues.createComment({

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,11 +46,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -68,7 +68,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -81,6 +81,6 @@ jobs:
       #     ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/dependabot-rebase-stale.yml
+++ b/.github/workflows/dependabot-rebase-stale.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Rebase open Dependabot PR"
-        uses: orange-buffalo/dependabot-auto-rebase@v1
+        uses: orange-buffalo/dependabot-auto-rebase@fa9e05d7a8152381af0a92ffca942a0d46712544 # v1
         with:
           api-token: ${{ secrets.DEP_REBASE_PAT }}
           repository: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,8 +68,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
-        with:
-          version: 9.15.0
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,18 +61,18 @@ jobs:
             exit 1
           fi
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 9.15.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
@@ -232,7 +232,7 @@ jobs:
 
       - name: Upload release artifacts to GitHub Release
         if: inputs.dry_run == false
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: v${{ steps.version.outputs.version }}
           files: release-artifacts/*.tar.gz
@@ -242,8 +242,10 @@ jobs:
 
       - name: Notify Slack on success
         if: success() && inputs.dry_run == false
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "✅ Langfuse JS/TS SDK v${{ steps.version.outputs.version }} published to npm",
@@ -331,14 +333,13 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_RELEASES }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
       - name: Notify Slack on dry run success
         if: success() && inputs.dry_run == true
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_ENGINEERING }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "🧪 Langfuse JS/TS SDK dry run completed for v${{ steps.version.outputs.version }}",
@@ -414,14 +415,13 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_ENGINEERING }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
       - name: Notify Slack on failure
         if: failure()
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_ENGINEERING }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "❌ Langfuse JS/TS SDK release workflow failed",
@@ -507,9 +507,6 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_ENGINEERING }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
       - name: Rollback notification on partial failure
         if: failure() && steps.release.outcome == 'success'

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@ai-sdk/anthropic": "^2",
     "@ai-sdk/openai": "^2",
+    "@eslint/js": "^9.32.0",
     "@langchain/core": "^1.1.24",
     "@langchain/langgraph": "^1.1.4",
     "@langchain/openai": "^1.2.7",
@@ -76,5 +77,5 @@
   "resolutions": {
     "ml-spectra-processing": "14.14.0"
   },
-  "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c"
+  "packageManager": "pnpm@10.33.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^2
         version: 2.0.20(zod@3.25.76)
+      '@eslint/js':
+        specifier: ^9.32.0
+        version: 9.32.0
       '@langchain/core':
         specifier: ^1.1.24
         version: 1.1.24(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(openai@5.10.2(ws@8.20.0)(zod@3.25.76))
@@ -993,56 +996,67 @@ packages:
     resolution: {integrity: sha512-+xmiDGGaSfIIOXMzkhJ++Oa0Gwvl9oXUeIiwarsdRXSe27HUIvjbSIpPxvnNsRebsNdUo7uAiQVgBD1hVriwSQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.44.2':
     resolution: {integrity: sha512-bDHvhzOfORk3wt8yxIra8N4k/N0MnKInCW5OGZaeDYa/hMrdPaJzo7CSkjKZqX4JFUWjUGm88lI6QJLCM7lDrA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.44.2':
     resolution: {integrity: sha512-NMsDEsDiYghTbeZWEGnNi4F0hSbGnsuOG+VnNvxkKg0IGDvFh7UVpM/14mnMwxRxUf9AdAVJgHPvKXf6FpMB7A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.44.2':
     resolution: {integrity: sha512-lb5bxXnxXglVq+7imxykIp5xMq+idehfl+wOgiiix0191av84OqbjUED+PRC5OA8eFJYj5xAGcpAZ0pF2MnW+A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.44.2':
     resolution: {integrity: sha512-Yl5Rdpf9pIc4GW1PmkUGHdMtbx0fBLE1//SxDmuf3X0dUC57+zMepow2LK0V21661cjXdTn8hO2tXDdAWAqE5g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.44.2':
     resolution: {integrity: sha512-03vUDH+w55s680YYryyr78jsO1RWU9ocRMaeV2vMniJJW/6HhoTBwyyiiTPVHNWLnhsnwcQ0oH3S9JSBEKuyqw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.44.2':
     resolution: {integrity: sha512-iYtAqBg5eEMG4dEfVlkqo05xMOk6y/JXIToRca2bAWuqjrJYJlx/I7+Z+4hSrsWU8GdJDFPL4ktV3dy4yBSrzg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.44.2':
     resolution: {integrity: sha512-e6vEbgaaqz2yEHqtkPXa28fFuBGmUJ0N2dOJK8YUfijejInt9gfCSA7YDdJ4nYlv67JfP3+PSWFX4IVw/xRIPg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.44.2':
     resolution: {integrity: sha512-evFOtkmVdY3udE+0QKrV5wBx7bKI0iHz5yEVx5WqDJkxp9YQefy4Mpx3RajIVcM6o7jxTvVd/qpC1IXUhGc1Mw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.44.2':
     resolution: {integrity: sha512-/bXb0bEsWMyEkIsUL2Yt5nFB5naLAwyOWMEviQfQY1x3l5WsLKgvZf66TM7UTfED6erckUVUJQ/jJ1FSpm3pRQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.44.2':
     resolution: {integrity: sha512-3D3OB1vSSBXmkGEZR27uiMRNiwN08/RVAcBKwhUYPaiZ8bcvdeEwWPvbnXvvXHY+A/7xluzcN+kaiOFNiOZwWg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.44.2':
     resolution: {integrity: sha512-VfU0fsMK+rwdK8mwODqYeM2hDrF2WiHaSmCBrS7gColkQft95/8tphyzv2EupVxn3iE0FI78wzffoULH1G+dkw==}


### PR DESCRIPTION
## Problem

Supply chain attacks

## Changes

- **ci: pin all GitHub Actions to full commit SHAs and bump to latest versions**
- **ci: add grouped dependabot schedule for GitHub Actions**


## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [ ] Patch
- [x] None that needs a release

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] langfuse
- [ ] langfuse-node
- [x] None 

### Changelog notes

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR hardens the CI/CD supply chain by pinning every third-party GitHub Action to an immutable full commit SHA, and adds a Dependabot schedule to keep those pins current automatically. It also includes a functional upgrade of `slackapi/slack-github-action` from v1 to v3, which required migrating the webhook configuration from environment variables to `with` inputs — all three Slack notification steps (`success`, `dry run success`, `failure`) were correctly updated.

**Key changes:**
- All actions across five workflow files are now pinned to full SHAs with version comments for readability (e.g. `# v6`).
- `slackapi/slack-github-action` migrated from v1 (`SLACK_WEBHOOK_URL`/`SLACK_WEBHOOK_TYPE` env vars) to v3 (`webhook`/`webhook-type` with-inputs); all three notification steps updated consistently.
- `github/codeql-action` upgraded from v2 → v3 across init, autobuild, and analyze sub-actions.
- `.github/dependabot.yml` gains a `github-actions` ecosystem entry with a weekly schedule and a single group to batch all action updates into one PR.
- The `rollback notification on partial failure` step uses a plain `run:` echo command (no Slack action), so it required no changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive supply-chain hardening with no logic modifications to build/test/release behavior.

Every changed file only swaps mutable version tags for immutable SHAs or updates the slackapi action to its new v3 input API. The Slack migration is complete and consistent across all three notification steps. The dependabot addition is correctly scoped. No test logic, application code, or secrets handling was altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Adds a new github-actions ecosystem block with weekly schedule and a group that bundles all action updates into one PR |
| .github/workflows/ci.yml | Pins all actions (checkout, pnpm/action-setup, setup-node, cache) to full commit SHAs; version bumps from v3→v6 / v3→v5 / v3→v5 respectively |
| .github/workflows/release.yml | Pins checkout/pnpm/setup-node/action-gh-release to SHAs; migrates all three Slack notification steps from slackapi/slack-github-action v1 (env-var API) to v3 (with-input API) correctly |
| .github/workflows/claude-review-maintainer-prs.yml | Pins actions/github-script from v7 to v8 SHA; no behavioral changes to the script logic |
| .github/workflows/codeql.yml | Upgrades all three github/codeql-action sub-actions (init, autobuild, analyze) from v2 to v3, pinned to the same SHA; checkout bumped from v3 to v6 |
| .github/workflows/dependabot-rebase-stale.yml | Pins orange-buffalo/dependabot-auto-rebase v1 to its full commit SHA; no functional change |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GitHub Event] --> B{Workflow Trigger}
    B --> C[ci.yml - Test & Lint]
    B --> D[codeql.yml - Security Scan]
    B --> E[release.yml - Publish]
    B --> F[claude-review-maintainer-prs.yml]
    B --> G[dependabot-rebase-stale.yml]
    C --> C1["actions/checkout @ SHA v6"]
    C --> C2["pnpm/action-setup @ SHA v5"]
    C --> C3["actions/setup-node @ SHA v6"]
    C --> C4["actions/cache @ SHA v5"]
    D --> D1["actions/checkout @ SHA v6"]
    D --> D2["github/codeql-action/* @ SHA v3"]
    E --> E1["actions/checkout @ SHA v6"]
    E --> E2["pnpm/action-setup @ SHA v5"]
    E --> E3["actions/setup-node @ SHA v6"]
    E --> E4["softprops/action-gh-release @ SHA v2"]
    E --> E5["slackapi/slack-github-action @ SHA v3"]
    F --> F1["actions/github-script @ SHA v8"]
    G --> G1["orange-buffalo/dependabot-auto-rebase @ SHA v1"]
    H[Dependabot weekly] --> I[".github/dependabot.yml\ngithub-actions ecosystem"]
    I --> C1 & D1 & E1 & F1 & G1
```

<sub>Reviews (1): Last reviewed commit: ["ci: add grouped dependabot schedule for ..."](https://github.com/langfuse/langfuse-js/commit/596c3f1069681c18c0f3167fb23db4acf96bdb4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26883062)</sub>

<!-- /greptile_comment -->