### PR TITLE
fix(tracing): preserve empty-string metadata values

### DIFF
--- a/packages/tracing/src/attributes.ts
+++ b/packages/tracing/src/attributes.ts
@@ -131,13 +131,13 @@ function _flattenAndSerializeMetadata(
 
   if (typeof metadata !== "object" || Array.isArray(metadata)) {
     const serialized = _serialize(metadata);
-    if (serialized) {
+    if (serialized !== undefined) {
       metadataAttributes[prefix] = serialized;
     }
   } else {
     for (const [key, value] of Object.entries(metadata)) {
       const serialized = typeof value === "string" ? value : _serialize(value);
-      if (serialized) {
+      if (serialized !== undefined) {
         metadataAttributes[`${prefix}.${key}`] = serialized;
       }
     }

--- a/tests/integration/tracing.integration.test.ts
+++ b/tests/integration/tracing.integration.test.ts
@@ -97,6 +97,26 @@ describe("Tracing Methods Interoperability E2E Tests", () => {
       );
     });
 
+    it("should preserve empty-string metadata values", async () => {
+      const span = startObservation("empty-meta-span", {
+        metadata: { empty: "", filled: "x" },
+      });
+      span.end();
+
+      await waitForSpanExport(testEnv.mockExporter, 1);
+
+      assertions.expectSpanAttribute(
+        "empty-meta-span",
+        LangfuseOtelSpanAttributes.OBSERVATION_METADATA + ".empty",
+        "",
+      );
+      assertions.expectSpanAttribute(
+        "empty-meta-span",
+        LangfuseOtelSpanAttributes.OBSERVATION_METADATA + ".filled",
+        "x",
+      );
+    });
+
     it("should handle span with error status", async () => {
       const span = startObservation("error-span");
       // Use update method to set error status in attributes


### PR DESCRIPTION
Empty-string metadata values are silently dropped. In `_flattenAndSerializeMetadata`:

```ts
const serialized = typeof value === "string" ? value : _serialize(value);
if (serialized) {                       // "" is falsy -> dropped
  metadataAttributes[`${prefix}.${key}`] = serialized;
}
```

So `metadata: { a: "", b: "x", c: 0, d: false }` emits `b`, `c` (`"0"`), `d` (`"false"`) but **silently drops `a`** — inconsistent, since `0` and `false` survive.

`_serialize` returns `undefined` only for `null`/`undefined`, so switching the guard to `if (serialized !== undefined)` preserves `""` (and any other falsy-but-present value) while still skipping `null`/`undefined`. Applied to both the scalar-metadata branch and the object-entry loop.

### Test
Adds an integration test (`tracing.integration.test.ts`) asserting an empty-string metadata value is exported. Fails before (attribute absent), passes after. `prettier`/`eslint`/`tsc` clean (pre-commit hook).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent data-loss bug in `_flattenAndSerializeMetadata` where empty-string metadata values (`""`) were dropped because the truthiness guard `if (serialized)` evaluated `""` as falsy. The fix changes both guards to `serialized !== undefined`, which aligns with `_serialize`'s contract of returning `undefined` only for `null`/`undefined` inputs.

- **`packages/tracing/src/attributes.ts`**: Two `if (serialized)` guards replaced with `if (serialized !== undefined)` in the scalar and object-entry branches of `_flattenAndSerializeMetadata`.
- **`tests/integration/tracing.integration.test.ts`**: Integration test added that verifies an empty-string metadata value appears as a span attribute after export.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted guard fix that preserves existing behavior for all non-empty values while correctly retaining empty strings.

The two-line change is narrowly scoped: `_serialize` is guaranteed to return either a `string` or `undefined`, so `!== undefined` is the correct predicate. All previously-passing values (non-empty strings, numbers, booleans, objects) continue to pass the new guard unchanged, and only the previously-dropped `""` case is now correctly preserved. The integration test directly validates the fixed scenario.

No files require special attention — both changed files are straightforward and self-contained.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["_flattenAndSerializeMetadata(metadata, type)"] --> B{metadata null/undefined?}
    B -- Yes --> C[return empty object]
    B -- No --> D{Is metadata non-object or Array?}
    D -- Yes --> E["serialized = _serialize(metadata)"]
    E --> F{"serialized !== undefined?\n(was: if serialized)"}
    F -- Yes --> G["metadataAttributes[prefix] = serialized"]
    F -- No --> C
    D -- No --> H["for each [key, value] in metadata"]
    H --> I{"typeof value === 'string'?"}
    I -- Yes --> J["serialized = value (direct, e.g. '')"]    
    I -- No --> K["serialized = _serialize(value)"]
    J --> L{"serialized !== undefined?\n(was: if serialized — dropped '')"}
    K --> L
    L -- Yes --> M["metadataAttributes[prefix.key] = serialized"]
    L -- No --> H
    G --> N[return metadataAttributes]
    M --> N
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tracing): preserve empty-string meta..."](https://github.com/langfuse/langfuse-js/commit/5efce7932d491e984f0ed1a7ec69660cacca2811) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37504074)</sub>

<!-- /greptile_comment -->