### PR TITLE
fix(ci): allow for immutable GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,28 +227,6 @@ jobs:
         id: version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
-      - name: Create release artifacts archive
-        if: inputs.dry_run == false
-        run: |
-          mkdir -p release-artifacts
-          for pkg in packages/*/dist; do
-            pkg_name=$(basename $(dirname $pkg))
-            echo "Creating archive for $pkg_name..."
-            tar -czf release-artifacts/langfuse-js-sdk-${pkg_name}-${STEPS_VERSION_OUTPUTS_VERSION}.tar.gz -C $(dirname $pkg) dist
-          done
-          echo "Build artifacts:"
-          ls -lh release-artifacts/
-        env:
-          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
-
-      - name: Upload release artifacts to GitHub Release
-        if: inputs.dry_run == false
-        run: |
-          gh release upload "v${VERSION}" release-artifacts/*.tar.gz --clobber
-        env:
-          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-          VERSION: ${{ steps.version.outputs.version }}
-
       - name: Notify Slack on success
         if: success() && inputs.dry_run == false
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -498,12 +498,10 @@ jobs:
       - name: Rollback notification on partial failure
         if: failure() && steps.release.outcome == 'success'
         run: |
-          echo "⚠️  CRITICAL: Release succeeded but subsequent steps failed"
+          echo "⚠️  Release succeeded but post-release steps failed"
           echo "Published version: v${STEPS_VERSION_OUTPUTS_VERSION}"
-          echo "Manual intervention may be required"
           echo ""
-          echo "Options:"
-          echo "1. Re-run the workflow to complete GitHub release artifacts upload"
-          echo "2. Manually upload release artifacts for tag v${STEPS_VERSION_OUTPUTS_VERSION}"
+          echo "The release is fully complete (version bumped, npm published, GitHub release with all artifacts created)."
+          echo "Check the workflow logs for what failed in post-release steps (e.g., Slack notifications)."
         env:
           STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 # Build outputs
 dist/
 build/
+release-artifacts/
 *.tsbuildinfo
 .turbo
 

--- a/.release-it.ci.json
+++ b/.release-it.ci.json
@@ -18,7 +18,7 @@
     "before:init": [],
     "after:bump": [
       "pnpm build",
-      "mkdir -p release-artifacts && for pkg in packages/*/dist; do pkg_name=$(basename $(dirname $pkg)); tar -czf release-artifacts/langfuse-js-sdk-$pkg_name-v${version}.tar.gz -C $(dirname $pkg) dist; done"
+      "set -e; mkdir -p release-artifacts && for pkg in packages/*/dist; do pkg_name=$(basename $(dirname $pkg)); tar -czf release-artifacts/langfuse-js-sdk-$pkg_name-${version}.tar.gz -C $(dirname $pkg) dist; done"
     ],
     "after:release": "pnpm -r publish --access public --no-git-checks --provenance"
   },

--- a/.release-it.ci.json
+++ b/.release-it.ci.json
@@ -16,13 +16,17 @@
   },
   "hooks": {
     "before:init": [],
-    "after:bump": ["pnpm build"],
+    "after:bump": [
+      "pnpm build",
+      "mkdir -p release-artifacts && for pkg in packages/*/dist; do pkg_name=$(basename $(dirname $pkg)); tar -czf release-artifacts/langfuse-js-sdk-$pkg_name-v${version}.tar.gz -C $(dirname $pkg) dist; done"
+    ],
     "after:release": "pnpm -r publish --access public --no-git-checks --provenance"
   },
   "github": {
     "release": true,
     "releaseName": "v${version}",
-    "autoGenerate": true
+    "autoGenerate": true,
+    "assets": ["release-artifacts/*.tar.gz"]
   },
   "plugins": {
     "@release-it/bumper": {


### PR DESCRIPTION
## Summary
- Move release artifact archive creation from a separate workflow step into release-it's `after:bump` hook
- Use release-it's `github.assets` to upload archives atomically with the GitHub release creation
- Remove the separate `gh release upload --clobber` step that allowed artifacts to be silently overwritten on re-runs
- Add `release-artifacts/` to `.gitignore`

## Context
Previously, the GitHub release was created by release-it and the artifact upload was a separate workflow step. This meant:
1. If the upload step failed, you'd have a release without artifacts and no clean retry path
2. The `--clobber` flag was needed as a workaround, but it also meant artifacts could be overwritten at any time

Now release-it handles both in a single atomic operation.

## Test plan
- [x] `release-it --dry-run` shows correct lifecycle ordering (bump → build → archive → release)
- [x] Archive creation command produces all 6 package tarballs
- [ ] Run a pre-release (`prepatch --preRelease=alpha`) to verify end-to-end


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR consolidates GitHub release artifact creation and upload into release-it's `after:bump` hook and `github.assets`, replacing the former separate `gh release upload --clobber` step. The result is an atomic release where the GitHub release and its 6 tarballs are either created together or not at all, eliminating the previous race condition where a failed upload left a release without artifacts.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the core atomic release logic is correct and the only finding is a stale comment in the rollback notification step.

All findings are P2. The implementation correctly moves archive creation into `after:bump` before the GitHub release is created, achieving the stated atomicity goal. The gitignore addition and config changes are clean. The single flagged issue (stale rollback message text) is a documentation-quality concern that doesn't affect runtime behavior.

`.github/workflows/release.yml` lines 498–509 — stale rollback guidance should be updated to reflect the new atomic flow.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .release-it.ci.json | Added archive creation in `after:bump` hook and `github.assets` glob; release-it now atomically creates the GitHub release with all 6 tarballs. |
| .github/workflows/release.yml | Workflow unchanged structurally; separate artifact upload step removed; rollback notification text is now stale after the atomic release change. |
| .gitignore | Added `release-artifacts/` to prevent generated tarballs from being accidentally committed. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Workflow trigger] --> B[pnpm build + verify artifacts]
    B --> C[release-it: bump versions in package.json]
    C --> D["after:bump hook: pnpm build (versioned)"]
    D --> E["after:bump hook: tar all packages → release-artifacts/*.tar.gz"]
    E --> F[release-it: git commit + tag + push]
    F --> G["release-it: create GitHub release WITH assets (atomic)"]
    G --> H["after:release hook: pnpm -r publish to npm"]
    H --> I[Slack notification]

    G -- upload fails --> X[❌ Release creation fails — no orphaned release]
    D -- build fails --> Y[❌ Hook fails — no version bumped yet]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/release.yml`, line 498-509 ([link](https://github.com/langfuse/langfuse-js/blob/c56f3da47293db9c42b90488dda0c07b8a45ceff/.github/workflows/release.yml#L498-L509)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale rollback guidance**

   With the new atomic approach, if `steps.release` succeeds, the GitHub release **and** its artifacts are already uploaded — there is nothing left to re-upload. Options 1 and 2 in this echo block no longer apply and could mislead an on-call engineer into performing unnecessary manual work. The only remaining failure scenario at this point is the Slack notification steps, which are non-critical.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/release.yml
   Line: 498-509

   Comment:
   **Stale rollback guidance**

   With the new atomic approach, if `steps.release` succeeds, the GitHub release **and** its artifacts are already uploaded — there is nothing left to re-upload. Options 1 and 2 in this echo block no longer apply and could mislead an on-call engineer into performing unnecessary manual work. The only remaining failure scenario at this point is the Slack notification steps, which are non-critical.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/release.yml
Line: 498-509

Comment:
**Stale rollback guidance**

With the new atomic approach, if `steps.release` succeeds, the GitHub release **and** its artifacts are already uploaded — there is nothing left to re-upload. Options 1 and 2 in this echo block no longer apply and could mislead an on-call engineer into performing unnecessary manual work. The only remaining failure scenario at this point is the Slack notification steps, which are non-critical.

```suggestion
      - name: Rollback notification on partial failure
        if: failure() && steps.release.outcome == 'success'
        run: |
          echo "⚠️  CRITICAL: Release succeeded but a subsequent step failed"
          echo "Published version: v${STEPS_VERSION_OUTPUTS_VERSION}"
          echo ""
          echo "The GitHub release, artifacts, and npm packages were published successfully."
          echo "Only post-release steps (e.g. Slack notification) may have failed — check the workflow logs."
        env:
          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): make GitHub release artifacts i..."](https://github.com/langfuse/langfuse-js/commit/c56f3da47293db9c42b90488dda0c07b8a45ceff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28765542)</sub>

<!-- /greptile_comment -->