### PR TITLE
fix(client): link dataset run items to observations

### DIFF
--- a/packages/client/src/dataset/index.ts
+++ b/packages/client/src/dataset/index.ts
@@ -309,10 +309,13 @@ export class DatasetManager {
         metadata?: any;
       },
     ): Promise<DatasetRunItem> => {
+      const { traceId, spanId } = obj.otelSpan.spanContext();
+
       return await this.langfuseClient.api.datasetRunItems.create({
         runName,
         datasetItemId: item.id,
-        traceId: obj.otelSpan.spanContext().traceId,
+        traceId,
+        observationId: spanId,
         runDescription: runArgs?.description,
         metadata: runArgs?.metadata,
       });

--- a/tests/e2e/datasets.e2e.test.ts
+++ b/tests/e2e/datasets.e2e.test.ts
@@ -328,6 +328,7 @@ describe("Langfuse Datasets E2E", () => {
         expect.arrayContaining([
           expect.objectContaining({
             traceId: generation.traceId,
+            observationId: generation.id,
           }),
         ]),
       );


### PR DESCRIPTION
## Summary
- Send `observationId` from `otelSpan.spanContext().spanId` when using manual dataset item `.link()`.
- Add a targeted e2e assertion that linked generation run items include the observation id.

Linear: LFE-10352

## Verification
- Not run per request.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes dataset run item linking by also sending the `observationId` (derived from `otelSpan.spanContext().spanId`) alongside the existing `traceId`, enabling the Langfuse server to associate a run item with a specific observation rather than just its parent trace. The pattern is consistent with how `score/index.ts` already populates `observationId` for scoring operations.

- **`packages/client/src/dataset/index.ts`**: Destructures `spanId` alongside `traceId` from `otelSpan.spanContext()` and passes it as `observationId` in the `datasetRunItems.create` call.
- **`tests/e2e/datasets.e2e.test.ts`**: Adds an assertion that the linked generation run item contains `observationId: generation.id`, confirming the span ID round-trips correctly (aligned with `spanWrapper.ts` line 151 where `this.id = params.otelSpan.spanContext().spanId`).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted fix to a single function that already handles the trace ID correctly.

The two-line source change follows the exact same pattern already used in score/index.ts for observationId, and the spanId-to-observation.id mapping is confirmed by spanWrapper.ts. The new e2e assertion exercises the changed code path end-to-end. No existing behavior is removed or altered; only the previously missing observationId field is now populated.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User Code
    participant LO as LangfuseObservation
    participant DM as DatasetManager
    participant API as Langfuse API

    U->>LO: "startObservation("generation", ..., { asType: "generation" })"
    Note over LO: this.id = otelSpan.spanContext().spanId

    U->>DM: "item.link({ otelSpan: generation.otelSpan }, runName)"
    DM->>DM: "const { traceId, spanId } = otelSpan.spanContext()"
    DM->>API: "datasetRunItems.create({ traceId, observationId: spanId, ... })"
    API-->>DM: DatasetRunItem (with observationId linked)
    DM-->>U: DatasetRunItem
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User Code
    participant LO as LangfuseObservation
    participant DM as DatasetManager
    participant API as Langfuse API

    U->>LO: "startObservation("generation", ..., { asType: "generation" })"
    Note over LO: this.id = otelSpan.spanContext().spanId

    U->>DM: "item.link({ otelSpan: generation.otelSpan }, runName)"
    DM->>DM: "const { traceId, spanId } = otelSpan.spanContext()"
    DM->>API: "datasetRunItems.create({ traceId, observationId: spanId, ... })"
    API-->>DM: DatasetRunItem (with observationId linked)
    DM-->>U: DatasetRunItem
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(client): link dataset run items to o..."](https://github.com/langfuse/langfuse-js/commit/9456987113f224450da8d84b59dc06a517fba85a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37913717)</sub>

<!-- /greptile_comment -->