### PR TITLE
fix(tracing): set active observation type without update

### DIFF
--- a/packages/tracing/src/spanWrapper.ts
+++ b/packages/tracing/src/spanWrapper.ts
@@ -85,10 +85,7 @@ export type LangfuseObservation =
 type LangfuseObservationParams = {
   otelSpan: Span;
   type: LangfuseObservationType;
-  attributes?:
-    | LangfuseSpanAttributes
-    | LangfuseGenerationAttributes
-    | LangfuseEventAttributes;
+  attributes?: LangfuseObservationAttributes;
 };
 
 /**
@@ -155,11 +152,9 @@ abstract class LangfuseBaseObservation {
     this.traceId = params.otelSpan.spanContext().traceId;
     this.type = params.type;
 
-    if (params.attributes) {
-      this.otelSpan.setAttributes(
-        createObservationAttributes(params.type, params.attributes),
-      );
-    }
+    this.otelSpan.setAttributes(
+      createObservationAttributes(params.type, params.attributes ?? {}),
+    );
   }
 
   /** Gets the Langfuse OpenTelemetry tracer instance */

--- a/tests/integration/tracing.integration.test.ts
+++ b/tests/integration/tracing.integration.test.ts
@@ -2620,6 +2620,23 @@ describe("Tracing Methods Interoperability E2E Tests", () => {
       assertions.expectSpanWithName("vector-retrieval");
     });
 
+    it("should set active observation type without requiring update", async () => {
+      const result = startActiveObservation(
+        "vector-retrieval-without-update",
+        () => "retrieved",
+        { asType: "retriever" },
+      );
+
+      await waitForSpanExport(testEnv.mockExporter, 1);
+
+      expect(result).toBe("retrieved");
+      assertions.expectSpanAttribute(
+        "vector-retrieval-without-update",
+        LangfuseOtelSpanAttributes.OBSERVATION_TYPE,
+        "retriever",
+      );
+    });
+
     it("should execute function with active evaluator context", async () => {
       const result = await startActiveObservation(
         "response-evaluator",


### PR DESCRIPTION
## What changed

- Always writes normalized Langfuse observation attributes when constructing an observation wrapper, even when no user attributes are supplied.
- Adds a regression test for `startActiveObservation(..., { asType: "retriever" })` where the callback never calls `update()`.

## Root cause

`startActiveObservation` constructs typed observation wrappers with only the OTel span. The base observation constructor only called `createObservationAttributes(...)` when `params.attributes` was truthy, so `langfuse.observation.type` was not written until a later `update()` call.

## Impacted packages

- `@langfuse/tracing`

## Validation

- `pnpm exec prettier --check packages/tracing/src/spanWrapper.ts tests/integration/tracing.integration.test.ts --log-level error`
- `pnpm exec vitest run --project=integration tests/integration/tracing.integration.test.ts -t "should set active observation type without requiring update"`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:integration`

Refs LFE-9887 and langfuse/langfuse#13746.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a bug where `startActiveObservation` with a non-default `asType` would fail to write `langfuse.observation.type` to the OTel span if the callback never called `update()`, because the base constructor guarded `createObservationAttributes` behind a truthiness check on `params.attributes`.

- Removes the `if (params.attributes)` guard in `LangfuseBaseObservation` constructor, unconditionally calling `createObservationAttributes(params.type, params.attributes ?? {})` so the type attribute is always written on construction.
- Simplifies the internal `LangfuseObservationParams.attributes` type from a three-member union to the broader `LangfuseObservationAttributes` intersection type.
- Adds a regression integration test verifying that `startActiveObservation("…", cb, { asType: "retriever" })` produces a span with the correct `OBSERVATION_TYPE` attribute even when `update()` is never called.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Minimal, well-scoped change — only the constructor guard is removed and an empty-object default is added. The regression test directly covers the repaired path.

The constructor now unconditionally calls `createObservationAttributes`, which filters out null/undefined values before writing to the span, so passing `{}` when no attributes are supplied is safe. The type narrowing change for the internal `LangfuseObservationParams` is purely structural and has no runtime impact. The integration test exercises the exact previously-broken path. No other callers are adversely affected.

No files require special attention — both changed files are straightforward and the logic is easy to follow.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant startActiveObservation
    participant LangfuseRetriever
    participant LangfuseBaseObservation
    participant OtelSpan

    Caller->>startActiveObservation: "startActiveObservation(name, cb, { asType: retriever })"
    startActiveObservation->>LangfuseRetriever: "new LangfuseRetriever({ otelSpan, attributes? })"
    LangfuseRetriever->>LangfuseBaseObservation: "super({ otelSpan, type: retriever, attributes? })"
    Note over LangfuseBaseObservation: BEFORE: skipped if !attributes AFTER: always executes
    LangfuseBaseObservation->>OtelSpan: "setAttributes({ langfuse.observation.type: retriever })"
    LangfuseBaseObservation-->>LangfuseRetriever: constructed
    LangfuseRetriever-->>startActiveObservation: wrapper
    startActiveObservation->>Caller: invoke cb() inside active context
    Note over Caller: cb never calls update()
    startActiveObservation->>OtelSpan: end()
    OtelSpan-->>Caller: span exported with correct type
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into hassiebbot/fix-..."](https://github.com/langfuse/langfuse-js/commit/4951809886814d7abfa7d04f5f4d780f05b1b9cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37581285)</sub>

<!-- /greptile_comment -->