### PR TITLE
docs: update README banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![GitHub Banner](https://github.com/langfuse/langfuse-js/assets/2834609/d1613347-445f-4e91-9e84-428fda9c3659)
+<img width="2400" height="600" alt="hero-b" src="https://github.com/user-attachments/assets/d78fe000-209b-4e18-8c46-c73410559cec" />
 
 # langfuse-js
 


### PR DESCRIPTION
Replaced GitHub banner image with a new hero image.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the old GitHub banner markdown image with an HTML `<img>` tag pointing to a new hero image asset hosted on GitHub. This is a pure documentation change with no code impact.

- The new `<img>` tag explicitly sets `width="2400"` and `height="600"`, which helps browsers reserve layout space before the image loads.
- The `alt` attribute is currently `"hero-b"` (an internal asset name) rather than a meaningful description — worth updating for accessibility.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change swapping a banner image — no code paths affected, safe to merge.

The change touches only the README banner image, switching from markdown syntax to an HTML img tag. The only minor observation is the non-descriptive alt text "hero-b".

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README.md] -->|Before| B["![GitHub Banner]\nMarkdown image syntax\nAsset: assets/2834609/d1613347"]
    A -->|After| C["&lt;img&gt; HTML tag\nwidth=2400 height=600\nAsset: user-attachments/d78fe000\nalt='hero-b'"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
README.md:1
The `alt` attribute is set to `"hero-b"`, which appears to be an internal asset name rather than a meaningful description. Screen readers and users with images disabled will read this value literally, providing no useful context about the image content.

```suggestion
<img width="2400" height="600" alt="Langfuse hero image" src="https://github.com/user-attachments/assets/d78fe000-209b-4e18-8c46-c73410559cec" />
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: update README banner"](https://github.com/langfuse/langfuse-js/commit/396112a3084d131ffdfbee5f20ae2852dd083765) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34918347)</sub>

<!-- /greptile_comment -->