### PR TITLE
fix(ci): pin actions/setup-node version comment to v6.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       # Pin to v5 — v6 uses pnpm v11 internally which mutates the lockfile
       # https://github.com/pnpm/action-setup/issues/228
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
       - run: pnpm install --frozen-lockfile
@@ -60,7 +60,7 @@ jobs:
       # Pin to v5 — v6 uses pnpm v11 internally which mutates the lockfile
       # https://github.com/pnpm/action-setup/issues/228
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
 
@@ -159,7 +159,7 @@ jobs:
       # Pin to v5 — v6 uses pnpm v11 internally which mutates the lockfile
       # https://github.com/pnpm/action-setup/issues/228
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary
- The pinned SHA for `actions/setup-node` resolves to tag `v6.3.0`, but the comment said `# v6`, which zizmor flags as `ref-version-mismatch` and fails the security workflow.
- Updates 4 call sites (3 in `ci.yml`, 1 in `release.yml`) to `# v6.3.0`.

## Test plan
- [ ] zizmor security workflow passes on this PR
- [ ] CI jobs still run `actions/setup-node` as before (no behavior change — same SHA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR corrects the version comment on all four `actions/setup-node` usages from `# v6` to `# v6.3.0` to match the pinned SHA `53b83947a5a98c8d113130e565377fae1a50d02f`, resolving a `ref-version-mismatch` finding from zizmor. No behavior changes — the SHA and workflow logic are identical.

<h3>Confidence Score: 5/5</h3>

Safe to merge — comment-only change with no behavior impact.

All four changes are purely cosmetic comment corrections that align the version tag with the pinned SHA. No logic, no dependencies, no security surface altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Updated 3 `actions/setup-node` version comments from `# v6` to `# v6.3.0`; SHA and workflow logic unchanged. |
| .github/workflows/release.yml | Updated 1 `actions/setup-node` version comment from `# v6` to `# v6.3.0`; SHA and workflow logic unchanged. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["zizmor lint check"] -->|"ref-version-mismatch: SHA ≠ comment tag"| B["Security workflow fails"]
    B --> C["PR fix: comment updated\n# v6 → # v6.3.0\n(SHA unchanged)"]
    C --> D["zizmor lint passes"]
    D --> E["CI & release workflows\nrun as before"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): pin actions/setup-node version ..."](https://github.com/langfuse/langfuse-js/commit/99438978cd84829e710447dff94d8e934080fbcd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29149092)</sub>

<!-- /greptile_comment -->