### PR TITLE
chore(ci): pin remaining action version comments to immutable patch tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       # Pin to v5 — v6 uses pnpm v11 internally which mutates the lockfile
       # https://github.com/pnpm/action-setup/issues/228
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
       - run: pnpm install --frozen-lockfile
@@ -60,7 +60,7 @@ jobs:
       # Pin to v5 — v6 uses pnpm v11 internally which mutates the lockfile
       # https://github.com/pnpm/action-setup/issues/228
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
 
@@ -159,7 +159,7 @@ jobs:
       # Pin to v5 — v6 uses pnpm v11 internally which mutates the lockfile
       # https://github.com/pnpm/action-setup/issues/228
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       LANGFUSE_PUBLIC_KEY: "pk-lf-1234567890"
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       # Pin to v5 — v6 uses pnpm v11 internally which mutates the lockfile
@@ -54,7 +54,7 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       # Pin to v5 — v6 uses pnpm v11 internally which mutates the lockfile
@@ -153,7 +153,7 @@ jobs:
     timeout-minutes: 3
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       # Pin to v5 — v6 uses pnpm v11 internally which mutates the lockfile

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         env:
           INPUTS_CONFIRM_MAJOR: ${{ inputs.confirm_major }}
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_ACCESS_TOKEN }}
@@ -231,7 +231,7 @@ jobs:
 
       - name: Notify Slack on success
         if: success() && inputs.dry_run == false
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }}
           webhook-type: incoming-webhook
@@ -325,7 +325,7 @@ jobs:
 
       - name: Notify Slack on dry run success
         if: success() && inputs.dry_run == true
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_ENGINEERING }}
           webhook-type: incoming-webhook
@@ -407,7 +407,7 @@ jobs:
 
       - name: Notify Slack on failure
         if: failure()
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_ENGINEERING }}
           webhook-type: incoming-webhook

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Run zizmor


### PR DESCRIPTION
## Summary
- Tightens the `# v6` / `# v3` floating-major comments on SHA-pinned actions to their exact patch-level tags so the pin documentation is unambiguous.
  - `actions/checkout` → `# v6.0.2` (ci.yml, codeql.yml, zizmor.yml, release.yml)
  - `slackapi/slack-github-action` → `# v3.0.1` (release.yml ×3)
- No behavior change — the SHAs are identical, only the trailing comment is updated.
- Stacked on top of #792. Merge that first, then rebase this onto `main`.

`orange-buffalo/dependabot-auto-rebase` is intentionally left alone: its pin resolves to a `v1` *branch* head (not a tag), and changing that is a separate decision about whether to move off a mutable ref.

## Test plan
- [ ] zizmor security workflow passes on this PR (no `ref-version-mismatch` findings)
- [ ] CI still green — no functional change to any action invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR tightens the trailing version comments on SHA-pinned GitHub Actions references from floating major tags (`# v6`, `# v3`) to exact patch-level tags (`# v6.0.2`, `# v3.0.1`) across `ci.yml`, `codeql.yml`, `release.yml`, and `zizmor.yml`. The pinned SHAs are identical — this is a documentation-only change with no behavioral impact, improving audit clarity and satisfying zizmor's `ref-version-mismatch` lint rule.

<h3>Confidence Score: 5/5</h3>

Safe to merge — comment-only change, no action SHAs or workflow logic modified.

All changes are trailing comments on already-pinned SHA references. No SHAs were altered, no workflow logic changed, and all files are internally consistent. No issues found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Three `actions/checkout` version comments updated from `# v6` to `# v6.0.2`; SHA unchanged, no functional impact. |
| .github/workflows/codeql.yml | One `actions/checkout` version comment updated from `# v6` to `# v6.0.2`; SHA and behavior unchanged. |
| .github/workflows/release.yml | `actions/checkout` comment updated to `# v6.0.2` and all three `slackapi/slack-github-action` comments updated to `# v3.0.1`; SHAs unchanged. |
| .github/workflows/zizmor.yml | One `actions/checkout` version comment updated from `# v6` to `# v6.0.2`; SHA and behavior unchanged. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SHA-pinned action reference] --> B{Version comment}
    B -- Before --> C["# v6 / # v3 (floating major)"]
    B -- After --> D["# v6.0.2 / # v3.0.1 (exact patch tag)"]
    C --> E[Ambiguous — SHA could be any patch in that major]
    D --> F[Unambiguous — exact patch documented]
    F --> G[Passes zizmor ref-version-mismatch check]
```

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into chore/tighten-a..."](https://github.com/langfuse/langfuse-js/commit/495a87b7aa9c3e2cd3c005296bbbae0090801fe7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29149745)</sub>

<!-- /greptile_comment -->