### PR TITLE
ci: add missing dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,9 @@ updates:
     directory: "/examples"
     schedule:
       interval: "daily"
+    # making zizmor happy as it requires a cooldown value, but we ignore all dependencies in this folder anyway
+    cooldown:
+      default-days: 7
     labels: []
     ignore:
       - dependency-name: "*"


### PR DESCRIPTION
## Change
- add missing cooldown to fix a zizmor warning

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

Adds the missing `cooldown` block to the `/examples` npm entry in `dependabot.yml`, matching the pattern already used by the root npm and `github-actions` entries. The comment correctly notes this entry ignores all dependencies anyway, so the value is effectively a no-op beyond satisfying the zizmor linter.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a config consistency fix with no functional impact.

Single-line config addition that aligns the /examples entry with the existing cooldown pattern used by the other two dependabot entries. No logic changes, no regressions possible.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Adds missing `cooldown: default-days: 7` to the `/examples` npm entry, making it consistent with the other two entries and satisfying the zizmor linter requirement. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[dependabot.yml entries] --> B[npm @ /]
    A --> C[github-actions @ /]
    A --> D[npm @ /examples]

    B --> B1[cooldown: default-days: 7 ✅]
    C --> C1[cooldown: default-days: 7 ✅]
    D --> D1["cooldown: default-days: 7 ✅ (added by this PR)"]
    D --> D2[ignore: dependency-name: '*']
```

<sub>Reviews (1): Last reviewed commit: ["ci: add missing dependabot cooldown"](https://github.com/langfuse/langfuse-js/commit/eee86ec5b4a5f9a2eb3b7a237f4bf708fd466af4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28461820)</sub>

<!-- /greptile_comment -->