### PR TITLE
chore(ci): move to blacksmith runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   test-integration:
     timeout-minutes: 3
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       LANGFUSE_BASE_URL: "http://localhost:3000"
       LANGFUSE_SECRET_KEY: "sk-lf-1234567890"
@@ -31,7 +31,7 @@ jobs:
 
   test-e2e:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       LANGFUSE_BASE_URL: "http://localhost:3000"
       LANGFUSE_SECRET_KEY: "sk-lf-1234567890"
@@ -76,7 +76,7 @@ jobs:
 
           echo "::group::Seed db"
           cp .env.dev.example .env
-          pnpm run db:migrate          
+          pnpm run db:migrate
           pnpm run db:seed
           rm -rf node_modules
           rm -rf .env
@@ -115,7 +115,7 @@ jobs:
 
   lint:
     timeout-minutes: 3
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
@@ -129,7 +129,7 @@ jobs:
       - run: pnpm format:check
 
   all-tests-passed:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: [test-e2e, test-integration, lint]
     if: always()
     steps:


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR migrates the CI pipeline from GitHub-hosted `ubuntu-latest` runners to Blacksmith runners (`blacksmith-4vcpu-ubuntu-2404` for `test-integration` and `test-e2e`, `blacksmith-2vcpu-ubuntu-2404` for `lint` and `all-tests-passed`). Blacksmith is a third-party runner provider that offers faster and more cost-efficient compute on GitHub Actions.

- All four CI jobs updated to use appropriately sized Blacksmith runners: heavier jobs (`test-integration`, `test-e2e`) get 4 vCPUs, lighter jobs (`lint`, `all-tests-passed`) get 2 vCPUs
- Pinning to `ubuntu-2404` (Ubuntu 24.04) is better practice than `ubuntu-latest`, which prevents unexpected environment drift when GitHub updates the default image
- Blacksmith runners support Docker out of the box, so the `test-e2e` job's `docker compose` usage remains unaffected
- Trailing whitespace removed from the `pnpm run db:migrate` line (minor cosmetic cleanup)

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it is a straightforward CI infrastructure change with no code logic impact.

All changes are confined to runner labels in the CI workflow. Runner sizes are appropriately chosen for each job's workload, Ubuntu 24.04 is pinned rather than floating, and Blacksmith runners support Docker (required for the e2e tests using docker compose). No logic issues, security concerns, or behavioral changes.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Migrates all four CI jobs from ubuntu-latest to pinned Blacksmith runners (4vcpu for heavy jobs, 2vcpu for lighter jobs); removes trailing whitespace on db:migrate line |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PR[Pull Request / Push to main] --> TI[test-integration
blacksmith-4vcpu-ubuntu-2404]
    PR --> TE[test-e2e
blacksmith-4vcpu-ubuntu-2404]
    PR --> LI[lint
blacksmith-2vcpu-ubuntu-2404]
    TI --> ATP[all-tests-passed
blacksmith-2vcpu-ubuntu-2404]
    TE --> ATP
    LI --> ATP
    ATP -->|all pass| MERGE[Safe to merge]
    ATP -->|any fail| FAIL[Block merge]
```

<sub>Reviews (1): Last reviewed commit: ["chore(ci): move to blacksmith runners"](https://github.com/langfuse/langfuse-js/commit/f91e421fd6ca55013b77be9c17c36ca67f3f869e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27612742)</sub>

<!-- /greptile_comment -->