### PR TITLE
chore(ci): optimize e2e langfuse server setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,73 +36,100 @@ jobs:
       LANGFUSE_BASE_URL: "http://localhost:3000"
       LANGFUSE_SECRET_KEY: "sk-lf-1234567890"
       LANGFUSE_PUBLIC_KEY: "pk-lf-1234567890"
+      LANGFUSE_INIT_ORG_ID: "0c6c96f4-0ca0-4f16-92a8-6dd7d7c6a501"
+      LANGFUSE_INIT_ORG_NAME: "SDK Test Org"
+      LANGFUSE_INIT_PROJECT_ID: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a"
+      LANGFUSE_INIT_PROJECT_NAME: "SDK Test Project"
+      LANGFUSE_INIT_PROJECT_PUBLIC_KEY: "pk-lf-1234567890"
+      LANGFUSE_INIT_PROJECT_SECRET_KEY: "sk-lf-1234567890"
+      LANGFUSE_INIT_USER_EMAIL: "sdk-tests@langfuse.local"
+      LANGFUSE_INIT_USER_NAME: "SDK Tests"
+      LANGFUSE_INIT_USER_PASSWORD: "langfuse-ci-password"
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
-
-      - name: Clone langfuse server
-        run: |
-          git clone https://github.com/langfuse/langfuse.git ./langfuse-server
-
-      - name: Cache langfuse server dependencies
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: ./langfuse-server/node_modules
-          key: |
-            langfuse-server-${{ hashFiles('./langfuse-server/package-lock.json') }}
-            langfuse-server-
-
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 24 # https://github.com/langfuse/langfuse/blob/main/package.json#L8
+          node-version: 20
+
+      - name: Prepare langfuse server compose
+        run: |
+          mkdir -p ./langfuse-server
+          LANGFUSE_SERVER_SHA="$(git ls-remote https://github.com/langfuse/langfuse.git HEAD | cut -f1)"
+          curl -fsSL "https://raw.githubusercontent.com/langfuse/langfuse/${LANGFUSE_SERVER_SHA}/docker-compose.yml" \
+            -o ./langfuse-server/docker-compose.yml
+          echo "${LANGFUSE_SERVER_SHA}"
 
       - name: Run langfuse server
         run: |
           cd ./langfuse-server
 
-          echo "::group::Run langfuse server"
-          TELEMETRY_ENABLED=false docker compose up -d postgres
-          echo "::endgroup::"
-
-          echo "::group::Logs from langfuse server"
-          TELEMETRY_ENABLED=false docker compose logs
-          echo "::endgroup::"
-
-          echo "::group::Install dependencies (necessary to run seeder)"
-          pnpm i
-          echo "::endgroup::"
-
-          echo "::group::Seed db"
-          cp .env.dev.example .env
-          pnpm run db:migrate
-          pnpm run db:seed
-          rm -rf node_modules
-          rm -rf .env
-
-          echo "::group::Run server"
+          echo "::group::Start langfuse server"
           TELEMETRY_ENABLED=false \
+          NEXT_PUBLIC_LANGFUSE_RUN_NEXT_INIT=true \
           LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT=http://localhost:9090 \
           LANGFUSE_INGESTION_QUEUE_DELAY_MS=10 \
           LANGFUSE_INGESTION_CLICKHOUSE_WRITE_INTERVAL_MS=10 \
+          LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE=true \
+          QUEUE_CONSUMER_EVENT_PROPAGATION_QUEUE_IS_ENABLED=true \
+          LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS=true \
+          LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS=true \
           docker compose up -d
-
           echo "::endgroup::"
 
-      # Add this step to check the health of the container
+      - run: pnpm install
+
       - name: Health check for langfuse server
         run: |
           echo "Checking if the langfuse server is up..."
           retry_count=0
-          max_retries=10
-          until curl --output /dev/null --silent --head --fail http://localhost:3000/api/public/health
+          max_retries=20
+          until curl --output /dev/null --silent --head --fail http://localhost:3000/api/public/health && \
+            node - <<'NODE'
+          const auth = Buffer.from(
+            `${process.env.LANGFUSE_PUBLIC_KEY}:${process.env.LANGFUSE_SECRET_KEY}`,
+          ).toString("base64");
+
+          fetch(`${process.env.LANGFUSE_BASE_URL}/api/public/projects`, {
+            headers: {
+              Authorization: `Basic ${auth}`,
+            },
+          })
+            .then(async (response) => {
+              if (!response.ok) {
+                throw new Error(`Request failed with status ${response.status}`);
+              }
+
+              return response.json();
+            })
+            .then((body) => {
+              const project = body.data?.find(
+                (candidate) =>
+                  candidate.id === process.env.LANGFUSE_INIT_PROJECT_ID,
+              );
+
+              if (!project) {
+                throw new Error(
+                  `Expected initialized project ${process.env.LANGFUSE_INIT_PROJECT_ID}`,
+                );
+              }
+
+              console.log(project.id);
+            })
+            .catch((error) => {
+              console.error(error);
+              process.exit(1);
+            });
+          NODE
           do
             retry_count=`expr $retry_count + 1`
             echo "Attempt $retry_count of $max_retries..."
             if [ $retry_count -ge $max_retries ]; then
               echo "Langfuse server did not respond in time. Printing logs..."
-              docker logs langfuse-server-langfuse-web-1
+              (cd ./langfuse-server && docker compose ps)
+              (cd ./langfuse-server && docker compose logs langfuse-web langfuse-worker)
               echo "Failing the step..."
               exit 1
             fi
@@ -110,7 +137,6 @@ jobs:
           done
           echo "Langfuse server is up and running!"
 
-      - run: pnpm install
       - run: pnpm test:e2e
 
   lint:


### PR DESCRIPTION
## Summary
- replace the JS SDK e2e job's full `langfuse` repo clone and local seed flow with a lightweight upstream `docker-compose.yml` fetch
- initialize the Langfuse test org/project/user via `LANGFUSE_INIT_*` environment variables so the server self-bootstraps with deterministic credentials
- update the health check to verify both the public health endpoint and authenticated access to the initialized project, while keeping compose logs on failure

## Why
The previous workflow booted the server by cloning the full Langfuse repo, installing its dependencies, and running migrations/seeds in CI. This adds extra setup time and maintenance overhead that the Python SDK workflow already avoids.

Using the same compose-download plus init-env pattern keeps the JS SDK e2e setup closer to the server's supported bootstrap path and reduces CI work in this repo.

## Impact
- faster, simpler e2e environment setup
- less coupling to the Langfuse server repository's package manager and local scripts
- deterministic project credentials for e2e assertions

## Validation
- parsed `.github/workflows/ci.yml` successfully with Ruby YAML
- reviewed the staged diff and verified the branch pushes cleanly
- did not run the GitHub Actions workflow itself from local

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR replaces the costly full-repo clone + local seed flow for the `test-e2e` job with a lightweight docker-compose fetch from the langfuse upstream HEAD, using `LANGFUSE_INIT_*` env vars for deterministic server bootstrapping. The `pnpm install` step is also moved earlier to overlap with server startup, and the health check now validates authenticated project access in addition to the public health endpoint.

<h3>Confidence Score: 4/5</h3>

Safe to merge with low risk; all findings are P2 but two of them (unpinned compose SHA, missing fetch timeout) could cause flaky CI failures in practice.

The overall approach is sound and a clear improvement over the previous full-repo-clone flow. The three P2 findings—unpinned upstream SHA, absent fetch timeout, and implicit dependency on the upstream compose file forwarding LANGFUSE_INIT_* to containers—don't block correctness when the upstream compose is stable, but each can produce hard-to-diagnose CI hangs or intermittent failures as the upstream evolves.

.github/workflows/ci.yml — specifically the compose SHA resolution and the inline node health-check script.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Replaces full-repo clone with compose-file fetch; adds LANGFUSE_INIT_* vars; enriches health check with authenticated project validation; moves pnpm install earlier for parallelism. Two reliability concerns: unpinned upstream compose SHA and missing fetch timeout in the health-check node script. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CI: test-e2e job starts] --> B[Checkout + setup-node + pnpm setup]
    B --> C[Prepare langfuse server compose\ngit ls-remote HEAD → fetch docker-compose.yml]
    C --> D[docker compose up -d\nwith LANGFUSE_INIT_* env vars]
    D --> E[pnpm install\nruns in parallel with server startup]
    E --> F{Health check loop\nmax 20 retries x 5s}
    F -- curl /api/public/health fails --> G[Sleep 5s → retry]
    G --> F
    F -- curl passes --> H{node script: fetch /api/public/projects}
    H -- project not found or HTTP error --> G
    H -- project.id matches LANGFUSE_INIT_PROJECT_ID --> I[Server confirmed ready]
    F -- retry_count ge 20 --> J[Print compose logs / exit 1]
    I --> K[pnpm test:e2e]
```

<sub>Reviews (1): Last reviewed commit: ["optimize e2e langfuse server setup"](https://github.com/langfuse/langfuse-js/commit/29848abba890077a5542dbccb211dd3613a0b1c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27997373)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->