### PR TITLE
fix(otel): bridge Vercel AI SDK TTFT to completion_start_time

### DIFF
--- a/packages/otel/src/span-processor.test.ts
+++ b/packages/otel/src/span-processor.test.ts
@@ -36,6 +36,7 @@ function createTestSpan(opts: {
   instrumentationScopeName?: string;
   name?: string;
   initialAttributes?: Record<string, unknown>;
+  startTime?: [number, number];
 }): TestSpan {
   const attributes: Record<string, unknown> = {
     ...(opts.initialAttributes ?? {}),
@@ -68,7 +69,7 @@ function createTestSpan(opts: {
     },
     // Stubbed ReadableSpan surface used by the export pipeline.
     duration: [0, 0],
-    startTime: [0, 0],
+    startTime: opts.startTime ?? [0, 0],
     endTime: [0, 0],
     kind: 0,
     status: { code: 0 },
@@ -364,6 +365,92 @@ describe("LangfuseSpanProcessor app-root marking", () => {
 
     // V1 does not repair: the marker remains, but the span will not be exported.
     expect(span.attributes[LangfuseOtelSpanAttributes.IS_APP_ROOT]).toBe(true);
+  });
+});
+
+describe("Vercel AI SDK TTFT bridge", () => {
+  let processor: LangfuseSpanProcessor;
+
+  beforeEach(() => {
+    spanIdCounter = 0;
+    processor = new LangfuseSpanProcessor({
+      exporter: noopExporter,
+      shouldExportSpan: () => true,
+    });
+  });
+
+  const TTFT_ATTR =
+    LangfuseOtelSpanAttributes.OBSERVATION_COMPLETION_START_TIME;
+
+  it("sets completion_start_time from ai.response.msToFirstChunk (streamText)", async () => {
+    const span = createTestSpan({
+      traceId: TRACE_ID,
+      instrumentationScopeName: "ai",
+      initialAttributes: { "ai.response.msToFirstChunk": 250 },
+      startTime: [1, 0], // 1000ms since epoch
+    });
+
+    processor.onEnd(span);
+    await processor.forceFlush();
+
+    expect(span.attributes[TTFT_ATTR]).toBe(JSON.stringify(new Date(1250)));
+  });
+
+  it("sets completion_start_time from ai.stream.msToFirstChunk (streamObject)", async () => {
+    const span = createTestSpan({
+      traceId: TRACE_ID,
+      instrumentationScopeName: "ai",
+      initialAttributes: { "ai.stream.msToFirstChunk": 400 },
+      startTime: [2, 0],
+    });
+
+    processor.onEnd(span);
+    await processor.forceFlush();
+
+    expect(span.attributes[TTFT_ATTR]).toBe(JSON.stringify(new Date(2400)));
+  });
+
+  it("does nothing when neither msToFirstChunk attribute is present", async () => {
+    const span = createTestSpan({
+      traceId: TRACE_ID,
+      instrumentationScopeName: "ai",
+    });
+
+    processor.onEnd(span);
+    await processor.forceFlush();
+
+    expect(span.attributes[TTFT_ATTR]).toBeUndefined();
+  });
+
+  it("does nothing for spans outside the ai instrumentation scope", async () => {
+    const span = createTestSpan({
+      traceId: TRACE_ID,
+      instrumentationScopeName: "unknown.instrumentation",
+      initialAttributes: { "ai.response.msToFirstChunk": 250 },
+    });
+
+    processor.onEnd(span);
+    await processor.forceFlush();
+
+    expect(span.attributes[TTFT_ATTR]).toBeUndefined();
+  });
+
+  it("does not overwrite a pre-existing completion_start_time", async () => {
+    const userSetValue = JSON.stringify(new Date(9999));
+    const span = createTestSpan({
+      traceId: TRACE_ID,
+      instrumentationScopeName: "ai",
+      initialAttributes: {
+        "ai.response.msToFirstChunk": 250,
+        [TTFT_ATTR]: userSetValue,
+      },
+      startTime: [1, 0],
+    });
+
+    processor.onEnd(span);
+    await processor.forceFlush();
+
+    expect(span.attributes[TTFT_ATTR]).toBe(userSetValue);
   });
 });
 

--- a/packages/otel/src/span-processor.ts
+++ b/packages/otel/src/span-processor.ts
@@ -432,6 +432,23 @@ export class LangfuseSpanProcessor implements SpanProcessor {
       return;
     }
 
+    if (
+      span.instrumentationScope.name === "ai" &&
+      !(
+        LangfuseOtelSpanAttributes.OBSERVATION_COMPLETION_START_TIME in
+        span.attributes
+      )
+    ) {
+      const ms =
+        span.attributes["ai.response.msToFirstChunk"] ??
+        span.attributes["ai.stream.msToFirstChunk"];
+      if (typeof ms === "number") {
+        span.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_COMPLETION_START_TIME
+        ] = JSON.stringify(new Date(hrTimeToMilliseconds(span.startTime) + ms));
+      }
+    }
+
     await this.applyMaskInPlace(span);
     await this.mediaService.process(span);
 


### PR DESCRIPTION
## Problem

`LangfuseSpanProcessor` doesn't set `completionStartTime` for Vercel AI SDK
spans, so TTFT is always blank in the UI.

The AI SDK emits `ai.response.msToFirstChunk` (streamText) and
`ai.stream.msToFirstChunk` (streamObject). Nothing reads them.

`langfuse-vercel` handled this in #379 and #401. Lost in the move to
`@langfuse/otel`.

## Fix

Port the #379/#401 bridge. Same math, same attribute names. Old exporter set
a property on the ingestion event; new processor sets the attribute on the
span before OTLP export.

A user-set `completion_start_time` is preserved.

## Verification

- `pnpm typecheck` — green
- `pnpm lint` — green
- `pnpm exec vitest run packages/otel/src/span-processor.test.ts` — 19/19 pass (5 new)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR ports the TTFT (time-to-first-token) bridge from the old `langfuse-vercel` exporter into `LangfuseSpanProcessor`, so `completionStartTime` is populated for Vercel AI SDK spans in the new OTEL pipeline.

- **New logic in `span-processor.ts`**: On `onEnd`, if the span's instrumentation scope is `"ai"` and `langfuse.observation.completion_start_time` is not already set, it reads `ai.response.msToFirstChunk` (streamText) or `ai.stream.msToFirstChunk` (streamObject) and computes `startTime + ms` to derive the absolute first-chunk timestamp.
- **Test coverage**: Five new test cases covering the `streamText` path, the `streamObject` path, the no-op path when neither attribute is present, the scope guard (non-AI spans are skipped), and the pre-existing-value guard (user-set values are not overwritten).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to spans from the Vercel AI SDK instrumentation scope, never mutates spans that already carry a user-set value, and is guarded by a type check on the numeric attribute before writing anything.

The logic is a faithful port of the same computation that existed in the old exporter, the math is verified by the new tests, the guard conditions (scope name, pre-existing attribute, typeof ms === 'number') are all correct, and the attribute format matches what the rest of the codebase produces via _serialize. No imports were added inside functions.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant SDK as Vercel AI SDK
    participant OTel as OpenTelemetry
    participant Proc as LangfuseSpanProcessor.onEnd
    participant Export as OTLP Exporter

    SDK->>OTel: "end span (ai.response.msToFirstChunk = N or ai.stream.msToFirstChunk = N)"
    OTel->>Proc: onEnd(span)
    Proc->>Proc: shouldExportSpan?
    alt "scope == 'ai' AND completion_start_time not set"
        Proc->>Proc: "ms = msToFirstChunk attribute"
        Proc->>Proc: "completion_start_time = JSON.stringify(new Date(startTime + ms))"
    end
    Proc->>Proc: applyMaskInPlace(span)
    Proc->>Export: processor.onEnd(span) with completion_start_time set
    Export->>Export: OTLP export to Langfuse
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): bridge Vercel AI SDK TTFT to ..."](https://github.com/langfuse/langfuse-js/commit/f8c2fd111f636884fb702066f2c14e5013468a65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33613458)</sub>

<!-- /greptile_comment -->