### PR TITLE
fix(otel): apply mask function to object metadata attributes

### DIFF
--- a/packages/otel/src/span-processor.ts
+++ b/packages/otel/src/span-processor.ts
@@ -520,10 +520,15 @@ export class LangfuseSpanProcessor implements SpanProcessor {
     ];
 
     for (const maskCandidate of maskCandidates) {
-      if (maskCandidate in span.attributes) {
-        span.attributes[maskCandidate] = await this.applyMask(
-          span.attributes[maskCandidate],
-        );
+      // Metadata is flattened into `${candidate}.${key}` attributes, so an
+      // exact-key check never masks object metadata. Scan by prefix (mirroring
+      // MediaService) to also cover the flattened keys.
+      const maskRelevantAttributeKeys = Object.keys(span.attributes).filter(
+        (attributeName) => attributeName.startsWith(maskCandidate),
+      );
+
+      for (const key of maskRelevantAttributeKeys) {
+        span.attributes[key] = await this.applyMask(span.attributes[key]);
       }
     }
   }

--- a/packages/otel/src/span-processor.ts
+++ b/packages/otel/src/span-processor.ts
@@ -521,10 +521,13 @@ export class LangfuseSpanProcessor implements SpanProcessor {
 
     for (const maskCandidate of maskCandidates) {
       // Metadata is flattened into `${candidate}.${key}` attributes, so an
-      // exact-key check never masks object metadata. Scan by prefix (mirroring
-      // MediaService) to also cover the flattened keys.
+      // exact-key check never masks object metadata. Match the candidate itself
+      // or its dot-prefixed children (avoiding coincidental prefixes like
+      // `${candidate}_schema`).
       const maskRelevantAttributeKeys = Object.keys(span.attributes).filter(
-        (attributeName) => attributeName.startsWith(maskCandidate),
+        (attributeName) =>
+          attributeName === maskCandidate ||
+          attributeName.startsWith(maskCandidate + "."),
       );
 
       for (const key of maskRelevantAttributeKeys) {

--- a/tests/integration/span-processor.integration.test.ts
+++ b/tests/integration/span-processor.integration.test.ts
@@ -68,6 +68,40 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       );
     });
 
+    it("should apply mask function to object metadata", async () => {
+      await teardownTestEnvironment(testEnv);
+
+      testEnv = await setupTestEnvironment({
+        spanProcessorConfig: {
+          mask: ({ data }) => {
+            if (typeof data === "string") {
+              return data.replace(/secret/g, "***");
+            }
+            return data;
+          },
+        },
+      });
+      assertions = new SpanAssertions(testEnv.mockExporter);
+
+      const span = startObservation("masked-metadata-span", {
+        metadata: { apiKey: "secret-123", note: "no secret here" },
+      });
+      span.end();
+
+      await waitForSpanExport(testEnv.mockExporter, 1);
+
+      assertions.expectSpanAttribute(
+        "masked-metadata-span",
+        "langfuse.observation.metadata.apiKey",
+        "***-123",
+      );
+      assertions.expectSpanAttribute(
+        "masked-metadata-span",
+        "langfuse.observation.metadata.note",
+        "no *** here",
+      );
+    });
+
     it("should apply async mask function to span attributes", async () => {
       await teardownTestEnvironment(testEnv);
 


### PR DESCRIPTION
A configured `mask` function is **never applied to object metadata**, so secrets in metadata are exported verbatim.

`applyMaskInPlace` only masks exact-key attributes:
```ts
for (const maskCandidate of maskCandidates) {
  if (maskCandidate in span.attributes) {   // exact key only
    span.attributes[maskCandidate] = await this.applyMask(span.attributes[maskCandidate]);
  }
}
```
But object metadata is flattened into `${candidate}.${key}` attributes (e.g. `langfuse.observation.metadata.apiKey`), which the bare-key `in` check never matches. So:
```ts
startObservation("s", { metadata: { apiKey: "secret-123" } });
// exported: langfuse.observation.metadata.apiKey = "secret-123"  // unmasked, leaks
```
`input`/`output` mask correctly (they use the bare key); only the uncommon primitive-metadata path was masked.

Fix scans attribute keys by prefix — mirroring `MediaService.process`, which walks the **same** attribute list immediately after masking using `startsWith`. Now flattened metadata keys are masked too.

### Test
Adds an integration test masking object metadata (`{ apiKey: "secret-123" }` → `"***-123"`). Fails before (exported as `"secret-123"`), passes after. All existing mask tests still pass; `prettier`/`eslint`/`tsc` clean (pre-commit).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where a configured `mask` function was never applied to object-valued metadata: because metadata objects are flattened into `${candidate}.${key}` span attributes (e.g., `langfuse.observation.metadata.apiKey`), the previous exact-key `in` check in `applyMaskInPlace` never matched them, so the values leaked verbatim. The fix replaces the exact-key lookup with a prefix scan — identical to the existing pattern in `MediaService.process`.

- **`span-processor.ts`**: Replaces `if (maskCandidate in span.attributes)` with an `Object.keys` prefix filter, masking both the bare key (primitive metadata) and all flattened child keys (object metadata).
- **Integration test**: Adds a test that starts an observation with `{ apiKey: "secret-123" }` metadata, runs the mask function, and asserts each flattened attribute receives the transformed value.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a two-line fix confined to a single private method, the logic is correct, and the new integration test validates the full round-trip.

The fix is correct and well-tested, but the `startsWith` prefix match without a dot separator is a loose pattern inherited from `MediaService` — a future attribute whose name starts with the same string would be silently masked. No current attribute conflicts exist, so this is a robustness concern rather than a present defect.

No files require special attention; the single-method change in `span-processor.ts` is straightforward and self-contained.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/otel/src/span-processor.ts:526-528
The prefix check `startsWith(maskCandidate)` does not require a separator, so it would also match an attribute whose name happens to begin with the same string by coincidence — for example, a future `langfuse.observation.metadata_schema` key would be silently masked. The same gap exists in `MediaService.ts` where this pattern was adopted from. A precise check of either an exact match or a dot-continuation is safer and future-proof.

```suggestion
      const maskRelevantAttributeKeys = Object.keys(span.attributes).filter(
        (attributeName) =>
          attributeName === maskCandidate ||
          attributeName.startsWith(maskCandidate + "."),
      );
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): apply mask function to object..."](https://github.com/langfuse/langfuse-js/commit/615e9754b16dd5f119a042fc0aa56d50f546075b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37515970)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->