### PR TITLE
ci: allow JS SDK branch prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,9 @@ on:
       prerelease_type:
         description: "Pre-release type (used when version is prepatch/preminor/premajor)"
         type: choice
-        default: ""
+        default: "none"
         options:
-          - ""
+          - none
           - alpha
           - beta
           - rc
@@ -46,13 +46,39 @@ jobs:
     runs-on: ubuntu-latest
     environment: protected branches
     steps:
-      - name: Verify branch
+      - name: Verify release ref
         run: |
-          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
-            echo "❌ Error: Releases can only be triggered from main branch"
+          if [ "${GITHUB_REF_TYPE}" != "branch" ]; then
+            echo "❌ Error: Releases can only be triggered from branches"
             echo "Current ref: ${GITHUB_REF}"
             exit 1
           fi
+
+          if [ "${GITHUB_REF_NAME}" = "main" ]; then
+            echo "✅ Official and pre-release releases are allowed from main"
+            exit 0
+          fi
+
+          case "${INPUTS_VERSION}" in
+            prepatch|preminor|premajor)
+              ;;
+            *)
+              echo "❌ Error: Official releases can only be triggered from main branch"
+              echo "Current branch: ${GITHUB_REF_NAME}"
+              echo "Requested version bump: ${INPUTS_VERSION}"
+              exit 1
+              ;;
+          esac
+
+          if [ -z "${INPUTS_PRERELEASE_TYPE}" ] || [ "${INPUTS_PRERELEASE_TYPE}" = "none" ]; then
+            echo "❌ Error: Branch releases must specify prerelease_type as alpha, beta, or rc"
+            exit 1
+          fi
+
+          echo "✅ Pre-release branch release allowed from ${GITHUB_REF_NAME}"
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
+          INPUTS_PRERELEASE_TYPE: ${{ inputs.prerelease_type }}
       - name: Confirm major release
         if: ${{ inputs.version == 'major' || inputs.version == 'premajor' }}
         run: |
@@ -110,7 +136,7 @@ jobs:
 
           if [ "$version_type" = "prepatch" ] || [ "$version_type" = "preminor" ] || [ "$version_type" = "premajor" ]; then
             prerelease_type="${INPUTS_PRERELEASE_TYPE}"
-            if [ -z "$prerelease_type" ]; then
+            if [ -z "$prerelease_type" ] || [ "$prerelease_type" = "none" ]; then
               echo "❌ Error: prerelease_type must be specified when version is prepatch/preminor/premajor"
               exit 1
             fi


### PR DESCRIPTION
## Summary
- allow the JS SDK release workflow to run prereleases from non-main branches while keeping official releases main-only
- require `alpha`, `beta`, or `rc` prerelease type for branch prereleases
- replace the blank prerelease choice with `none` so the workflow passes actionlint and rejects unset prerelease dispatches

## Operational note
- Updated the `protected branches` GitHub Environment deployment branch policy outside the repo to allow branch pattern `v*-stable`, alongside existing `main` and `v*` tag policies.

## Verification
- `actionlint .github/workflows/release.yml`
- `pnpm dlx prettier@3.6.2 --check .github/workflows/release.yml`
- YAML parse check
- `git diff --check`
- manual release-ref guard matrix for main, stable branch prerelease, stable branch official release, missing prerelease type, and tag refs

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the JS SDK release workflow to support prereleases from non-`main` branches (e.g., `v*-stable`) while keeping official stable releases `main`-only, and replaces the empty-string `prerelease_type` default with `"none"` to satisfy `actionlint`.

- **Branch guard refactor**: the single `main`-only check is replaced by a multi-stage shell script that fast-exits for `main`, rejects non-prerelease version types (`patch`/`minor`/`major`) from any branch other than `main`, and rejects prerelease version types that lack an explicit `alpha`/`beta`/`rc` tag.
- **`none` sentinel**: the blank `""` choice option and default are replaced with `none` everywhere, and both the new guard and the existing "Determine release parameters" step treat `none` as an absent prerelease type, ensuring the two validation layers stay consistent.
- **Downstream double-check**: the "Determine release parameters" step already rejected an empty `prerelease_type`; the new `|| [ "$prerelease_type" = "none" ]` clause closes the gap now that `none` is the canonical sentinel value.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are confined to CI workflow logic, all error paths exit non-zero, and the new branch guard is consistent with the downstream parameter-validation step.

The branch-guard logic correctly handles all five dispatch scenarios described in the PR. The none sentinel is applied consistently in both the new step and the pre-existing Determine release parameters step. All inputs are choice-typed, limiting injection surface.

No files require special attention — the single changed file is a well-scoped CI workflow update.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[workflow_dispatch triggered] --> B{GITHUB_REF_TYPE == branch?}
    B -- No --> E1[❌ Error: not a branch]
    B -- Yes --> C{GITHUB_REF_NAME == main?}
    C -- Yes --> D[✅ All releases allowed\nexit 0]
    C -- No\nnon-main branch --> F{version in prepatch\npreminor premajor?}
    F -- No\npatch/minor/major --> E2[❌ Error: Official releases\nmain-only]
    F -- Yes --> G{prerelease_type\nempty or none?}
    G -- Yes --> E3[❌ Error: must specify\nalpha/beta/rc]
    G -- No\nalpha/beta/rc --> H[✅ Pre-release branch\nrelease allowed]
    D --> I[Confirm major release?\nif premajor or major]
    H --> I
    I --> J[Checkout / Setup / Build]
    J --> K[Determine release parameters\nalso validates prerelease_type≠none\nfor pre* version types]
    K --> L[Run release-it]
    L --> M[Notify Slack]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into codex/js-sdk-br..."](https://github.com/langfuse/langfuse-js/commit/a0468bc3dd6f9edf39c64d17173809b5f8041d1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33759080)</sub>

<!-- /greptile_comment -->