### PR TITLE
ci: add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     versioning-strategy: "increase"
     commit-message:
       prefix: chore
@@ -18,6 +20,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ci
       include: scope


### PR DESCRIPTION
## Summary

- add a 7-day Dependabot cooldown for npm updates
- add a 7-day Dependabot cooldown for GitHub Actions updates

## Why

- reduce PR churn from repeated version update runs while keeping daily and weekly schedules intact

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "YAML OK"'

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds a 7-day `cooldown: default-days: 7` to both the `npm` and `github-actions` Dependabot update configurations in `.github/dependabot.yml`, reducing PR churn by requiring packages to be at least 7 days old before Dependabot opens an update PR. The branch also includes auto-generated Fern API type additions for `TEXT` scores and a CONTRIBUTING.md documentation update from prior commits.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only substantive change is a valid Dependabot cooldown configuration, and all remaining findings are P2.

The `cooldown: default-days: 7` option is a documented, supported Dependabot feature. The YAML placement and syntax are correct. The TypeScript files are auto-generated. The only finding is a P2 incomplete sentence in CONTRIBUTING.md.

CONTRIBUTING.md — step 2 of the 'Update openapi spec' section is incomplete.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Adds valid `cooldown: default-days: 7` to npm and github-actions update blocks; configuration is syntactically correct and placement follows GitHub Dependabot docs. |
| CONTRIBUTING.md | Adds 'Update openapi spec' section, but step 2 is incomplete ('2. Publish a new' with no continuation). |
| packages/core/src/api/api/resources/commons/types/Score.ts | Auto-generated: adds TEXT score variant to the Score union type. |
| packages/core/src/api/api/resources/commons/types/TextScore.ts | Auto-generated: new TextScore interface extending BaseScore with a stringValue field. |
| packages/core/src/api/api/resources/scores/types/GetScoresResponseData.ts | Auto-generated: adds Text variant to the GetScoresResponseData discriminated union. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dependabot scheduled run] --> B{Package updated recently?}
    B -- "< 7 days old" --> C[Skip — cooldown active]
    B -- ">= 7 days old" --> D[Open update PR]
    D --> E{Ecosystem}
    E -- npm daily --> F[chore prefix PR]
    E -- github-actions weekly --> G[ci prefix PR]
    C --> H[Wait for next scheduled run]
```

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into codex/add-depen..."](https://github.com/langfuse/langfuse-js/commit/b9d400eadc68e5fa67a75becd095997de915d64b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28002976)</sub>

<!-- /greptile_comment -->