### PR TITLE
chore: add CODEOWNERS for GitHub config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # Currently inactive
 # * @langfuse/maintainers
+
+# Require maintainer review for GitHub configuration changes
+.github/ @langfuse/maintainers


### PR DESCRIPTION
## Summary
- add/update `.github/CODEOWNERS` to require `@langfuse/maintainers` review for `.github/` changes

Linear: https://linear.app/langfuse/issue/LFE-9760/repo-owners-for-github-actions

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR activates GitHub CODEOWNERS enforcement for the `.github/` directory by requiring `@langfuse/maintainers` approval on any changes to it, while leaving the previously commented-out catch-all rule untouched.

- Adds `.github/ @langfuse/maintainers` to protect GitHub Actions, workflows, and other repository configuration from unreviewed changes — including changes to CODEOWNERS itself.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a one-line addition to CODEOWNERS that activates maintainer review requirements for the .github/ directory.

The change is a single CODEOWNERS entry with no executable code or configuration logic. It will start enforcing required reviews on .github/ going forward, including for CODEOWNERS itself, which is the intended goal. The only note is that the pattern could use a leading slash for explicit root anchoring, but this has no practical impact in this repository.

No files require special attention.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/CODEOWNERS:5
The pattern `.github/` without a leading `/` is treated as a gitignore-style pattern and can technically match a directory named `.github` anywhere in the tree. Using `/.github/` anchors the pattern explicitly to the repository root, which is the intended target.

```suggestion
/.github/ @langfuse/maintainers
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add codeowners for github config"](https://github.com/langfuse/langfuse-js/commit/39dd5503d9911126ce4f1939bf25e8956170dfb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31952302)</sub>

<!-- /greptile_comment -->