### PR TITLE
feat(span-processor): add app root detection

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -42,6 +42,7 @@ export enum LangfuseOtelSpanAttributes {
 
   // Internal
   AS_ROOT = "langfuse.internal.as_root",
+  IS_APP_ROOT = "langfuse.internal.is_app_root",
 
   // Experiment attributes
   EXPERIMENT_ID = "langfuse.experiment.id",

--- a/packages/core/src/propagation.ts
+++ b/packages/core/src/propagation.ts
@@ -74,6 +74,56 @@ const LANGFUSE_BAGGAGE_PREFIX = "langfuse_";
 const LANGFUSE_BAGGAGE_TAGS_SEPARATOR = ",";
 
 /**
+ * Baggage key used by the SDK to claim that an upstream Langfuse-controlled
+ * scope already exists for a given trace id. Downstream processors read this
+ * to suppress duplicate app-root markers across services.
+ *
+ * @internal
+ */
+export const LANGFUSE_TRACE_ID_BAGGAGE_KEY = "langfuse_trace_id";
+
+/**
+ * Reads the Langfuse trace-id app-root claim from the baggage attached to a
+ * context. Returns the lowercased trace id, or undefined if no claim exists.
+ *
+ * @internal
+ */
+export function getLangfuseTraceIdFromBaggage(
+  context: Context,
+): string | undefined {
+  const baggage = propagation.getBaggage(context);
+  const entry = baggage?.getEntry(LANGFUSE_TRACE_ID_BAGGAGE_KEY);
+
+  if (!entry?.value) return undefined;
+
+  return entry.value.toLowerCase();
+}
+
+/**
+ * Returns a context that carries the Langfuse trace-id app-root claim in
+ * baggage. If the context already carries the same claim, the original
+ * context is returned unchanged so we don't churn baggage instances.
+ *
+ * @internal
+ */
+export function setLangfuseTraceIdInBaggage(
+  context: Context,
+  traceId: string,
+): Context {
+  const normalized = traceId.toLowerCase();
+
+  if (getLangfuseTraceIdFromBaggage(context) === normalized) return context;
+
+  const baggage =
+    propagation.getBaggage(context) ?? propagation.createBaggage();
+  const updated = baggage.setEntry(LANGFUSE_TRACE_ID_BAGGAGE_KEY, {
+    value: normalized,
+  });
+
+  return propagation.setBaggage(context, updated);
+}
+
+/**
  * Parameters for propagateAttributes function.
  *
  * @public
@@ -406,6 +456,8 @@ export function getPropagatedAttributesFromContext(
 
   if (baggage) {
     baggage.getAllEntries().forEach(([baggageKey, baggageEntry]) => {
+      if (baggageKey === LANGFUSE_TRACE_ID_BAGGAGE_KEY) return;
+
       if (baggageKey.startsWith(LANGFUSE_BAGGAGE_PREFIX)) {
         const spanKey = getSpanKeyFromBaggageKey(baggageKey);
 

--- a/packages/otel/src/span-filter.test.ts
+++ b/packages/otel/src/span-filter.test.ts
@@ -64,9 +64,29 @@ describe("span-filter", () => {
     expect(isDefaultExportSpan(span)).toBe(true);
   });
 
+  it.each([
+    "opentelemetry.instrumentation.openai",
+    "opentelemetry.instrumentation.openai_v2",
+    "opentelemetry.instrumentation.aws_bedrock",
+    "opentelemetry.instrumentation.bedrock",
+    "opentelemetry.instrumentation.vertex_ai",
+    "opentelemetry.instrumentation.vertexai",
+    "opentelemetry.instrumentation.gemini",
+    "opentelemetry.instrumentation.google_genai",
+    "opentelemetry.instrumentation.google_generativeai",
+  ])(
+    "matches late-attribute GenAI instrumentation scope %s",
+    (instrumentationScopeName) => {
+      const span = createTestSpan({ instrumentationScopeName });
+
+      expect(isKnownLLMInstrumentor(span)).toBe(true);
+      expect(isDefaultExportSpan(span)).toBe(true);
+    },
+  );
+
   it("does not match prefix boundary false positives", () => {
     const span = createTestSpan({
-      instrumentationScopeName: "openinference.instrumentation.agno2.agent",
+      instrumentationScopeName: "openinference2.instrumentation.agno.agent",
     });
 
     expect(isKnownLLMInstrumentor(span)).toBe(false);

--- a/packages/otel/src/span-filter.ts
+++ b/packages/otel/src/span-filter.ts
@@ -10,9 +10,20 @@ export const KNOWN_LLM_INSTRUMENTATION_SCOPE_PREFIXES = [
   "litellm",
   "openinference",
   "opentelemetry.instrumentation.anthropic",
+  "opentelemetry.instrumentation.aws_bedrock",
+  "opentelemetry.instrumentation.bedrock",
+  "opentelemetry.instrumentation.gemini",
+  "opentelemetry.instrumentation.google_genai",
+  "opentelemetry.instrumentation.google_generativeai",
+  "opentelemetry.instrumentation.openai",
+  "opentelemetry.instrumentation.openai_v2",
+  "opentelemetry.instrumentation.vertex_ai",
+  "opentelemetry.instrumentation.vertexai",
   "strands-agents",
   "vllm",
 ] as const;
+
+const EXACT_LLM_INSTRUMENTATION_SCOPES = new Set<string>(["ai"]);
 
 export function isLangfuseSpan(span: ReadableSpan): boolean {
   return span.instrumentationScope.name === LANGFUSE_TRACER_NAME;
@@ -28,7 +39,10 @@ export function isKnownLLMInstrumentor(span: ReadableSpan): boolean {
   const scope = span.instrumentationScope.name;
 
   return KNOWN_LLM_INSTRUMENTATION_SCOPE_PREFIXES.some(
-    (prefix) => scope === prefix || scope.startsWith(`${prefix}.`),
+    (prefix) =>
+      scope === prefix ||
+      (!EXACT_LLM_INSTRUMENTATION_SCOPES.has(prefix) &&
+        scope.startsWith(`${prefix}.`)),
   );
 }
 

--- a/packages/otel/src/span-processor.test.ts
+++ b/packages/otel/src/span-processor.test.ts
@@ -263,7 +263,7 @@ describe("LangfuseSpanProcessor app-root marking", () => {
     expect(child.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT]).toBe(true);
   });
 
-  it("releases local trace state after all active spans end", async () => {
+  it("releases local span state after all tracked spans end", async () => {
     const parent = createTestSpan({
       traceId: TRACE_ID,
       instrumentationScopeName: LANGFUSE_TRACER_NAME,
@@ -281,10 +281,38 @@ describe("LangfuseSpanProcessor app-root marking", () => {
     processor.onEnd(parent);
     await processor.forceFlush();
 
-    const internalTraces = (
-      processor as unknown as { appRootTraces: Map<string, unknown> }
-    ).appRootTraces;
-    expect(internalTraces.has(TRACE_ID)).toBe(false);
+    const internalSpans = (
+      processor as unknown as {
+        spanExportExpectationById: Map<string, unknown>;
+      }
+    ).spanExportExpectationById;
+    expect(internalSpans.size).toBe(0);
+  });
+
+  it("marks a child started after its parent ended as an app root", async () => {
+    const parent = createTestSpan({
+      traceId: TRACE_ID,
+      instrumentationScopeName: LANGFUSE_TRACER_NAME,
+    });
+    processor.onStart(parent, ROOT_CONTEXT);
+
+    expect(parent.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT]).toBe(
+      true,
+    );
+
+    processor.onEnd(parent);
+
+    const child = createTestSpan({
+      traceId: TRACE_ID,
+      parentSpanId: parent.spanContext().spanId,
+      instrumentationScopeName: LANGFUSE_TRACER_NAME,
+    });
+    processor.onStart(child, contextWithBaggageClaim(TRACE_ID));
+
+    expect(child.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT]).toBe(true);
+
+    processor.onEnd(child);
+    await processor.forceFlush();
   });
 
   it("retains state for never-ended spans (documented best-effort gap)", () => {
@@ -294,10 +322,12 @@ describe("LangfuseSpanProcessor app-root marking", () => {
     });
     processor.onStart(parent, ROOT_CONTEXT);
 
-    const internalTraces = (
-      processor as unknown as { appRootTraces: Map<string, unknown> }
-    ).appRootTraces;
-    expect(internalTraces.has(TRACE_ID)).toBe(true);
+    const internalSpans = (
+      processor as unknown as {
+        spanExportExpectationById: Map<string, unknown>;
+      }
+    ).spanExportExpectationById;
+    expect(internalSpans.has(parent.spanContext().spanId)).toBe(true);
   });
 
   it("keeps the start-time marker even when the end-time filter rejects the span", async () => {

--- a/packages/otel/src/span-processor.test.ts
+++ b/packages/otel/src/span-processor.test.ts
@@ -2,6 +2,7 @@ import {
   LANGFUSE_TRACER_NAME,
   LANGFUSE_TRACE_ID_BAGGAGE_KEY,
   LangfuseOtelSpanAttributes,
+  getPropagatedAttributesFromContext,
 } from "@langfuse/core";
 import { propagation, ROOT_CONTEXT, type Context } from "@opentelemetry/api";
 import { ExportResultCode } from "@opentelemetry/core";
@@ -367,11 +368,7 @@ describe("LangfuseSpanProcessor app-root marking", () => {
 });
 
 describe("propagation: internal app-root baggage", () => {
-  it("does not surface the internal trace-id baggage as user metadata", async () => {
-    const { getPropagatedAttributesFromContext } = await import(
-      "@langfuse/core"
-    );
-
+  it("does not surface the internal trace-id baggage as user metadata", () => {
     const ctx = contextWithBaggageClaim(TRACE_ID);
     const propagated = getPropagatedAttributesFromContext(ctx);
 

--- a/packages/otel/src/span-processor.test.ts
+++ b/packages/otel/src/span-processor.test.ts
@@ -1,0 +1,342 @@
+import {
+  LANGFUSE_TRACER_NAME,
+  LANGFUSE_TRACE_ID_BAGGAGE_KEY,
+  LangfuseOtelSpanAttributes,
+} from "@langfuse/core";
+import { propagation, ROOT_CONTEXT, type Context } from "@opentelemetry/api";
+import { ExportResultCode } from "@opentelemetry/core";
+import type {
+  ReadableSpan,
+  Span,
+  SpanExporter,
+} from "@opentelemetry/sdk-trace-base";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { LangfuseSpanProcessor } from "./span-processor.js";
+
+const noopExporter: SpanExporter = {
+  export: (_spans, cb) => cb({ code: ExportResultCode.SUCCESS }),
+  shutdown: async () => undefined,
+};
+
+type TestSpan = Span &
+  ReadableSpan & {
+    setAttribute: (key: string, value: unknown) => TestSpan;
+    setAttributes: (kv: Record<string, unknown>) => TestSpan;
+  };
+
+let spanIdCounter = 0;
+const nextSpanId = () => (++spanIdCounter).toString(16).padStart(16, "0");
+
+function createTestSpan(opts: {
+  traceId: string;
+  spanId?: string;
+  parentSpanId?: string;
+  instrumentationScopeName?: string;
+  name?: string;
+  initialAttributes?: Record<string, unknown>;
+}): TestSpan {
+  const attributes: Record<string, unknown> = {
+    ...(opts.initialAttributes ?? {}),
+  };
+  const spanId = opts.spanId ?? nextSpanId();
+
+  const span = {
+    name: opts.name ?? "test-span",
+    attributes,
+    instrumentationScope: {
+      name: opts.instrumentationScopeName ?? "unknown.instrumentation",
+      version: undefined,
+      schemaUrl: undefined,
+    },
+    parentSpanContext: opts.parentSpanId
+      ? { traceId: opts.traceId, spanId: opts.parentSpanId, traceFlags: 1 }
+      : undefined,
+    spanContext: () => ({
+      traceId: opts.traceId,
+      spanId,
+      traceFlags: 1,
+    }),
+    setAttribute(key: string, value: unknown) {
+      attributes[key] = value;
+      return span;
+    },
+    setAttributes(kv: Record<string, unknown>) {
+      Object.assign(attributes, kv);
+      return span;
+    },
+    // Stubbed ReadableSpan surface used by the export pipeline.
+    duration: [0, 0],
+    startTime: [0, 0],
+    endTime: [0, 0],
+    kind: 0,
+    status: { code: 0 },
+    resource: { attributes: {} },
+    events: [],
+    links: [],
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+    ended: false,
+  } as unknown as TestSpan;
+
+  return span;
+}
+
+function contextWithBaggageClaim(
+  traceId: string,
+  base: Context = ROOT_CONTEXT,
+): Context {
+  const baggage = propagation
+    .createBaggage()
+    .setEntry(LANGFUSE_TRACE_ID_BAGGAGE_KEY, { value: traceId });
+
+  return propagation.setBaggage(base, baggage);
+}
+
+const TRACE_ID = "0123456789abcdef0123456789abcdef";
+
+describe("LangfuseSpanProcessor app-root marking", () => {
+  let processor: LangfuseSpanProcessor;
+
+  beforeEach(() => {
+    spanIdCounter = 0;
+    processor = new LangfuseSpanProcessor({ exporter: noopExporter });
+  });
+
+  it("marks an exported child whose immediate parent is filtered", () => {
+    const parent = createTestSpan({
+      traceId: TRACE_ID,
+      instrumentationScopeName: "unknown.instrumentation",
+    });
+    processor.onStart(parent, ROOT_CONTEXT);
+
+    const child = createTestSpan({
+      traceId: TRACE_ID,
+      parentSpanId: parent.spanContext().spanId,
+      instrumentationScopeName: LANGFUSE_TRACER_NAME,
+    });
+    processor.onStart(child, ROOT_CONTEXT);
+
+    expect(
+      parent.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT],
+    ).toBeUndefined();
+    expect(child.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT]).toBe(true);
+  });
+
+  it("marks all exported siblings under a filtered parent", () => {
+    const parent = createTestSpan({
+      traceId: TRACE_ID,
+      instrumentationScopeName: "unknown.instrumentation",
+    });
+    processor.onStart(parent, ROOT_CONTEXT);
+
+    const childA = createTestSpan({
+      traceId: TRACE_ID,
+      parentSpanId: parent.spanContext().spanId,
+      instrumentationScopeName: LANGFUSE_TRACER_NAME,
+    });
+    const childB = createTestSpan({
+      traceId: TRACE_ID,
+      parentSpanId: parent.spanContext().spanId,
+      instrumentationScopeName: LANGFUSE_TRACER_NAME,
+    });
+    processor.onStart(childA, ROOT_CONTEXT);
+    processor.onStart(childB, ROOT_CONTEXT);
+
+    expect(childA.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT]).toBe(
+      true,
+    );
+    expect(childB.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT]).toBe(
+      true,
+    );
+  });
+
+  it("only considers the immediate parent's export status", () => {
+    const grandparent = createTestSpan({
+      traceId: TRACE_ID,
+      instrumentationScopeName: LANGFUSE_TRACER_NAME,
+    });
+    processor.onStart(grandparent, ROOT_CONTEXT);
+
+    const parent = createTestSpan({
+      traceId: TRACE_ID,
+      parentSpanId: grandparent.spanContext().spanId,
+      instrumentationScopeName: "unknown.instrumentation",
+    });
+    processor.onStart(parent, ROOT_CONTEXT);
+
+    const child = createTestSpan({
+      traceId: TRACE_ID,
+      parentSpanId: parent.spanContext().spanId,
+      instrumentationScopeName: LANGFUSE_TRACER_NAME,
+    });
+    processor.onStart(child, ROOT_CONTEXT);
+
+    expect(grandparent.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT]).toBe(
+      true,
+    );
+    expect(
+      parent.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT],
+    ).toBeUndefined();
+    expect(child.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT]).toBe(true);
+  });
+
+  it("marks only the parent when both parent and child export", () => {
+    const parent = createTestSpan({
+      traceId: TRACE_ID,
+      instrumentationScopeName: LANGFUSE_TRACER_NAME,
+    });
+    processor.onStart(parent, ROOT_CONTEXT);
+
+    const child = createTestSpan({
+      traceId: TRACE_ID,
+      parentSpanId: parent.spanContext().spanId,
+      instrumentationScopeName: LANGFUSE_TRACER_NAME,
+    });
+    processor.onStart(child, ROOT_CONTEXT);
+
+    expect(parent.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT]).toBe(
+      true,
+    );
+    expect(
+      child.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT],
+    ).toBeUndefined();
+  });
+
+  it("never marks spans rejected by a custom shouldExportSpan filter", () => {
+    const rejectAll = new LangfuseSpanProcessor({
+      exporter: noopExporter,
+      shouldExportSpan: () => false,
+    });
+
+    const span = createTestSpan({
+      traceId: TRACE_ID,
+      instrumentationScopeName: LANGFUSE_TRACER_NAME,
+    });
+    rejectAll.onStart(span, ROOT_CONTEXT);
+
+    expect(
+      span.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT],
+    ).toBeUndefined();
+  });
+
+  it("suppresses local marking when matching baggage claim exists and no local parent", () => {
+    const span = createTestSpan({
+      traceId: TRACE_ID,
+      instrumentationScopeName: LANGFUSE_TRACER_NAME,
+    });
+    processor.onStart(span, contextWithBaggageClaim(TRACE_ID));
+
+    expect(
+      span.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT],
+    ).toBeUndefined();
+  });
+
+  it("does not suppress when baggage claim is for a different trace", () => {
+    const otherTrace = "ffffffffffffffffffffffffffffffff";
+    const span = createTestSpan({
+      traceId: TRACE_ID,
+      instrumentationScopeName: LANGFUSE_TRACER_NAME,
+    });
+    processor.onStart(span, contextWithBaggageClaim(otherTrace));
+
+    expect(span.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT]).toBe(true);
+  });
+
+  it("prefers local parent state over upstream baggage claim", () => {
+    const parent = createTestSpan({
+      traceId: TRACE_ID,
+      instrumentationScopeName: "unknown.instrumentation",
+    });
+    processor.onStart(parent, contextWithBaggageClaim(TRACE_ID));
+
+    const child = createTestSpan({
+      traceId: TRACE_ID,
+      parentSpanId: parent.spanContext().spanId,
+      instrumentationScopeName: LANGFUSE_TRACER_NAME,
+    });
+    processor.onStart(child, contextWithBaggageClaim(TRACE_ID));
+
+    // Local parent is filtered, so the child still surfaces as an app root
+    // even though an upstream baggage claim exists for the same trace.
+    expect(child.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT]).toBe(true);
+  });
+
+  it("releases local trace state after all active spans end", async () => {
+    const parent = createTestSpan({
+      traceId: TRACE_ID,
+      instrumentationScopeName: LANGFUSE_TRACER_NAME,
+    });
+    processor.onStart(parent, ROOT_CONTEXT);
+
+    const child = createTestSpan({
+      traceId: TRACE_ID,
+      parentSpanId: parent.spanContext().spanId,
+      instrumentationScopeName: LANGFUSE_TRACER_NAME,
+    });
+    processor.onStart(child, ROOT_CONTEXT);
+
+    processor.onEnd(child);
+    processor.onEnd(parent);
+    await processor.forceFlush();
+
+    const internalTraces = (
+      processor as unknown as { appRootTraces: Map<string, unknown> }
+    ).appRootTraces;
+    expect(internalTraces.has(TRACE_ID)).toBe(false);
+  });
+
+  it("retains state for never-ended spans (documented best-effort gap)", () => {
+    const parent = createTestSpan({
+      traceId: TRACE_ID,
+      instrumentationScopeName: LANGFUSE_TRACER_NAME,
+    });
+    processor.onStart(parent, ROOT_CONTEXT);
+
+    const internalTraces = (
+      processor as unknown as { appRootTraces: Map<string, unknown> }
+    ).appRootTraces;
+    expect(internalTraces.has(TRACE_ID)).toBe(true);
+  });
+
+  it("keeps the start-time marker even when the end-time filter rejects the span", async () => {
+    let calls = 0;
+    const flipFilter = new LangfuseSpanProcessor({
+      exporter: noopExporter,
+      shouldExportSpan: () => {
+        calls += 1;
+        return calls === 1; // accept on start, reject on end
+      },
+    });
+
+    const span = createTestSpan({
+      traceId: TRACE_ID,
+      instrumentationScopeName: "unknown.instrumentation",
+    });
+    flipFilter.onStart(span, ROOT_CONTEXT);
+
+    expect(span.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT]).toBe(true);
+
+    flipFilter.onEnd(span);
+    await flipFilter.forceFlush();
+
+    // V1 does not repair: the marker remains, but the span will not be exported.
+    expect(span.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT]).toBe(true);
+  });
+});
+
+describe("propagation: internal app-root baggage", () => {
+  it("does not surface the internal trace-id baggage as user metadata", async () => {
+    const { getPropagatedAttributesFromContext } = await import(
+      "@langfuse/core"
+    );
+
+    const ctx = contextWithBaggageClaim(TRACE_ID);
+    const propagated = getPropagatedAttributesFromContext(ctx);
+
+    for (const key of Object.keys(propagated)) {
+      expect(key).not.toContain("langfuse_trace_id");
+    }
+  });
+});

--- a/packages/otel/src/span-processor.test.ts
+++ b/packages/otel/src/span-processor.test.ts
@@ -221,6 +221,16 @@ describe("LangfuseSpanProcessor app-root marking", () => {
     ).toBeUndefined();
   });
 
+  it("marks known GenAI instrumentation scopes before gen_ai attributes are set", () => {
+    const span = createTestSpan({
+      traceId: TRACE_ID,
+      instrumentationScopeName: "opentelemetry.instrumentation.openai",
+    });
+    processor.onStart(span, ROOT_CONTEXT);
+
+    expect(span.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT]).toBe(true);
+  });
+
   it("suppresses local marking when matching baggage claim exists and no local parent", () => {
     const span = createTestSpan({
       traceId: TRACE_ID,
@@ -244,7 +254,7 @@ describe("LangfuseSpanProcessor app-root marking", () => {
     expect(span.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT]).toBe(true);
   });
 
-  it("prefers local parent state over upstream baggage claim", () => {
+  it("suppresses local children when matching baggage claim exists", () => {
     const parent = createTestSpan({
       traceId: TRACE_ID,
       instrumentationScopeName: "unknown.instrumentation",
@@ -258,9 +268,9 @@ describe("LangfuseSpanProcessor app-root marking", () => {
     });
     processor.onStart(child, contextWithBaggageClaim(TRACE_ID));
 
-    // Local parent is filtered, so the child still surfaces as an app root
-    // even though an upstream baggage claim exists for the same trace.
-    expect(child.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT]).toBe(true);
+    expect(
+      child.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT],
+    ).toBeUndefined();
   });
 
   it("releases local span state after all tracked spans end", async () => {
@@ -307,7 +317,7 @@ describe("LangfuseSpanProcessor app-root marking", () => {
       parentSpanId: parent.spanContext().spanId,
       instrumentationScopeName: LANGFUSE_TRACER_NAME,
     });
-    processor.onStart(child, contextWithBaggageClaim(TRACE_ID));
+    processor.onStart(child, ROOT_CONTEXT);
 
     expect(child.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT]).toBe(true);
 

--- a/packages/otel/src/span-processor.ts
+++ b/packages/otel/src/span-processor.ts
@@ -7,6 +7,7 @@ import {
   LangfuseOtelSpanAttributes,
   getEnv,
   base64Encode,
+  getLangfuseTraceIdFromBaggage,
   getPropagatedAttributesFromContext,
 } from "@langfuse/core";
 import { Context } from "@opentelemetry/api";
@@ -147,6 +148,16 @@ export interface LangfuseSpanProcessorParams {
   exportMode?: "immediate" | "batched";
 }
 
+type AppRootSpanState = {
+  expectedExportedAtStart: boolean;
+  ended: boolean;
+};
+
+type AppRootTraceState = {
+  activeCount: number;
+  spans: Map<string, AppRootSpanState>;
+};
+
 /**
  * OpenTelemetry span processor for sending spans to Langfuse.
  *
@@ -195,6 +206,7 @@ export class LangfuseSpanProcessor implements SpanProcessor {
   private apiClient: LangfuseAPIClient;
   private processor: SpanProcessor;
   private mediaService: MediaService;
+  private appRootTraces: Map<string, AppRootTraceState> = new Map();
 
   /**
    * Creates a new LangfuseSpanProcessor instance.
@@ -329,6 +341,16 @@ export class LangfuseSpanProcessor implements SpanProcessor {
       ...getPropagatedAttributesFromContext(parentContext),
     });
 
+    try {
+      this.markAppRootCandidate(span, parentContext);
+    } catch (err) {
+      this.logger.debug(
+        "App-root start-time check failed. Span will not be marked as app root.",
+        { spanName: span.name },
+        err,
+      );
+    }
+
     return this.processor.onStart(span, parentContext);
   }
 
@@ -393,54 +415,140 @@ export class LangfuseSpanProcessor implements SpanProcessor {
 
   private async processEndedSpan(span: ReadableSpan) {
     try {
-      if (this.shouldExportSpan({ otelSpan: span }) === false) {
-        this.logger.debug("Dropped span due to shouldExportSpan filter.", {
-          spanName: span.name,
-          instrumentationScope: span.instrumentationScope.name,
-        });
+      try {
+        if (this.shouldExportSpan({ otelSpan: span }) === false) {
+          this.logger.debug("Dropped span due to shouldExportSpan filter.", {
+            spanName: span.name,
+            instrumentationScope: span.instrumentationScope.name,
+          });
+
+          return;
+        }
+      } catch (err) {
+        this.logger.error(
+          "shouldExportSpan failed with error. Dropping span.",
+          {
+            spanName: span.name,
+            instrumentationScope: span.instrumentationScope.name,
+          },
+          err,
+        );
 
         return;
       }
+
+      await this.applyMaskInPlace(span);
+      await this.mediaService.process(span);
+
+      if (this.logger.isLevelEnabled(LogLevel.DEBUG)) {
+        this.logger.debug(
+          `Processed span:\n${JSON.stringify(
+            {
+              name: span.name,
+              traceId: span.spanContext().traceId,
+              spanId: span.spanContext().spanId,
+              parentSpanId: span.parentSpanContext?.spanId ?? null,
+              attributes: span.attributes,
+              startTime: new Date(hrTimeToMilliseconds(span.startTime)),
+              endTime: new Date(hrTimeToMilliseconds(span.endTime)),
+              durationMs: hrTimeToMilliseconds(span.duration),
+              kind: span.kind,
+              status: span.status,
+              resource: span.resource.attributes,
+              instrumentationScope: span.instrumentationScope,
+            },
+            null,
+            2,
+          )}`,
+        );
+      }
+
+      this.processor.onEnd(span);
+    } finally {
+      this.cleanupAppRootState(span);
+    }
+  }
+
+  private markAppRootCandidate(span: Span, parentContext: Context): void {
+    const traceId = span.spanContext().traceId.toLowerCase();
+    const spanId = span.spanContext().spanId;
+    const parentSpanId = span.parentSpanContext?.spanId;
+
+    const expectedExportedAtStart = this.isExpectedExportedAtStart(span);
+    const propagatedClaim = getLangfuseTraceIdFromBaggage(parentContext);
+
+    let traceState = this.appRootTraces.get(traceId);
+    if (!traceState) {
+      traceState = { activeCount: 0, spans: new Map() };
+      this.appRootTraces.set(traceId, traceState);
+    }
+
+    const parentState =
+      parentSpanId !== undefined
+        ? traceState.spans.get(parentSpanId)
+        : undefined;
+    const parentExpectedExportedAtStart =
+      parentState?.expectedExportedAtStart === true;
+
+    // Local parent state takes precedence over the upstream baggage claim:
+    // only suppress when no local parent is tracked and the claim matches.
+    const suppressedByParentClaim =
+      parentState === undefined && propagatedClaim === traceId;
+
+    traceState.spans.set(spanId, {
+      expectedExportedAtStart,
+      ended: false,
+    });
+    traceState.activeCount += 1;
+
+    const markAppRoot =
+      expectedExportedAtStart &&
+      !parentExpectedExportedAtStart &&
+      !suppressedByParentClaim;
+
+    if (markAppRoot) {
+      span.setAttribute(LangfuseOtelSpanAttributes.IS_APP_ROOT, true);
+    }
+  }
+
+  private cleanupAppRootState(span: ReadableSpan): void {
+    const traceId = span.spanContext().traceId.toLowerCase();
+    const spanId = span.spanContext().spanId;
+
+    const traceState = this.appRootTraces.get(traceId);
+    if (!traceState) return;
+
+    const spanState = traceState.spans.get(spanId);
+    if (spanState && !spanState.ended) {
+      spanState.ended = true;
+      traceState.activeCount -= 1;
+    }
+
+    if (traceState.activeCount <= 0) {
+      this.appRootTraces.delete(traceId);
+    }
+  }
+
+  private isExpectedExportedAtStart(span: Span): boolean {
+    // Span (from sdk-trace-base) already implements ReadableSpan, so the cast
+    // is safe and avoids depending on private OTel APIs.
+    const readable = span as unknown as ReadableSpan;
+
+    try {
+      return this.shouldExportSpan({ otelSpan: readable }) === true;
     } catch (err) {
-      this.logger.error(
-        "shouldExportSpan failed with error. Dropping span.",
+      this.logger.debug(
+        "shouldExportSpan threw during app-root start-time check. " +
+          "Span will not be marked as app root.",
         {
           spanName: span.name,
-          instrumentationScope: span.instrumentationScope.name,
+          instrumentationScope: readable.instrumentationScope.name,
         },
         err,
       );
 
-      return;
+      return false;
     }
-
-    await this.applyMaskInPlace(span);
-    await this.mediaService.process(span);
-
-    if (this.logger.isLevelEnabled(LogLevel.DEBUG)) {
-      this.logger.debug(
-        `Processed span:\n${JSON.stringify(
-          {
-            name: span.name,
-            traceId: span.spanContext().traceId,
-            spanId: span.spanContext().spanId,
-            parentSpanId: span.parentSpanContext?.spanId ?? null,
-            attributes: span.attributes,
-            startTime: new Date(hrTimeToMilliseconds(span.startTime)),
-            endTime: new Date(hrTimeToMilliseconds(span.endTime)),
-            durationMs: hrTimeToMilliseconds(span.duration),
-            kind: span.kind,
-            status: span.status,
-            resource: span.resource.attributes,
-            instrumentationScope: span.instrumentationScope,
-          },
-          null,
-          2,
-        )}`,
-      );
-    }
-
-    this.processor.onEnd(span);
   }
   private async applyMaskInPlace(span: ReadableSpan): Promise<void> {
     const maskCandidates = [

--- a/packages/otel/src/span-processor.ts
+++ b/packages/otel/src/span-processor.ts
@@ -489,11 +489,7 @@ export class LangfuseSpanProcessor implements SpanProcessor {
         : undefined;
     const parentExpectedExportedAtStart =
       parentState?.expectedExportedAtStart === true;
-
-    // Local parent state takes precedence over the upstream baggage claim:
-    // only suppress when no local parent is tracked and the claim matches.
-    const suppressedByParentClaim =
-      parentState === undefined && propagatedClaim === traceId;
+    const suppressedByParentClaim = propagatedClaim === traceId;
 
     traceState.spans.set(spanId, {
       expectedExportedAtStart,

--- a/packages/otel/src/span-processor.ts
+++ b/packages/otel/src/span-processor.ts
@@ -148,16 +148,6 @@ export interface LangfuseSpanProcessorParams {
   exportMode?: "immediate" | "batched";
 }
 
-type AppRootSpanState = {
-  expectedExportedAtStart: boolean;
-  ended: boolean;
-};
-
-type AppRootTraceState = {
-  activeCount: number;
-  spans: Map<string, AppRootSpanState>;
-};
-
 /**
  * OpenTelemetry span processor for sending spans to Langfuse.
  *
@@ -206,7 +196,7 @@ export class LangfuseSpanProcessor implements SpanProcessor {
   private apiClient: LangfuseAPIClient;
   private processor: SpanProcessor;
   private mediaService: MediaService;
-  private appRootTraces: Map<string, AppRootTraceState> = new Map();
+  private spanExportExpectationById: Map<string, boolean> = new Map();
 
   /**
    * Creates a new LangfuseSpanProcessor instance.
@@ -370,6 +360,8 @@ export class LangfuseSpanProcessor implements SpanProcessor {
    * @override
    */
   public onEnd(span: ReadableSpan): void {
+    this.spanExportExpectationById.delete(span.spanContext().spanId);
+
     const processEndedSpanPromise = this.processEndedSpan(span).catch((err) => {
       this.logger.error(err);
     });
@@ -415,113 +407,79 @@ export class LangfuseSpanProcessor implements SpanProcessor {
 
   private async processEndedSpan(span: ReadableSpan) {
     try {
-      try {
-        if (this.shouldExportSpan({ otelSpan: span }) === false) {
-          this.logger.debug("Dropped span due to shouldExportSpan filter.", {
-            spanName: span.name,
-            instrumentationScope: span.instrumentationScope.name,
-          });
-
-          return;
-        }
-      } catch (err) {
-        this.logger.error(
-          "shouldExportSpan failed with error. Dropping span.",
-          {
-            spanName: span.name,
-            instrumentationScope: span.instrumentationScope.name,
-          },
-          err,
-        );
+      if (this.shouldExportSpan({ otelSpan: span }) === false) {
+        this.logger.debug("Dropped span due to shouldExportSpan filter.", {
+          spanName: span.name,
+          instrumentationScope: span.instrumentationScope.name,
+        });
 
         return;
       }
+    } catch (err) {
+      this.logger.error(
+        "shouldExportSpan failed with error. Dropping span.",
+        {
+          spanName: span.name,
+          instrumentationScope: span.instrumentationScope.name,
+        },
+        err,
+      );
 
-      await this.applyMaskInPlace(span);
-      await this.mediaService.process(span);
-
-      if (this.logger.isLevelEnabled(LogLevel.DEBUG)) {
-        this.logger.debug(
-          `Processed span:\n${JSON.stringify(
-            {
-              name: span.name,
-              traceId: span.spanContext().traceId,
-              spanId: span.spanContext().spanId,
-              parentSpanId: span.parentSpanContext?.spanId ?? null,
-              attributes: span.attributes,
-              startTime: new Date(hrTimeToMilliseconds(span.startTime)),
-              endTime: new Date(hrTimeToMilliseconds(span.endTime)),
-              durationMs: hrTimeToMilliseconds(span.duration),
-              kind: span.kind,
-              status: span.status,
-              resource: span.resource.attributes,
-              instrumentationScope: span.instrumentationScope,
-            },
-            null,
-            2,
-          )}`,
-        );
-      }
-
-      this.processor.onEnd(span);
-    } finally {
-      this.cleanupAppRootState(span);
+      return;
     }
+
+    await this.applyMaskInPlace(span);
+    await this.mediaService.process(span);
+
+    if (this.logger.isLevelEnabled(LogLevel.DEBUG)) {
+      this.logger.debug(
+        `Processed span:\n${JSON.stringify(
+          {
+            name: span.name,
+            traceId: span.spanContext().traceId,
+            spanId: span.spanContext().spanId,
+            parentSpanId: span.parentSpanContext?.spanId ?? null,
+            attributes: span.attributes,
+            startTime: new Date(hrTimeToMilliseconds(span.startTime)),
+            endTime: new Date(hrTimeToMilliseconds(span.endTime)),
+            durationMs: hrTimeToMilliseconds(span.duration),
+            kind: span.kind,
+            status: span.status,
+            resource: span.resource.attributes,
+            instrumentationScope: span.instrumentationScope,
+          },
+          null,
+          2,
+        )}`,
+      );
+    }
+
+    this.processor.onEnd(span);
   }
 
   private markAppRootCandidate(span: Span, parentContext: Context): void {
-    const traceId = span.spanContext().traceId.toLowerCase();
+    const traceId = span.spanContext().traceId;
     const spanId = span.spanContext().spanId;
     const parentSpanId = span.parentSpanContext?.spanId;
 
     const expectedExportedAtStart = this.isExpectedExportedAtStart(span);
     const propagatedClaim = getLangfuseTraceIdFromBaggage(parentContext);
 
-    let traceState = this.appRootTraces.get(traceId);
-    if (!traceState) {
-      traceState = { activeCount: 0, spans: new Map() };
-      this.appRootTraces.set(traceId, traceState);
-    }
-
-    const parentState =
+    const isParentExpectedExported =
       parentSpanId !== undefined
-        ? traceState.spans.get(parentSpanId)
-        : undefined;
-    const parentExpectedExportedAtStart =
-      parentState?.expectedExportedAtStart === true;
+        ? this.spanExportExpectationById.get(parentSpanId) === true
+        : false;
     const suppressedByParentClaim = propagatedClaim === traceId;
 
-    traceState.spans.set(spanId, {
-      expectedExportedAtStart,
-      ended: false,
-    });
-    traceState.activeCount += 1;
+    this.spanExportExpectationById.set(spanId, expectedExportedAtStart);
 
     const markAppRoot =
       expectedExportedAtStart &&
-      !parentExpectedExportedAtStart &&
+      !isParentExpectedExported &&
       !suppressedByParentClaim;
 
     if (markAppRoot) {
       span.setAttribute(LangfuseOtelSpanAttributes.IS_APP_ROOT, true);
-    }
-  }
-
-  private cleanupAppRootState(span: ReadableSpan): void {
-    const traceId = span.spanContext().traceId.toLowerCase();
-    const spanId = span.spanContext().spanId;
-
-    const traceState = this.appRootTraces.get(traceId);
-    if (!traceState) return;
-
-    const spanState = traceState.spans.get(spanId);
-    if (spanState && !spanState.ended) {
-      spanState.ended = true;
-      traceState.activeCount -= 1;
-    }
-
-    if (traceState.activeCount <= 0) {
-      this.appRootTraces.delete(traceId);
     }
   }
 
@@ -546,6 +504,7 @@ export class LangfuseSpanProcessor implements SpanProcessor {
       return false;
     }
   }
+
   private async applyMaskInPlace(span: ReadableSpan): Promise<void> {
     const maskCandidates = [
       LangfuseOtelSpanAttributes.OBSERVATION_INPUT,

--- a/packages/otel/src/span-processor.ts
+++ b/packages/otel/src/span-processor.ts
@@ -49,6 +49,10 @@ export type MaskFunction = (params: { data: any }) => any | Promise<any>;
 /**
  * Function type for determining whether a span should be exported to Langfuse.
  * If provided, this is treated as a full override of the default filtering behavior.
+ * Langfuse may call this predicate both when a span starts for app-root classification
+ * and when the span ends for export filtering. Prefer side-effect-free predicates; the
+ * start-time call sees only attributes available at span creation, and end-time fields
+ * such as duration may not be populated yet.
  *
  * @param params - Object containing the span to evaluate
  * @param params.otelSpan - The OpenTelemetry span to evaluate

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -1,4 +1,8 @@
-import { getGlobalLogger, LangfuseOtelSpanAttributes } from "@langfuse/core";
+import {
+  getGlobalLogger,
+  LangfuseOtelSpanAttributes,
+  setLangfuseTraceIdInBaggage,
+} from "@langfuse/core";
 import {
   trace,
   context,
@@ -778,100 +782,110 @@ export function startActiveObservation<
     createParentContext(observationOptions?.parentSpanContext) ??
       context.active(),
     (span) => {
-      try {
-        let observation: LangfuseObservation;
+      // Establish the trace-bound app-root claim for descendants. The span's
+      // own onStart has already run against the unmodified parent context, so
+      // this cannot cause self-suppression.
+      const claimContext = setLangfuseTraceIdInBaggage(
+        context.active(),
+        span.spanContext().traceId,
+      );
 
-        switch (asType) {
-          case "generation":
-            observation = new LangfuseGeneration({
-              otelSpan: span,
-            });
-            break;
+      return context.with(claimContext, () => {
+        try {
+          let observation: LangfuseObservation;
 
-          case "embedding":
-            observation = new LangfuseEmbedding({
-              otelSpan: span,
-            });
-            break;
+          switch (asType) {
+            case "generation":
+              observation = new LangfuseGeneration({
+                otelSpan: span,
+              });
+              break;
 
-          case "agent":
-            observation = new LangfuseAgent({
-              otelSpan: span,
-            });
-            break;
+            case "embedding":
+              observation = new LangfuseEmbedding({
+                otelSpan: span,
+              });
+              break;
 
-          case "tool":
-            observation = new LangfuseTool({
-              otelSpan: span,
-            });
-            break;
+            case "agent":
+              observation = new LangfuseAgent({
+                otelSpan: span,
+              });
+              break;
 
-          case "chain":
-            observation = new LangfuseChain({
-              otelSpan: span,
-            });
-            break;
+            case "tool":
+              observation = new LangfuseTool({
+                otelSpan: span,
+              });
+              break;
 
-          case "retriever":
-            observation = new LangfuseRetriever({
-              otelSpan: span,
-            });
-            break;
+            case "chain":
+              observation = new LangfuseChain({
+                otelSpan: span,
+              });
+              break;
 
-          case "evaluator":
-            observation = new LangfuseEvaluator({
-              otelSpan: span,
-            });
-            break;
+            case "retriever":
+              observation = new LangfuseRetriever({
+                otelSpan: span,
+              });
+              break;
 
-          case "guardrail":
-            observation = new LangfuseGuardrail({
-              otelSpan: span,
-            });
-            break;
+            case "evaluator":
+              observation = new LangfuseEvaluator({
+                otelSpan: span,
+              });
+              break;
 
-          case "event": {
-            const timestamp = observationOptions?.startTime ?? new Date();
-            observation = new LangfuseEvent({
-              otelSpan: span,
-              timestamp,
-            });
-            break;
+            case "guardrail":
+              observation = new LangfuseGuardrail({
+                otelSpan: span,
+              });
+              break;
+
+            case "event": {
+              const timestamp = observationOptions?.startTime ?? new Date();
+              observation = new LangfuseEvent({
+                otelSpan: span,
+                timestamp,
+              });
+              break;
+            }
+            case "span":
+            default:
+              observation = new LangfuseSpan({
+                otelSpan: span,
+              });
           }
-          case "span":
-          default:
-            observation = new LangfuseSpan({
-              otelSpan: span,
-            });
-        }
 
-        const result = fn(observation as Parameters<F>[0]);
+          const result = fn(observation as Parameters<F>[0]);
 
-        if (result instanceof Promise) {
-          return wrapPromise(
-            result,
-            span,
-            observationOptions?.endOnExit,
-          ) as ReturnType<F>;
-        } else {
+          if (result instanceof Promise) {
+            return wrapPromise(
+              result,
+              span,
+              observationOptions?.endOnExit,
+            ) as ReturnType<F>;
+          } else {
+            if (observationOptions?.endOnExit !== false) {
+              span.end();
+            }
+
+            return result as ReturnType<F>;
+          }
+        } catch (err) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: err instanceof Error ? err.message : "Unknown error",
+          });
+
           if (observationOptions?.endOnExit !== false) {
             span.end();
           }
 
-          return result as ReturnType<F>;
+          throw err;
         }
-      } catch (err) {
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: err instanceof Error ? err.message : "Unknown error",
-        });
-
-        if (observationOptions?.endOnExit !== false) {
-          span.end();
-        }
-
-        throw err;
-      }
+      });
     },
   );
 }
@@ -1449,8 +1463,14 @@ export function observe<T extends (...args: any[]) => any>(
       },
     );
 
-    // Set the observation span as active in the context
-    const activeContext = trace.setSpan(context.active(), observation.otelSpan);
+    // Set the observation span as active in the context, and carry the
+    // app-root claim for descendants. The observation was already started by
+    // startObservation above, so its onStart ran against the unmodified
+    // parent context and cannot self-suppress.
+    const activeContext = setLangfuseTraceIdInBaggage(
+      trace.setSpan(context.active(), observation.otelSpan),
+      observation.otelSpan.spanContext().traceId,
+    );
 
     try {
       const result = context.with(activeContext, () => fn.apply(this, args));

--- a/tests/integration/span-processor.integration.test.ts
+++ b/tests/integration/span-processor.integration.test.ts
@@ -600,8 +600,9 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
 
       await waitForSpanExport(testEnv.mockExporter, 1);
 
-      // Should have called the function twice
-      expect(callCount).toBe(2);
+      // Called once for app-root start-time classification and once for
+      // export-time filtering on each span.
+      expect(callCount).toBe(4);
 
       // Only the normal span should be exported (error span filtered out due to exception)
       assertions.expectSpanCount(1);


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces **app-root detection** for the Langfuse span processor: at `onStart` time, spans are marked with `langfuse.internal.is_app_root = true` when they are the first exported span under a filtered (non-Langfuse) parent, with cross-service suppression via a new internal OTel baggage key (`langfuse_trace_id`) that prevents duplicate app-root marking in downstream services.

- **`span-processor.ts`**: New per-trace in-memory state (`appRootTraces`) tracks which spans are expected to be exported at start time; `markAppRootCandidate` applies the app-root attribute with correct precedence (local parent state > upstream baggage claim); `cleanupAppRootState` is always called in a `finally` block to prevent state leaks.
- **`propagation.ts`**: Adds `LANGFUSE_TRACE_ID_BAGGAGE_KEY` and helper functions; explicitly skips the internal key in `getPropagatedAttributesFromContext` so it is never exposed as a user-facing span attribute.
- **`tracing/src/index.ts`**: Both `startActiveObservation` and `observe` set the trace-ID baggage claim **after** their own span's `onStart` has fired, ensuring the Langfuse span itself is not accidentally suppressed by its own claim.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with minor fixes — the core logic is correct and well-tested.

The app-root detection logic correctly handles local parent state taking precedence over upstream baggage claims, self-suppression prevention, cross-service coordination, and state cleanup. The one functional concern is that ended span entries are never evicted from traceState.spans individually — they accumulate until the entire trace ends — which could matter for batch-style traces with many sequential child spans. The test file also contains a dynamic import that violates the team module-structure rule.

packages/otel/src/span-processor.ts (cleanupAppRootState memory accumulation) and packages/otel/src/span-processor.test.ts (dynamic import inside test function)
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Tracer
    participant Processor as LangfuseSpanProcessor
    participant State as appRootTraces Map
    participant Span

    Note over Tracer,Span: onStart - app-root marking
    Tracer->>Processor: onStart(span, parentContext)
    Processor->>State: get or create AppRootTraceState
    Processor->>Processor: isExpectedExportedAtStart(span)
    Processor->>Processor: getLangfuseTraceIdFromBaggage(parentContext)
    alt parent not exported locally AND no upstream baggage claim
        Processor->>Span: setAttribute IS_APP_ROOT true
    end
    Processor->>State: record span state and increment activeCount

    Note over Tracer,Span: onEnd - cleanup
    Tracer->>Processor: onEnd(span)
    Processor->>Processor: shouldExportSpan check
    Processor->>State: mark span ended and decrement activeCount
    alt activeCount reaches zero
        Processor->>State: delete entire trace entry
    end

    Note over Tracer,Span: Cross-service claim propagation
    Tracer->>Processor: startActiveObservation creates Langfuse span
    Processor->>Processor: setLangfuseTraceIdInBaggage after onStart fires
    Processor->>Tracer: child spans inherit baggage claim
    Note right of Processor: Downstream service sees claim and suppresses IS_APP_ROOT
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/otel/src/span-processor.test.ts:1-5
Dynamic import inside a function body violates the team rule of placing imports at the top of the module. `getPropagatedAttributesFromContext` is already exported from `@langfuse/core`, which is already imported statically at the top of this file.

```suggestion
import {
  LANGFUSE_TRACER_NAME,
  LANGFUSE_TRACE_ID_BAGGAGE_KEY,
  LangfuseOtelSpanAttributes,
  getPropagatedAttributesFromContext,
} from "@langfuse/core";
```

### Issue 2 of 3
packages/otel/src/span-processor.test.ts:330-336
With the static import moved to the top, this dynamic import becomes unnecessary and can be replaced with a direct call.

```suggestion
  it("does not surface the internal trace-id baggage as user metadata", () => {
    const ctx = contextWithBaggageClaim(TRACE_ID);
    const propagated = getPropagatedAttributesFromContext(ctx);
```

### Issue 3 of 3
packages/otel/src/span-processor.ts:514-529
**Spans Map grows unbounded within a trace lifetime**

Individual span entries are added to `traceState.spans` in `markAppRootCandidate` but never removed in `cleanupAppRootState` — only the entire `AppRootTraceState` is deleted when `activeCount` reaches zero. For a long-lived root span that sequentially spawns thousands of child spans (e.g., a batch-processing trace), all child entries accumulate in the map until the root ends. Since OTel guarantees that a parent outlives all its children, it is safe to call `traceState.spans.delete(spanId)` here immediately after marking the span as ended — any child that will ever reference this span as its parent has already been registered. Consider adding `traceState.spans.delete(spanId)` inside the `if (spanState && !spanState.ended)` block.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(span-processor): add app root detec..."](https://github.com/langfuse/langfuse-js/commit/6b102979c0c6f5c56dcdb44f9852c91f40fd4495) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32823170)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/review/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->