### PR TITLE
fix(otel): detect base64 data URIs with media-type parameters

### DIFF
--- a/packages/otel/src/MediaService.ts
+++ b/packages/otel/src/MediaService.ts
@@ -50,9 +50,11 @@ export class MediaService {
           continue;
         }
 
-        // Find media base64 data URI
+        // Find media base64 data URI. The media type may carry parameters
+        // (e.g. `;charset=utf-8`) before `;base64`, so match any non-comma run
+        // up to `;base64,` rather than stopping at the first `;`.
         let mediaReplacedValue = value;
-        const regex = /data:[^;]+;base64,[A-Za-z0-9+/]+=*/g;
+        const regex = /data:[^,]*;base64,[A-Za-z0-9+/]+=*/g;
         const foundMedia = [...new Set(value.match(regex) ?? [])];
 
         if (foundMedia.length === 0) continue;

--- a/tests/integration/span-processor.integration.test.ts
+++ b/tests/integration/span-processor.integration.test.ts
@@ -222,6 +222,30 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       );
       expect(mediaMatches).toHaveLength(2);
     });
+
+    it("should replace data URIs that include a media-type parameter", async () => {
+      // RFC 2397 allows parameters (e.g. ;charset=utf-8) before ;base64
+      const dataUri = "data:text/plain;charset=utf-8;base64,SGVsbG8gd29ybGQ=";
+
+      const span = startObservation("param-media-span", {
+        input: { file: dataUri },
+      });
+      span.end();
+
+      await waitForSpanExport(testEnv.mockExporter, 1);
+
+      const inputValue = testEnv.mockExporter.getSpanAttributes(
+        "param-media-span",
+      )?.["langfuse.observation.input"] as string;
+      expect(inputValue).toBeDefined();
+
+      // Should not contain the original data URI
+      expect(inputValue).not.toContain(dataUri);
+      // Should contain a Langfuse media tag
+      expect(inputValue).toMatch(
+        /@@@langfuseMedia:type=[^|]+\|id=[^|]+\|source=[^@]+@@@/,
+      );
+    });
   });
 
   describe("Batch processing", () => {


### PR DESCRIPTION
The media-extraction regex in `MediaService` requires `;base64` to immediately follow the content type:

```ts
const regex = /data:[^;]+;base64,[A-Za-z0-9+/]+=*/g;
```

So a valid [RFC 2397](https://datatracker.ietf.org/doc/html/rfc2397) data URI with a media-type **parameter** never matches:

```
data:text/plain;charset=utf-8;base64,SGVsbG8=   // [^;]+ stops at the first ";"
```

The result: the media is **not** extracted/uploaded, and the raw base64 stays embedded verbatim in the exported attribute (payload bloat + the upload is silently skipped). Plain `data:image/png;base64,…` works only because it has no parameter.

The downstream parser (`@langfuse/core` `parseBase64DataUri`) is already parameter-aware (`header.split(";")`), so the extraction regex was stricter than the parser it feeds. Fix matches any non-comma run up to `;base64,`:

```ts
const regex = /data:[^,]*;base64,[A-Za-z0-9+/]+=*/g;
```

### Test
Adds an integration test embedding `data:text/plain;charset=utf-8;base64,…` and asserting it is replaced with a `@@@langfuseMedia:…@@@` tag. Fails before (URI left embedded), passes after. Existing media tests still pass; `prettier`/`eslint`/`tsc` clean (pre-commit).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a regex in `MediaService` that failed to match RFC 2397 data URIs containing media-type parameters (e.g. `data:text/plain;charset=utf-8;base64,…`), causing those URIs to be left embedded verbatim instead of being extracted and uploaded. The fix narrows the matching expression from `[^;]+` (stops at first `;`) to `[^,]*` (stops at first `,`, covering the full header), aligned with how the downstream `parseBase64DataUri` parser already handles parameters.

- `packages/otel/src/MediaService.ts`: single-character class change in the detection regex, with an explanatory comment added.
- `tests/integration/span-processor.integration.test.ts`: new integration test that embeds a parameterised data URI and asserts it is replaced with a `@@@langfuseMedia:…@@@` tag.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single-character class adjustment in a detection regex, well-covered by a new integration test, and consistent with the downstream parser.

The regex fix is minimal and well-reasoned: greedy backtracking on `[^,]*;base64,` correctly locates the last `;base64,` before the MIME-type/data boundary for both plain and parameterised URIs. The new integration test directly exercises the previously-broken path and confirms replacement. Existing tests continue to cover the simple `image/png;base64` case. No unrelated code is touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Span attribute value string] --> B{Regex match on value}
    B -- No match --> C[Skip attribute]
    B -- Match found --> D[Deduplicate matches]
    D --> E[For each data URI]
    E --> F[Create LangfuseMedia object]
    F --> G{Get media tag}
    G -- Failure --> H[Log warn, skip item]
    G -- Success --> I[Schedule upload]
    I --> J[Replace URI with langfuseMedia tag]
    J --> K[Write updated value back to span attributes]
    K --> E
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): detect base64 data URIs with ..."](https://github.com/langfuse/langfuse-js/commit/21d791426ac206f3a0eeffdb935b3bec515e6d9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37582400)</sub>

<!-- /greptile_comment -->