### PR TITLE
fix(langchain): emit tool observations for LangChain tool runs

### DIFF
--- a/packages/langchain/src/CallbackHandler.ts
+++ b/packages/langchain/src/CallbackHandler.ts
@@ -17,6 +17,8 @@ import {
   startActiveObservation,
   LangfuseGeneration,
   LangfuseSpan,
+  LangfuseTool,
+  LangfuseObservationAttributes,
   LangfuseGenerationAttributes,
   LangfuseSpanAttributes,
   propagateAttributes,
@@ -49,6 +51,8 @@ type ConstructorParams = {
   traceMetadata?: Record<string, unknown>; // added to all traces
 };
 
+type TrackedObservation = LangfuseSpan | LangfuseGeneration | LangfuseTool;
+
 export class CallbackHandler extends BaseCallbackHandler {
   name = "LangfuseCallbackHandler";
 
@@ -60,7 +64,7 @@ export class CallbackHandler extends BaseCallbackHandler {
 
   private completionStartTimes: Record<string, Date> = {};
   private promptToParentRunMap;
-  private runMap: Map<string, LangfuseSpan | LangfuseGeneration> = new Map();
+  private runMap: Map<string, TrackedObservation> = new Map();
 
   public last_trace_id: string | null = null;
 
@@ -457,6 +461,7 @@ export class CallbackHandler extends BaseCallbackHandler {
       this.logger.debug(`Tool start with ID: ${runId}`);
 
       this.startAndRegisterOtelSpan({
+        type: "tool",
         runId,
         parentRunId,
         runName: name ?? tool.id.at(-1)?.toString() ?? "Tool execution",
@@ -716,7 +721,7 @@ export class CallbackHandler extends BaseCallbackHandler {
     runName: string;
     runId: string;
     parentRunId?: string;
-    attributes: LangfuseGenerationAttributes;
+    attributes: LangfuseSpanAttributes;
     metadata?: Record<string, unknown>;
     tags?: string[];
   }): LangfuseSpan;
@@ -730,14 +735,23 @@ export class CallbackHandler extends BaseCallbackHandler {
     tags?: string[];
   }): LangfuseGeneration;
   private startAndRegisterOtelSpan(params: {
-    type?: "span" | "generation";
+    type: "tool";
     runName: string;
     runId: string;
     parentRunId?: string;
-    attributes: LangfuseGenerationAttributes;
+    attributes: LangfuseSpanAttributes;
     metadata?: Record<string, unknown>;
     tags?: string[];
-  }): LangfuseSpan | LangfuseGeneration {
+  }): LangfuseTool;
+  private startAndRegisterOtelSpan(params: {
+    type?: "span" | "generation" | "tool";
+    runName: string;
+    runId: string;
+    parentRunId?: string;
+    attributes: LangfuseObservationAttributes;
+    metadata?: Record<string, unknown>;
+    tags?: string[];
+  }): TrackedObservation {
     const { type, runName, runId, parentRunId, attributes, metadata, tags } =
       params;
 
@@ -746,37 +760,50 @@ export class CallbackHandler extends BaseCallbackHandler {
       metadata: this.joinTagsAndMetaData(tags, metadata),
       level: tags && tags.includes(LANGSMITH_HIDDEN_TAG) ? "DEBUG" : undefined,
       ...attributes,
-    } as LangfuseGenerationAttributes;
+    } as LangfuseObservationAttributes;
+
+    const parentSpanContext = parentRunId
+      ? this.runMap.get(parentRunId)?.otelSpan.spanContext()
+      : undefined;
 
     const observation =
       type === "generation"
         ? startActiveObservation(
             runName,
             (gen) => {
-              gen.update(observationAttributes);
+              gen.update(observationAttributes as LangfuseGenerationAttributes);
               return gen;
             },
             {
               asType: "generation",
-              parentSpanContext: parentRunId
-                ? this.runMap.get(parentRunId)?.otelSpan.spanContext()
-                : undefined,
+              parentSpanContext,
               endOnExit: false,
             },
           )
-        : startActiveObservation(
-            runName,
-            (span) => {
-              span.update(observationAttributes);
-              return span;
-            },
-            {
-              parentSpanContext: parentRunId
-                ? this.runMap.get(parentRunId)?.otelSpan.spanContext()
-                : undefined,
-              endOnExit: false,
-            },
-          );
+        : type === "tool"
+          ? startActiveObservation(
+              runName,
+              (tool) => {
+                tool.update(observationAttributes as LangfuseSpanAttributes);
+                return tool;
+              },
+              {
+                asType: "tool",
+                parentSpanContext,
+                endOnExit: false,
+              },
+            )
+          : startActiveObservation(
+              runName,
+              (span) => {
+                span.update(observationAttributes as LangfuseSpanAttributes);
+                return span;
+              },
+              {
+                parentSpanContext,
+                endOnExit: false,
+              },
+            );
     this.runMap.set(runId, observation);
 
     return observation;

--- a/tests/integration/langchain.integration.test.ts
+++ b/tests/integration/langchain.integration.test.ts
@@ -1,0 +1,67 @@
+import { DynamicTool } from "@langchain/core/tools";
+import { CallbackHandler } from "@langfuse/langchain";
+import { LangfuseOtelSpanAttributes } from "@langfuse/tracing";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { SpanAssertions } from "./helpers/assertions.js";
+import {
+  setupTestEnvironment,
+  teardownTestEnvironment,
+  waitForSpanExport,
+  type TestEnvironment,
+} from "./helpers/testSetup.js";
+
+describe("LangChain callback handler integration tests", () => {
+  let testEnv: TestEnvironment;
+  let assertions: SpanAssertions;
+
+  beforeEach(async () => {
+    testEnv = await setupTestEnvironment();
+    assertions = new SpanAssertions(testEnv.mockExporter);
+  });
+
+  afterEach(async () => {
+    await teardownTestEnvironment(testEnv);
+  });
+
+  it("should mark LangChain tool runs as tool observations", async () => {
+    const calculatorTool = new DynamicTool({
+      name: "calculator",
+      description:
+        "Perform basic arithmetic operations. Input should be a mathematical expression.",
+      func: async (input: string) => {
+        const sanitizedInput = input.replace(/[^0-9+\-*/().]/g, "");
+        const result = eval(sanitizedInput);
+        return `The result is: ${result}`;
+      },
+    });
+
+    const handler = new CallbackHandler();
+
+    const result = await calculatorTool.invoke("25*4", {
+      callbacks: [handler],
+    });
+
+    expect(result).toBe("The result is: 100");
+
+    await waitForSpanExport(testEnv.mockExporter, 1);
+
+    assertions.expectSpanCount(1);
+    assertions.expectSpanWithName("calculator");
+    assertions.expectSpanAttribute(
+      "calculator",
+      LangfuseOtelSpanAttributes.OBSERVATION_TYPE,
+      "tool",
+    );
+    assertions.expectSpanAttributeContains(
+      "calculator",
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+      "25*4",
+    );
+    assertions.expectSpanAttribute(
+      "calculator",
+      LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT,
+      "The result is: 100",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- create Langfuse `tool` observations when the LangChain callback handler sees `handleToolStart`
- keep the internal run map typed for the observation kinds this handler actually tracks
- add an integration test that invokes a LangChain `DynamicTool` and asserts the emitted OTEL observation type is `tool`

## Verification
- `source ~/.nvm/nvm.sh && pnpm build`
- `source ~/.nvm/nvm.sh && pnpm vitest run tests/integration/langchain.integration.test.ts`

## Context
- Fixes support issue 281: LangChain JS callback handler tool calls were being ingested as generic spans instead of type `tool`.
- Pylon issue: https://app.usepylon.com/support/issues/views/19694d27-e596-4e70-ab12-93efb60eb870?issueNumber=281

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes LangChain tool runs being emitted as generic span observations instead of `tool` observations by adding `type: \"tool\"` to the `startAndRegisterOtelSpan` call in `handleToolStart`, and updating the `runMap` type from `LangfuseSpan | LangfuseGeneration` to the new `TrackedObservation` union that includes `LangfuseTool`. An integration test validates the OTEL attribute emission end-to-end.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the core fix is sound and well-tested.

The implementation correctly adds `LangfuseTool` to the observation lifecycle. `LangfuseToolAttributes = LangfuseSpanAttributes` so all downstream paths (`handleToolEnd`, `handleToolError`, `handleOtelSpanEnd`) work without modification. The only finding is a P2 `eval()` style suggestion in a test fixture that does not affect correctness or production code.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/langchain/src/CallbackHandler.ts | Adds `type: "tool"` to `handleToolStart`, introduces `TrackedObservation` union type, and adds a third overload for `startAndRegisterOtelSpan`. The `handleOtelSpanEnd` path correctly works with `LangfuseTool` since `LangfuseToolAttributes = LangfuseSpanAttributes`. |
| tests/integration/langchain.integration.test.ts | New integration test verifies the tool observation type, input, and output via OTEL span attributes. Uses `eval()` on regex-sanitized input inside the test fixture, which is a minor code quality concern. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[LangChain Callback Event] --> B{Event Type}
    B -->|handleLLMStart| C["startAndRegisterOtelSpan(type: generation)"]
    B -->|handleChainStart| D["startAndRegisterOtelSpan(type: span)"]
    B -->|handleToolStart| E["startAndRegisterOtelSpan(type: tool) NEW"]
    B -->|handleRetrieverStart| F["startAndRegisterOtelSpan(type: span)"]
    C --> G["runMap → LangfuseGeneration"]
    D --> H["runMap → LangfuseSpan"]
    E --> I["runMap → LangfuseTool NEW"]
    F --> J["runMap → LangfuseSpan"]
    G --> K[handleOtelSpanEnd]
    H --> K
    I --> K
    J --> K
    K --> L["TrackedObservation.update().end()"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: tests/integration/langchain.integration.test.ts
Line: 33-35

Comment:
**`eval()` in test fixture**

The test tool uses `eval()` on the sanitized expression. While the regex `[^0-9+\-*/().]` is reasonable and the input is hardcoded in this test, `eval()` in fixture code can be copied into production and is unnecessary here — a simple numeric assertion like `25 * 4 === 100` would serve the same purpose without it.

```suggestion
        const result = Function(`"use strict"; return (${sanitizedInput})`)();
```

Or simpler, since the test only needs to verify the span type and not the arithmetic result, the `func` body could just `return \`The result is: \${sanitizedInput}\`;` directly.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(langchain): emit tool observations f..."](https://github.com/langfuse/langfuse-js/commit/396b26e8f4444e73210796e0c4b21a80b2118361) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28661122)</sub>

<!-- /greptile_comment -->