### PR TITLE
fix(langchain): do not throw in callback handler if usageDetails are unavailable

### DIFF
--- a/packages/langchain/src/CallbackHandler.ts
+++ b/packages/langchain/src/CallbackHandler.ts
@@ -594,18 +594,16 @@ export class CallbackHandler extends BaseCallbackHandler {
         output.llmOutput?.["tokenUsage"];
       const modelName = this.extractModelNameFromMetadata(lastResponse);
 
+      const usageObj =
+        llmUsage && typeof llmUsage === "object"
+          ? (llmUsage as Record<string, any>)
+          : undefined;
+
       const usageDetails: Record<string, any> = {
-        input:
-          llmUsage?.input_tokens ??
-          ("promptTokens" in llmUsage ? llmUsage?.promptTokens : undefined),
+        input: llmUsage?.input_tokens ?? usageObj?.promptTokens ?? undefined,
         output:
-          llmUsage?.output_tokens ??
-          ("completionTokens" in llmUsage
-            ? llmUsage?.completionTokens
-            : undefined),
-        total:
-          llmUsage?.total_tokens ??
-          ("totalTokens" in llmUsage ? llmUsage?.totalTokens : undefined),
+          llmUsage?.output_tokens ?? usageObj?.completionTokens ?? undefined,
+        total: llmUsage?.total_tokens ?? usageObj?.totalTokens ?? undefined,
       };
 
       if (llmUsage && "input_token_details" in llmUsage) {


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a `TypeError` in `handleLLMEnd` where the `in` operator was applied to `llmUsage` without first verifying it was a non-null object. When `llmUsage` is `undefined` — e.g. when neither `extractUsageMetadata` nor `output.llmOutput?.["tokenUsage"]` returns a value — expressions like `"promptTokens" in llmUsage` would throw instead of gracefully producing `undefined`.

**Key changes:**
- Introduces a `usageObj` guard that casts `llmUsage` to `Record<string, any>` only when it is both truthy and an object, safely handling `undefined`, `null`, and primitive values.
- Replaces explicit property-existence checks with optional chaining on `usageObj`, which is semantically equivalent for valid objects and safe for non-objects.
- Behavior is fully preserved when `llmUsage` is a well-formed `UsageMetadata` or OpenAI `tokenUsage` object; only the crash path is eliminated.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix correctly eliminates a real TypeError crash with no behaviour change on the happy path.

The single changed file addresses a well-scoped bug (TypeError from `in` on `undefined`). No new logic is introduced, existing behaviour on valid objects is preserved, and all remaining feedback is a P2 style suggestion (redundant `?? undefined` trailing expressions) that does not affect correctness.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/langchain/src/CallbackHandler.ts | Guards `llmUsage` against non-object values before property-existence checks, preventing a `TypeError` thrown by the `in` operator when `llmUsage` is `undefined`; logic and behavior preserved in all non-null paths. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[handleLLMEnd called] --> B[extractUsageMetadata]
    B --> C{UsageMetadata returned?}
    C -- yes --> D[llmUsage = UsageMetadata]
    C -- no --> E[llmUsage = output.llmOutput?.tokenUsage]
    E --> F{llmUsage defined and is object?}
    D --> F
    F -- yes --> G[usageObj = llmUsage as Record]
    F -- no --> H[usageObj = undefined]
    G --> I[Build usageDetails via optional chaining on usageObj]
    H --> I
    I --> J[Augment with input_token_details and output_token_details if present]
    J --> K[handleOtelSpanEnd with usageDetails]
```

<sub>Reviews (1): Last reviewed commit: ["fix(langchain): do not throw in callback..."](https://github.com/langfuse/langfuse-js/commit/96452ee9a0d82f46d947934a5a76d8e4a73f103c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26904509)</sub>

<!-- /greptile_comment -->