### PR TITLE
fix(client): apply mustache substitution to text items in array message content

### DIFF
--- a/packages/client/src/prompt/promptClients.test.ts
+++ b/packages/client/src/prompt/promptClients.test.ts
@@ -99,4 +99,31 @@ describe("ChatPromptClient.compile() — array (multimodal) content", () => {
     expect(result[1].role).toBe("user");
     expect(result[1].content[0]).toEqual({ type: "input_file", file_url: "path_to_pdf" });
   });
+
+  it("applies mustache substitution to text items inside placeholder-injected array content", () => {
+    const client = new ChatPromptClient(
+      makeChatPrompt([
+        { type: ChatMessageType.ChatMessage, role: "system", content: "You are helpful." },
+        { type: ChatMessageType.Placeholder, name: "messages" },
+      ]),
+    );
+    const messages = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Hello {{name}}" },
+          { type: "image_url", image_url: { url: "https://example.com/{{name}}.png" } },
+        ],
+      },
+    ];
+    const result = client.compile({ name: "Alice" }, { messages }) as any[];
+    expect(result).toHaveLength(2);
+    expect(result[1].role).toBe("user");
+    expect(result[1].content[0]).toEqual({ type: "text", text: "Hello Alice" });
+    // Non-text parts inside placeholder content are passed through untouched
+    expect(result[1].content[1]).toEqual({
+      type: "image_url",
+      image_url: { url: "https://example.com/{{name}}.png" },
+    });
+  });
 });

--- a/packages/client/src/prompt/promptClients.test.ts
+++ b/packages/client/src/prompt/promptClients.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { ChatPromptClient } from "./promptClients.js";
+import { ChatMessageType } from "./types.js";
+
+// Minimal prompt factory for tests
+function makeChatPrompt(messages: any[]): any {
+  return {
+    name: "test-prompt",
+    version: 1,
+    config: {},
+    labels: [],
+    tags: [],
+    commitMessage: null,
+    prompt: messages,
+  };
+}
+
+describe("ChatPromptClient.compile() — array (multimodal) content", () => {
+  it("compiles string content normally (regression)", () => {
+    const client = new ChatPromptClient(
+      makeChatPrompt([
+        { type: ChatMessageType.ChatMessage, role: "user", content: "Hello {{name}}" },
+      ]),
+    );
+    const result = client.compile({ name: "Alice" });
+    expect(result).toEqual([{ role: "user", content: "Hello Alice" }]);
+  });
+
+  it("does not crash when message content is an array", () => {
+    const client = new ChatPromptClient(
+      makeChatPrompt([
+        {
+          type: ChatMessageType.ChatMessage,
+          role: "user",
+          content: [
+            { type: "image_url", image_url: { url: "https://example.com/img.png" } },
+          ],
+        },
+      ]),
+    );
+    expect(() => client.compile({})).not.toThrow();
+  });
+
+  it("applies variable substitution to text-type items within array content", () => {
+    const client = new ChatPromptClient(
+      makeChatPrompt([
+        {
+          type: ChatMessageType.ChatMessage,
+          role: "user",
+          content: [
+            { type: "text", text: "Describe this {{doc_type}}" },
+            { type: "image_url", image_url: { url: "https://example.com/img.png" } },
+          ],
+        },
+      ]),
+    );
+    const result = client.compile({ doc_type: "invoice" }) as any[];
+    expect(result[0].content[0].text).toBe("Describe this invoice");
+    // Non-text parts are passed through unchanged
+    expect(result[0].content[1]).toEqual({
+      type: "image_url",
+      image_url: { url: "https://example.com/img.png" },
+    });
+  });
+
+  it("passes through non-text items in array content without modification", () => {
+    const client = new ChatPromptClient(
+      makeChatPrompt([
+        {
+          type: ChatMessageType.ChatMessage,
+          role: "user",
+          content: [
+            { type: "input_file", file_url: "path/to/file.pdf" },
+          ],
+        },
+      ]),
+    );
+    const result = client.compile({}) as any[];
+    expect(result[0].content[0]).toEqual({ type: "input_file", file_url: "path/to/file.pdf" });
+  });
+
+  it("resolves placeholder containing messages with array content (issue #12338)", () => {
+    const client = new ChatPromptClient(
+      makeChatPrompt([
+        { type: ChatMessageType.ChatMessage, role: "system", content: "You are helpful." },
+        { type: ChatMessageType.Placeholder, name: "attachments" },
+      ]),
+    );
+    const attachments = [
+      {
+        role: "user",
+        content: [
+          { type: "input_file", file_url: "path_to_pdf" },
+        ],
+      },
+    ];
+    const result = client.compile({ emailBody: "test" }, { attachments }) as any[];
+    expect(result).toHaveLength(2);
+    expect(result[1].role).toBe("user");
+    expect(result[1].content[0]).toEqual({ type: "input_file", file_url: "path_to_pdf" });
+  });
+});

--- a/packages/client/src/prompt/promptClients.ts
+++ b/packages/client/src/prompt/promptClients.ts
@@ -375,21 +375,33 @@ export class ChatPromptClient extends BasePromptClient {
     }
 
     return messagesWithPlaceholdersReplaced.map((item) => {
-      if (
-        typeof item === "object" &&
-        item !== null &&
-        "role" in item &&
-        "content" in item &&
-        typeof item.content === "string"
-      ) {
-        return {
-          ...item,
-          content: mustache.render(item.content, variables ?? {}),
-        };
-      } else {
-        // Return placeholder or stringified value as-is
-        return item;
+      if (typeof item === "object" && item !== null && "role" in item && "content" in item) {
+        if (typeof item.content === "string") {
+          return {
+            ...item,
+            content: mustache.render(item.content, variables ?? {}),
+          };
+        } else if (Array.isArray(item.content)) {
+          // Multimodal content: apply mustache substitution to text-type parts only,
+          // leaving image_url, input_file, and other non-text parts untouched.
+          return {
+            ...item,
+            content: (item.content as any[]).map((part: any) => {
+              if (
+                typeof part === "object" &&
+                part !== null &&
+                part.type === "text" &&
+                typeof part.text === "string"
+              ) {
+                return { ...part, text: mustache.render(part.text, variables ?? {}) };
+              }
+              return part;
+            }),
+          };
+        }
       }
+      // Return placeholder or non-message items as-is
+      return item;
     });
   }
 
@@ -436,6 +448,22 @@ export class ChatPromptClient extends BasePromptClient {
           // Complete placeholder fill-in, replace with it
           messagesWithPlaceholdersReplaced.push(
             ...(placeholderValue as ChatMessage[]).map((msg) => {
+              if (Array.isArray(msg.content)) {
+                return {
+                  role: msg.role,
+                  content: (msg.content as any[]).map((part: any) => {
+                    if (
+                      typeof part === "object" &&
+                      part !== null &&
+                      part.type === "text" &&
+                      typeof part.text === "string"
+                    ) {
+                      return { ...part, text: this._transformToLangchainVariables(part.text) };
+                    }
+                    return part;
+                  }),
+                };
+              }
               return {
                 role: msg.role,
                 content: this._transformToLangchainVariables(msg.content),
@@ -469,7 +497,19 @@ export class ChatPromptClient extends BasePromptClient {
       ) {
         messagesWithPlaceholdersReplaced.push({
           role: item.role,
-          content: this._transformToLangchainVariables(item.content),
+          content: Array.isArray(item.content)
+            ? (item.content as any[]).map((part: any) => {
+                if (
+                  typeof part === "object" &&
+                  part !== null &&
+                  part.type === "text" &&
+                  typeof part.text === "string"
+                ) {
+                  return { ...part, text: this._transformToLangchainVariables(part.text) };
+                }
+                return part;
+              })
+            : this._transformToLangchainVariables(item.content),
         });
       }
     }


### PR DESCRIPTION
## Problem

ChatPromptClient.compile() silently skips variable substitution when a chat message's content field is an **array** (multimodal / OpenAI-style format, e.g. [{ type: 'text', text: 'Hello {{name}}' }, { type: 'image_url', ... }]).

The existing guard 	ypeof item.content === 'string' short-circuits to the \else\ branch for array content, returning the array completely unchanged — \{{variable}}\ placeholders inside text parts are never resolved.

Reported in langfuse/langfuse#12338.

## Root cause

`	ypescript
// Before — array content falls into the else branch untouched
if (... && typeof item.content === 'string') {
  return { ...item, content: mustache.render(item.content, variables) };
} else {
  return item; // ← arrays pass through here with no substitution
}
`

## Fix

Split the \string\ branch into two cases:

1. **String content** — existing path unchanged.
2. **Array content** — iterate content parts; for each part with 	ype === 'text' and a string 	ext field, call mustache.render(part.text, variables). All other part types (image_url, input_file, etc.) are passed through untouched.

The same two-case pattern is applied inside getLangchainPrompt() wherever _transformToLangchainVariables() was previously called directly on msg.content/item.content (which would throw on arrays).

## Tests

Added packages/client/src/prompt/promptClients.test.ts with cases covering:
- String content regression
- No crash on array content
- Variable substitution in text parts
- Non-text parts passed through unchanged
- Placeholder resolution where placeholder messages have array content

## Checklist
- [x] Bug fix (non-breaking change)
- [x] Tests added
- [x] Existing behaviour unchanged for string content

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes `ChatPromptClient.compile()` and `getLangchainPrompt()` silently skipping Mustache variable substitution when a chat message's `content` field is an array (multimodal / OpenAI-style format). The fix adds an `Array.isArray` branch that iterates content parts and applies `mustache.render` (or `_transformToLangchainVariables`) only to parts with `type === "text"`, leaving all other part types untouched.

- **`compile()` fix**: a new `else if (Array.isArray(item.content))` branch in the final `map` handles multimodal messages; placeholder-injected messages with array content also flow through this same `map` and benefit automatically.
- **`getLangchainPrompt()` fix**: two symmetric array-content branches are added—one for placeholder-filled messages and one for regular chat messages—both converting `{{var}}` syntax to `{var}` for LangChain.
- **Tests**: five new `vitest` cases cover string-content regression, no-crash on array content, text-part substitution, non-text part pass-through, and placeholder resolution with array content.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the fix correctly extends both compile() and getLangchainPrompt() to handle array content, and existing string-content behaviour is unchanged.

The core logic is sound across all three new code paths and the added tests cover the key scenarios. The two remaining gaps—duplicated part-mapping code and a missing test for mustache substitution inside placeholder-injected array content—are style and coverage concerns that do not affect correctness of the shipped fix.

promptClients.ts warrants a second look for the three independent copies of the part-mapping pattern, which would be worth consolidating before the codebase grows further.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant compile
    participant map as compile() map
    participant mustache

    Caller->>compile: compile(variables, placeholders)
    Note over compile: Resolve placeholders into messagesWithPlaceholdersReplaced
    compile->>map: map over resolved messages
    alt string content
        map->>mustache: mustache.render(content, variables)
        mustache-->>map: rendered string
    else array content (NEW)
        loop each part in content array
            alt "part.type === text"
                map->>mustache: mustache.render(part.text, variables)
                mustache-->>map: rendered text
            else non-text part
                map->>map: pass through unchanged
            end
        end
    else other or placeholder
        map->>map: return item as-is
    end
    map-->>Caller: compiled messages[]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/client/src/prompt/promptClients.ts:384-401
**Duplicated array-content mapping logic**

The `part => (part.type === "text" && typeof part.text === "string") ? { ...part, text: ... } : part` pattern now appears three times: once in `compile()` and twice in `getLangchainPrompt()` (once for placeholder messages, once for regular chat messages). A small private helper—e.g. `_applyToArrayContentParts(parts, fn)`—would centralise the logic and make future changes (e.g., supporting a new part type) easier to apply consistently.

### Issue 2 of 2
packages/client/src/prompt/promptClients.test.ts:84-100
**No test for mustache substitution in placeholder-injected array content**

The test verifies that array content from a placeholder passes through without crashing, but the injected messages only contain an `input_file` part (which is intentionally not substituted). There is no test that injects a placeholder whose messages contain a `{ type: "text", text: "Hello {{name}}" }` part and then asserts that `compile({ name: "Alice" }, { ... })` resolves it to `"Hello Alice"`. Given that variable substitution in placeholder array content is now supported (the injected messages go through the `map` and hit the new array branch), a test for this path would confirm the intended behaviour and guard against regressions.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(client): apply mustache substitution..."](https://github.com/langfuse/langfuse-js/commit/b7d4cd7498121d18cce3312eac0a67da4f4694d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31758173)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->