### PR TITLE
refactor(experiments): deprecate link method and update documentation to use runExperiment() instead

### DIFF
--- a/packages/client/src/dataset/index.ts
+++ b/packages/client/src/dataset/index.ts
@@ -137,9 +137,6 @@ export type RunExperimentOnDataset = (
  * // Work with individual items
  * for (const item of dataset.items) {
  *   console.log(item.input, item.expectedOutput);
- *
- *   // Link item to a trace
- *   await item.link(myObservation, "experiment-run-1");
  * }
  *
  * // Run experiments on the entire dataset
@@ -154,7 +151,7 @@ export type RunExperimentOnDataset = (
  * @since 4.0.0
  */
 export type FetchedDataset = Dataset & {
-  /** Dataset items with linking functionality. @deprecated Use `runExperiment()` instead. */
+  /** Dataset items fetched from this dataset. */
   items: (DatasetItem & {
     /** @deprecated Use `runExperiment()` instead. */
     link: LinkDatasetItemFunction;
@@ -171,8 +168,8 @@ export type FetchedDataset = Dataset & {
 /**
  * Function type for linking dataset items to OpenTelemetry spans.
  *
- * @deprecated Use `langfuse.experiment.run()` instead for running experiments on datasets.
- * @see {@link https://langfuse.com/docs/evaluation/experiments/experiments-via-sdk#experiment-runner-sdk} Experiment SDK documentation
+ * @deprecated Use `runExperiment()` instead.
+ * @see {@link https://langfuse.com/docs/evaluation/experiments/experiments-via-sdk#experiment-runner-sdk}
  * @public
  */
 export type LinkDatasetItemFunction = (
@@ -237,9 +234,6 @@ export class DatasetManager {
    * for (const item of dataset.items) {
    *   console.log("Question:", item.input);
    *   console.log("Expected Answer:", item.expectedOutput);
-   *
-   *   // Each item has a link function for connecting to traces
-   *   // await item.link(span, "experiment-name");
    * }
    * ```
    *
@@ -425,7 +419,7 @@ export class DatasetManager {
 
   /**
    * Creates a link function for a specific dataset item.
-   * @deprecated Use `langfuse.experiment.run()` instead.
+   * @deprecated Use `runExperiment()` instead.
    * @internal
    */
   private createDatasetItemLinkFunction(
@@ -439,9 +433,6 @@ export class DatasetManager {
         metadata?: any;
       },
     ): Promise<DatasetRunItem> => {
-      getGlobalLogger().warn(
-        "dataset.items[].link() is deprecated. Use langfuse.experiment.run() instead.",
-      );
       const { traceId, spanId } = obj.otelSpan.spanContext();
 
       return await this.langfuseClient.api.datasetRunItems.create({

--- a/packages/client/src/dataset/index.ts
+++ b/packages/client/src/dataset/index.ts
@@ -154,8 +154,11 @@ export type RunExperimentOnDataset = (
  * @since 4.0.0
  */
 export type FetchedDataset = Dataset & {
-  /** Dataset items with additional linking functionality */
-  items: (DatasetItem & { link: LinkDatasetItemFunction })[];
+  /** Dataset items with linking functionality. @deprecated Use `runExperiment()` instead. */
+  items: (DatasetItem & {
+    /** @deprecated Use `runExperiment()` instead. */
+    link: LinkDatasetItemFunction;
+  })[];
   /** ISO 8601 timestamp (RFC 3339, Section 5.6) in UTC (e.g., "2026-01-21T14:35:42Z").
    * If provided, returns state of dataset at this timestamp.
    * If not provided, returns the latest version.
@@ -168,51 +171,9 @@ export type FetchedDataset = Dataset & {
 /**
  * Function type for linking dataset items to OpenTelemetry spans.
  *
- * This function creates a connection between a dataset item and a trace/observation,
- * enabling tracking of which dataset items were used in which experiments or runs.
- * This is essential for creating dataset runs and tracking experiment lineage.
- *
- * @param obj - Object containing the OpenTelemetry span to link to
- * @param obj.otelSpan - The OpenTelemetry span from a Langfuse observation
- * @param runName - Name of the experiment run for grouping related items
- * @param runArgs - Optional configuration for the dataset run
- * @param runArgs.description - Description of the experiment run
- * @param runArgs.metadata - Additional metadata to attach to the run
- * @returns Promise that resolves to the created dataset run item
- *
- * @example Basic linking
- * ```typescript
- * const dataset = await langfuse.dataset.get("my-dataset");
- * const span = startObservation("my-task", { input: "test" });
- * span.update({ output: "result" });
- * span.end();
- *
- * // Link the dataset item to this execution
- * await dataset.items[0].link(
- *   { otelSpan: span.otelSpan },
- *   "experiment-run-1"
- * );
- * ```
- *
- * @example Linking with metadata
- * ```typescript
- * await dataset.items[0].link(
- *   { otelSpan: span.otelSpan },
- *   "model-comparison-v2",
- *   {
- *     description: "Comparing GPT-4 vs Claude performance",
- *     metadata: {
- *       modelVersion: "gpt-4-1106-preview",
- *       temperature: 0.7,
- *       timestamp: new Date().toISOString()
- *     }
- *   }
- * );
- * ```
- *
- * @see {@link https://langfuse.com/docs/datasets} Langfuse datasets documentation
+ * @deprecated Use `langfuse.experiment.run()` instead for running experiments on datasets.
+ * @see {@link https://langfuse.com/docs/evaluation/experiments/experiments-via-sdk#experiment-runner-sdk} Experiment SDK documentation
  * @public
- * @since 4.0.0
  */
 export type LinkDatasetItemFunction = (
   obj: { otelSpan: Span },
@@ -464,9 +425,7 @@ export class DatasetManager {
 
   /**
    * Creates a link function for a specific dataset item.
-   *
-   * @param item - The dataset item to create a link function for
-   * @returns A function that can link the item to OpenTelemetry spans
+   * @deprecated Use `langfuse.experiment.run()` instead.
    * @internal
    */
   private createDatasetItemLinkFunction(
@@ -480,6 +439,9 @@ export class DatasetManager {
         metadata?: any;
       },
     ): Promise<DatasetRunItem> => {
+      getGlobalLogger().warn(
+        "dataset.items[].link() is deprecated. Use langfuse.experiment.run() instead.",
+      );
       const { traceId, spanId } = obj.otelSpan.spanContext();
 
       return await this.langfuseClient.api.datasetRunItems.create({


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR deprecates the `link()` method on `FetchedDataset` items and redirects users to the `runExperiment()` API, removing the detailed JSDoc examples in favour of a deprecation notice and a runtime `warn()` log.

- The `link` property on each dataset item is now marked `@deprecated` in its JSDoc, and `createDatasetItemLinkFunction` emits a `getGlobalLogger().warn()` on every invocation.
- `LinkDatasetItemFunction`'s type-level documentation now points to `langfuse.experiment.run()`, while the property-level JSDoc and runtime warning inconsistently reference `runExperiment()` — two different API surfaces that will confuse migrating users.
- The `@deprecated` tag was also placed on the `items` array property itself, not just on the `link` method inside each element, which will cause IDE tooling to strike through `dataset.items` even for code that never calls `link()`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The runtime behaviour of `link()` is unchanged; the only additions are a deprecation warning and updated JSDoc. The inconsistency in the migration target affects developer guidance rather than runtime correctness.

The `LinkDatasetItemFunction` type doc and the runtime `warn()` message both say `langfuse.experiment.run()`, while the `FetchedDataset.items` JSDoc says `runExperiment()`. These are two distinct methods, so users reading different parts of the documentation will be directed to different APIs when migrating away from `link()`. Additionally, placing `@deprecated` on the `items` array itself will cause IDE tooling to strike through any access to `dataset.items`, even for code that never touches `link()`.

packages/client/src/dataset/index.ts — the deprecation message in `LinkDatasetItemFunction` and the runtime warning should be reconciled with the `runExperiment()` references used everywhere else.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User calls link on dataset item] --> B[createDatasetItemLinkFunction closure]
    B --> C[Emit deprecation warning via getGlobalLogger]
    C --> D[Extract traceId and spanId from otelSpan]
    D --> E[Call langfuseClient.api.datasetRunItems.create]
    E --> F[Return DatasetRunItem]

    G[Recommended migration path] --> H[dataset.runExperiment or langfuse.experiment.run]
    H --> I[ExperimentManager handles iteration and linking]
    I --> F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User calls link on dataset item] --> B[createDatasetItemLinkFunction closure]
    B --> C[Emit deprecation warning via getGlobalLogger]
    C --> D[Extract traceId and spanId from otelSpan]
    D --> E[Call langfuseClient.api.datasetRunItems.create]
    E --> F[Return DatasetRunItem]

    G[Recommended migration path] --> H[dataset.runExperiment or langfuse.experiment.run]
    H --> I[ExperimentManager handles iteration and linking]
    I --> F
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/client/src/dataset/index.ts:174-176
The deprecation message on `LinkDatasetItemFunction` and the runtime warning both say `langfuse.experiment.run()`, but the JSDoc on `FetchedDataset.items` (and its `link` property) says `runExperiment()`. These point to two different methods, so a user migrating away from `link()` will see contradictory guidance depending on where they look. The PR title indicates `runExperiment()` is the intended canonical replacement — the type-level doc and the runtime warning should match.

```suggestion
 * @deprecated Use `runExperiment()` instead for running experiments on datasets.
 * @see {@link https://langfuse.com/docs/evaluation/experiments/experiments-via-sdk#experiment-runner-sdk} Experiment SDK documentation
 * @public
```

### Issue 2 of 3
packages/client/src/dataset/index.ts:442-444
The same inconsistency exists in the runtime warning: it tells users to call `langfuse.experiment.run()` while the property-level JSDoc points to `runExperiment()`. A developer who reads the console warning at runtime and tries to look up `langfuse.experiment.run()` may not land on the intended `dataset.runExperiment()` shorthand.

```suggestion
      getGlobalLogger().warn(
        "dataset.items[].link() is deprecated. Use runExperiment() instead.",
      );
```

### Issue 3 of 3
packages/client/src/dataset/index.ts:157-161
The `@deprecated` tag is placed on the `items` array property itself rather than solely on the `link` method inside it. This implies to IDE tooling and users that `items` as a whole is deprecated, when only the `link` method on each element is. Users will see a strikethrough on `dataset.items` even when they are just reading items without using `link`.

```suggestion
  /** Dataset items fetched from this dataset. */
  items: (DatasetItem & {
    /** @deprecated Use `runExperiment()` instead. */
    link: LinkDatasetItemFunction;
  })[];
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(experiments): deprecate link me..."](https://github.com/langfuse/langfuse-js/commit/8070522c933bb8ce1d7843572f4ec9109fd9bfd7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40624358)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->