### PR TITLE
fix(ci): disable zizmor advanced security to unblock releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,9 @@ updates:
     directory: "/examples"
     schedule:
       interval: "daily"
+    # making zizmor happy as it requires a cooldown value, but we ignore all dependencies in this folder anyway
+    cooldown:
+      default-days: 7
     labels: []
     ignore:
       - dependency-name: "*"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -19,7 +19,6 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
       contents: read
     steps:
       - name: Checkout
@@ -29,4 +28,7 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
         with:
-          advanced-security: true
+          # Using false as a code scanning ruleset would block the release
+          # workflow which creates a new commit and pushes directly to main.
+          advanced-security: false
+          min-severity: medium


### PR DESCRIPTION
## Summary
- Disables `advanced-security` for zizmor so it no longer uploads SARIF to GitHub Code Scanning
- Sets `min-severity: medium` to filter noisy low-severity findings
- Removes now-unnecessary `security-events: write` permission

## Context
Same change as langfuse/langfuse-python#1630. With `advanced-security: true`, zizmor registers as a code scanning tool. A branch protection ruleset requiring code scanning results would block the release workflow, which creates a new commit and pushes directly to main — the commit doesn't exist on GitHub yet, so code scanning can't produce results for it.

## Test plan
- [ ] Verify zizmor workflow still runs and catches issues on PRs
- [ ] Verify release workflow can push to main without being blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR disables zizmor's `advanced-security` mode (preventing SARIF upload to GitHub Code Scanning), sets a `min-severity: medium` filter to suppress low-severity noise, and removes the now-unneeded `security-events: write` permission. The change mirrors the fix already applied in `langfuse/langfuse-python#1630` and resolves the root cause: branch protection rules require code scanning results, but the release workflow commits directly to `main` with no prior scan, causing a deadlock.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted CI configuration fix with no functional or security regressions.

Both changed files are CI/Dependabot config only. The logic is correct: `advanced-security: false` stops SARIF upload (removing the branch-protection deadlock), `min-severity: medium` reduces noise without disabling the tool, and dropping `security-events: write` follows least-privilege. No P0/P1 findings; all changes are well-commented and mirror an already-landed fix in the Python SDK repo.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/zizmor.yml | Disables SARIF upload via `advanced-security: false`, adds `min-severity: medium` filter, and removes the now-unnecessary `security-events: write` permission — all consistent with the stated goal of unblocking releases. |
| .github/dependabot.yml | Adds `cooldown` entries (with an explanatory comment) to satisfy zizmor's medium-severity findings; straightforward housekeeping change with no functional risk. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PR as PR / push to main
    participant GHA as GitHub Actions
    participant Zizmor as zizmor-action
    participant CS as GitHub Code Scanning (SARIF)
    participant BP as Branch Protection Ruleset

    PR->>GHA: Trigger zizmor workflow
    GHA->>Zizmor: Run (advanced-security: false, min-severity: medium)
    Zizmor-->>GHA: Results (medium+ severity only, stdout/annotations)
    Note over CS: SARIF NOT uploaded
    Note over BP: No code-scanning result required → release push unblocked
    GHA-->>PR: Workflow pass/fail (annotation-only)
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): disable zizmor advanced securit..."](https://github.com/langfuse/langfuse-js/commit/3ee47ea9e1223885e9ed8f5f87405266a06cf6bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28761375)</sub>

<!-- /greptile_comment -->