### PR TITLE
ci: harden GitHub Actions workflows with zizmor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
       - main
   workflow_dispatch:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -22,6 +24,8 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -49,6 +53,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -144,6 +150,8 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:

--- a/.github/workflows/claude-review-maintainer-prs.yml
+++ b/.github/workflows/claude-review-maintainer-prs.yml
@@ -1,14 +1,15 @@
 name: Claude Review on Maintainer PRs
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - ready_for_review
 
 jobs:
   comment:
-    if: github.event.pull_request.draft == false
+    # Only run on PRs that are not drafts and are from the same repository (i.e., not from forks)
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/dependabot-rebase-stale.yml
+++ b/.github/workflows/dependabot-rebase-stale.yml
@@ -6,6 +6,8 @@ on:
       - main
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   rebase-dependabot:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,23 +48,26 @@ jobs:
     steps:
       - name: Verify branch
         run: |
-          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
             echo "❌ Error: Releases can only be triggered from main branch"
-            echo "Current ref: ${{ github.ref }}"
+            echo "Current ref: ${GITHUB_REF}"
             exit 1
           fi
       - name: Confirm major release
         if: ${{ inputs.version == 'major' || inputs.version == 'premajor' }}
         run: |
-          if [ "${{ inputs.confirm_major }}" != "RELEASE MAJOR" ]; then
+          if [ "${INPUTS_CONFIRM_MAJOR}" != "RELEASE MAJOR" ]; then
             echo "❌ For major/premajor releases, set confirm_major to RELEASE MAJOR"
             exit 1
           fi
+        env:
+          INPUTS_CONFIRM_MAJOR: ${{ inputs.confirm_major }}
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_ACCESS_TOKEN }}
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
@@ -74,6 +77,7 @@ jobs:
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
+          cache: "" # Disable cache for release workflow (publishes to npm)
 
       - name: Configure Git
         env:
@@ -98,11 +102,14 @@ jobs:
 
       - name: Determine release parameters
         id: release-params
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
+          INPUTS_PRERELEASE_TYPE: ${{ inputs.prerelease_type }}
         run: |
-          version_type="${{ inputs.version }}"
+          version_type="${INPUTS_VERSION}"
 
           if [ "$version_type" = "prepatch" ] || [ "$version_type" = "preminor" ] || [ "$version_type" = "premajor" ]; then
-            prerelease_type="${{ inputs.prerelease_type }}"
+            prerelease_type="${INPUTS_PRERELEASE_TYPE}"
             if [ -z "$prerelease_type" ]; then
               echo "❌ Error: prerelease_type must be specified when version is prepatch/preminor/premajor"
               exit 1
@@ -200,17 +207,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           NPM_CONFIG_TAG: ${{ steps.release-params.outputs.tag }}
+          STEPS_RELEASE_PARAMS_OUTPUTS_RELEASE_INCREMENT: ${{ steps.release-params.outputs.release_increment }}
+          STEPS_RELEASE_PARAMS_OUTPUTS_PRE_RELEASE_FLAG: ${{ steps.release-params.outputs.pre_release_flag }}
         run: |
-          pnpm exec release-it ${{ steps.release-params.outputs.release_increment }} ${{ steps.release-params.outputs.pre_release_flag }} --ci --config .release-it.ci.json
+          pnpm exec release-it ${STEPS_RELEASE_PARAMS_OUTPUTS_RELEASE_INCREMENT} ${STEPS_RELEASE_PARAMS_OUTPUTS_PRE_RELEASE_FLAG} --ci --config .release-it.ci.json
 
       - name: Run release-it (dry run)
         if: inputs.dry_run == true
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           NPM_CONFIG_TAG: ${{ steps.release-params.outputs.tag }}
+          STEPS_RELEASE_PARAMS_OUTPUTS_RELEASE_INCREMENT: ${{ steps.release-params.outputs.release_increment }}
+          STEPS_RELEASE_PARAMS_OUTPUTS_PRE_RELEASE_FLAG: ${{ steps.release-params.outputs.pre_release_flag }}
         run: |
           echo "🧪 Running in DRY RUN mode - no changes will be pushed"
-          pnpm exec release-it ${{ steps.release-params.outputs.release_increment }} ${{ steps.release-params.outputs.pre_release_flag }} --ci --config .release-it.ci.json --dry-run
+          pnpm exec release-it ${STEPS_RELEASE_PARAMS_OUTPUTS_RELEASE_INCREMENT} ${STEPS_RELEASE_PARAMS_OUTPUTS_PRE_RELEASE_FLAG} --ci --config .release-it.ci.json --dry-run
 
       - name: Get version
         id: version
@@ -223,20 +234,20 @@ jobs:
           for pkg in packages/*/dist; do
             pkg_name=$(basename $(dirname $pkg))
             echo "Creating archive for $pkg_name..."
-            tar -czf release-artifacts/langfuse-js-sdk-${pkg_name}-${{ steps.version.outputs.version }}.tar.gz -C $(dirname $pkg) dist
+            tar -czf release-artifacts/langfuse-js-sdk-${pkg_name}-${STEPS_VERSION_OUTPUTS_VERSION}.tar.gz -C $(dirname $pkg) dist
           done
           echo "Build artifacts:"
           ls -lh release-artifacts/
+        env:
+          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
 
       - name: Upload release artifacts to GitHub Release
         if: inputs.dry_run == false
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
-        with:
-          tag_name: v${{ steps.version.outputs.version }}
-          files: release-artifacts/*.tar.gz
-          fail_on_unmatched_files: true
+        run: |
+          gh release upload "v${VERSION}" release-artifacts/*.tar.gz --clobber
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
 
       - name: Notify Slack on success
         if: success() && inputs.dry_run == false
@@ -510,9 +521,11 @@ jobs:
         if: failure() && steps.release.outcome == 'success'
         run: |
           echo "⚠️  CRITICAL: Release succeeded but subsequent steps failed"
-          echo "Published version: v${{ steps.version.outputs.version }}"
+          echo "Published version: v${STEPS_VERSION_OUTPUTS_VERSION}"
           echo "Manual intervention may be required"
           echo ""
           echo "Options:"
           echo "1. Re-run the workflow to complete GitHub release artifacts upload"
-          echo "2. Manually upload release artifacts for tag v${{ steps.version.outputs.version }}"
+          echo "2. Manually upload release artifacts for tag v${STEPS_VERSION_OUTPUTS_VERSION}"
+        env:
+          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,32 @@
+---
+name: Check GitHub Actions
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+  merge_group:
+  pull_request:
+    branches:
+      - "main"
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Check GitHub Actions security
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: true


### PR DESCRIPTION
## Summary
- Add `permissions: {}` defaults to workflows missing explicit permissions
- Add `persist-credentials: false` to all `actions/checkout` steps
- Move `${{ }}` interpolations in `run:` blocks to `env:` vars (template injection prevention)
- Replace `softprops/action-gh-release` with `gh release upload`
- Switch `claude-review-maintainer-prs` from `pull_request_target` to `pull_request` with fork exclusion
- Disable node cache in release workflow (publishes to npm)
- Add zizmor CI workflow for ongoing monitoring

## Test plan
- [x] CI passes (integration tests, e2e tests, linting)
- [x] zizmor workflow runs clean
- [x] Verify next release workflow still works (persist-credentials + gh auth setup-git)

FIx: https://linear.app/langfuse/issue/LFE-9209/zizmor-js-sdk

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR applies a solid set of GitHub Actions security hardening measures recommended by zizmor: `permissions: {}` defaults, `persist-credentials: false` on all checkouts, moving `${{ }}` template expressions in `run:` blocks to `env:` variables, replacing the third-party `softprops/action-gh-release` action with the built-in `gh release upload`, and switching the claude-review workflow from the dangerous `pull_request_target` trigger to `pull_request` with a fork guard. All remaining `${{ }}` uses (Slack payloads, `if:` conditions, controlled `inputs.*`) are outside `run:` blocks and don't present template-injection risk.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — all findings are P2 style/consistency suggestions with no functional impact on correctness or security.
- The PR correctly addresses the primary security concerns flagged by zizmor. The two P2 findings (missing top-level permissions default in one workflow, and a note about step-order fragility in the release workflow) don't block merge and don't affect the current security posture.
- `release.yml` — confirm the `persist-credentials: false` + `gh auth setup-git` combination works end-to-end when the next real release is triggered.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Template injection hardening via env vars, `softprops/action-gh-release` replaced with `gh release upload`, `persist-credentials: false` added with compensating `gh auth setup-git`. Correct overall, but still has `${{ }}` interpolations in Slack payload YAML values (low risk) and `persist-credentials: false` with a token requires verifying the git-push flow actually works end-to-end. |
| .github/workflows/claude-review-maintainer-prs.yml | Switched from `pull_request_target` to `pull_request` with fork exclusion guard — key security improvement. Missing top-level `permissions: {}` unlike the other hardened workflows in this PR. |
| .github/workflows/zizmor.yml | New workflow for ongoing GitHub Actions security monitoring via zizmor. Correctly pinned, minimal permissions, excludes fork PRs. |
| .github/workflows/ci.yml | Added top-level `permissions: {}` and `persist-credentials: false` to all checkout steps — clean hardening with no functional impact. |
| .github/workflows/dependabot-rebase-stale.yml | Added top-level `permissions: {}`. The job uses an external PAT (`DEP_REBASE_PAT`) rather than `GITHUB_TOKEN`, so the empty permissions don't break its operation. |
| .github/workflows/codeql.yml | Added `persist-credentials: false` to checkout step — straightforward hardening change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Trigger] --> B{Workflow}

    B --> C[ci.yml\nRead-only, persist-credentials false]
    B --> D[claude-review-maintainer-prs.yml\npull_request + fork guard]
    B --> E[zizmor.yml\nSARIF security scan]
    B --> F[release.yml\nworkflow_dispatch only]
    B --> G[dependabot-rebase-stale.yml\nexternal PAT, permissions empty]

    F --> F1[Verify branch is main]
    F1 --> F2[Checkout\npersist-credentials false]
    F2 --> F3[Configure Git\ngh auth login + setup-git]
    F3 --> F4[release-it\nversion bump, npm publish]
    F4 --> F5[gh release upload artifacts]
    F5 --> F6[Slack notification]

    D --> D1{Same repo?}
    D1 -- Yes --> D2[Check author permission]
    D2 --> D3[Post claude review comment]
    D1 -- No --> D4[Skip - fork excluded]
```

<sub>Reviews (1): Last reviewed commit: ["ci: harden GitHub Actions workflows with..."](https://github.com/langfuse/langfuse-js/commit/84dbbd340c9aab6c542a8f5f65435b863c4ae498) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28368362)</sub>

<!-- /greptile_comment -->