### PR TITLE
fix(langchain): serialize tools and ToolMessage metadata in generation input

### DIFF
--- a/packages/langchain/src/CallbackHandler.ts
+++ b/packages/langchain/src/CallbackHandler.ts
@@ -55,6 +55,45 @@ type ConstructorParams = {
 
 type TrackedObservation = LangfuseSpan | LangfuseGeneration | LangfuseTool;
 
+/**
+ * Normalizes a tool definition to the canonical OpenAI Chat-Completions shape
+ * `{ type: "function", function: { name, description, parameters, ... } }` so
+ * Langfuse renders it as a recognizable function.
+ *
+ * The OpenAI Responses API (used by ChatOpenAI/AzureChatOpenAI for gpt-5.x)
+ * exposes tools in a flattened shape `{ type: "function", name, description,
+ * parameters, strict }` without the `function` wrapper, which Langfuse does
+ * not recognize. Tools already in canonical shape, and non-function built-in
+ * tools (e.g. `web_search`, which have no `name`), are returned unchanged.
+ */
+function normalizeToolForLangfuse(tool: unknown): unknown {
+  if (!tool || typeof tool !== "object") return tool;
+  const t = tool as Record<string, unknown>;
+  // Already canonical: { type: "function", function: {...} }
+  if (t.type === "function" && t.function && typeof t.function === "object") {
+    return tool;
+  }
+  // Responses API flat shape: { type: "function", name, ... } → wrap under function
+  if (t.type === "function" && typeof t.name === "string") {
+    const { type, name, description, parameters, strict, ...rest } = t;
+    return {
+      type: "function",
+      function: {
+        name,
+        ...(description !== undefined && description !== null
+          ? { description }
+          : {}),
+        ...(parameters !== undefined && parameters !== null
+          ? { parameters }
+          : {}),
+        ...(strict !== undefined && strict !== null ? { strict } : {}),
+        ...rest,
+      },
+    };
+  }
+  return tool;
+}
+
 export class CallbackHandler extends BaseCallbackHandler {
   name = "LangfuseCallbackHandler";
 
@@ -339,7 +378,13 @@ export class CallbackHandler extends BaseCallbackHandler {
     if (Array.isArray(tools) && tools.length > 0) {
       inputMessages = [
         ...messages,
-        ...tools.map((t) => ({ role: "tool", content: t }) as LlmMessage),
+        ...tools.map(
+          (t) =>
+            ({
+              role: "tool",
+              content: normalizeToolForLangfuse(t) as LlmMessage["content"],
+            }) as LlmMessage,
+        ),
       ];
     }
 

--- a/packages/langchain/src/CallbackHandler.ts
+++ b/packages/langchain/src/CallbackHandler.ts
@@ -36,11 +36,13 @@ export type LlmMessage = {
   role: string;
   content: BaseMessageFields["content"];
   additional_kwargs?: BaseMessageFields["additional_kwargs"];
+  tool_call_id?: string;
 };
 
 export type AnonymousLlmMessage = {
   content: BaseMessageFields["content"];
   additional_kwargs?: BaseMessageFields["additional_kwargs"];
+  tool_call_id?: string;
 };
 
 type ConstructorParams = {
@@ -331,6 +333,16 @@ export class CallbackHandler extends BaseCallbackHandler {
       this.deregisterLangfusePrompt(parentRunId);
     }
 
+    const tools = (invocationParams as Record<string, unknown> | undefined)
+      ?.tools;
+    let inputMessages = messages;
+    if (Array.isArray(tools) && tools.length > 0) {
+      inputMessages = [
+        ...messages,
+        ...tools.map((t) => ({ role: "tool", content: t }) as LlmMessage),
+      ];
+    }
+
     this.startAndRegisterOtelSpan({
       type: "generation",
       runId,
@@ -339,7 +351,7 @@ export class CallbackHandler extends BaseCallbackHandler {
       tags,
       runName,
       attributes: {
-        input: messages,
+        input: inputMessages,
         model: extractedModelName,
         modelParameters: modelParameters,
         prompt: registeredPrompt,
@@ -962,7 +974,15 @@ export class CallbackHandler extends BaseCallbackHandler {
       response = {
         content: message.content,
         additional_kwargs: message.additional_kwargs,
-        role: message.name,
+        role: "tool",
+        tool_call_id:
+          "tool_call_id" in message
+            ? (
+                message as BaseMessage & {
+                  tool_call_id?: string;
+                }
+              ).tool_call_id
+            : undefined,
       };
     } else if (!message.name) {
       response = { content: message.content };

--- a/tests/integration/langchain.integration.test.ts
+++ b/tests/integration/langchain.integration.test.ts
@@ -109,6 +109,56 @@ describe("LangChain callback handler integration tests", () => {
     );
   });
 
+  it("should normalize flat Responses API tools into canonical {function:{...}} shape in the generation input", async () => {
+    const handler = new CallbackHandler();
+
+    // Flat shape as emitted by the OpenAI Responses API (gpt-5.x via ChatOpenAI)
+    const tools = [
+      {
+        type: "function",
+        name: "get_current_weather",
+        description: "Get the current weather in a given location",
+        parameters: { type: "object", properties: {} },
+        strict: true,
+      },
+    ];
+
+    const runId = "run-id-tools-flat-test";
+
+    await handler.handleGenerationStart(
+      { id: ["test", "FakeLLM"] } as any,
+      [{ role: "user", content: "What's the weather?" }],
+      runId,
+      undefined,
+      { invocation_params: { tools } },
+    );
+    await handler.handleLLMEnd(
+      { generations: [[{ text: "ok" }]], llmOutput: {} } as any,
+      runId,
+    );
+
+    await waitForSpanExport(testEnv.mockExporter, 1);
+
+    assertions.expectSpanCount(1);
+    assertions.expectSpanAttributeContains(
+      "FakeLLM",
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+      '"role":"tool"',
+    );
+    // The flat tool must be wrapped under a `function` object key
+    assertions.expectSpanAttributeContains(
+      "FakeLLM",
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+      '"function":{"name":"get_current_weather"',
+    );
+    // The top-level `name` field must NOT be present (it moved under `function`)
+    assertions.expectSpanAttributeContains(
+      "FakeLLM",
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+      '"strict":true',
+    );
+  });
+
   it("should serialize ToolMessage with role 'tool' and tool_call_id in the generation input", async () => {
     const handler = new CallbackHandler();
 

--- a/tests/integration/langchain.integration.test.ts
+++ b/tests/integration/langchain.integration.test.ts
@@ -1,3 +1,4 @@
+import { HumanMessage, ToolMessage } from "@langchain/core/messages";
 import { DynamicTool } from "@langchain/core/tools";
 import { CallbackHandler } from "@langfuse/langchain";
 import { LangfuseOtelSpanAttributes } from "@langfuse/tracing";
@@ -61,6 +62,92 @@ describe("LangChain callback handler integration tests", () => {
     assertions.expectSpanAttribute(
       "calculator",
       LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT,
+      "The result is: 100",
+    );
+  });
+
+  it("should include invocation_params tools as {role:'tool'} messages in the generation input", async () => {
+    const handler = new CallbackHandler();
+
+    const tools = [
+      {
+        type: "function",
+        function: {
+          name: "get_current_weather",
+          description: "Get the current weather in a given location",
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    ];
+
+    const runId = "run-id-tools-test";
+
+    await handler.handleGenerationStart(
+      { id: ["test", "FakeLLM"] } as any,
+      [{ role: "user", content: "What's the weather?" }],
+      runId,
+      undefined,
+      { invocation_params: { tools } },
+    );
+    await handler.handleLLMEnd(
+      { generations: [[{ text: "ok" }]], llmOutput: {} } as any,
+      runId,
+    );
+
+    await waitForSpanExport(testEnv.mockExporter, 1);
+
+    assertions.expectSpanCount(1);
+    assertions.expectSpanAttributeContains(
+      "FakeLLM",
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+      '"role":"tool"',
+    );
+    assertions.expectSpanAttributeContains(
+      "FakeLLM",
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+      "get_current_weather",
+    );
+  });
+
+  it("should serialize ToolMessage with role 'tool' and tool_call_id in the generation input", async () => {
+    const handler = new CallbackHandler();
+
+    const toolMessage = new ToolMessage({
+      content: "The result is: 100",
+      tool_call_id: "call_abc123",
+      name: "calculator",
+    });
+
+    const runId = "run-id-tool-message-test";
+
+    await handler.handleChatModelStart(
+      { id: ["test", "FakeLLM"] } as any,
+      [[new HumanMessage("What is 25*4?"), toolMessage]],
+      runId,
+      undefined,
+      { invocation_params: {} },
+    );
+    await handler.handleLLMEnd(
+      { generations: [[{ text: "ok" }]], llmOutput: {} } as any,
+      runId,
+    );
+
+    await waitForSpanExport(testEnv.mockExporter, 1);
+
+    assertions.expectSpanCount(1);
+    assertions.expectSpanAttributeContains(
+      "FakeLLM",
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+      '"role":"tool"',
+    );
+    assertions.expectSpanAttributeContains(
+      "FakeLLM",
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+      '"tool_call_id":"call_abc123"',
+    );
+    assertions.expectSpanAttributeContains(
+      "FakeLLM",
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
       "The result is: 100",
     );
   });


### PR DESCRIPTION
## Problem

LangChain tools (function definitions passed via `invocation_params.tools`) and
`ToolMessage` outputs were not serialized in the generation input, so they did
not appear in the Langfuse UI. The JS SDK diverged from the Python SDK behavior
(`__on_llm_action` / `_convert_message_to_dict`), where tools are appended as
`{role: "tool"}` messages and `ToolMessage` is serialized with `role: "tool"` +
`tool_call_id`.

## Changes

- `packages/langchain/src/CallbackHandler.ts`:
  - `handleGenerationStart`: read `invocation_params.tools` and append each as
    `{role: "tool", content: tool}` to the generation input (matches Python's
    `__on_llm_action`).
  - `extractChatMessageContent`: for `ToolMessage`, set `role: "tool"` and
    propagate `tool_call_id` (matches Python's `_convert_message_to_dict` for
    `ToolMessage`). Previously `role` was set to `message.name` and
    `tool_call_id` was dropped.
  - Added optional `tool_call_id` field to `LlmMessage` / `AnonymousLlmMessage`
    types.
  - handleGenerationStart: tool definitions are normalised using `normalizeToolForLangfuse` to support both the Chat        Completions API (canonical) and the Responses API (flat, gpt-5.x).

## Verification

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (scoped: `vitest run --project=unit --project=integration` → 389/389 passed; e2e project excluded)
- [x] `pnpm test:integration` (included in the scoped run above; `langchain.integration` → 3/3 passed)
- [ ] `pnpm test:e2e` (not run: requires `LANGFUSE_BASE_URL`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `OPENAI_API_KEY` and a reachable Langfuse server)
- [x] `pnpm --filter @langfuse/langchain build`

Note: `pnpm test:e2e` could not run because it requires a reachable Langfuse
server and credentials, which are not available in this environment. The e2e
suite is not affected by this change (no modifications to export protocols,
media upload, or API client).

## Release info

### Bump level

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

- [ ] All of them
- [ ] @langfuse/core
- [ ] @langfuse/client
- [ ] @langfuse/tracing
- [ ] @langfuse/otel
- [ ] @langfuse/openai
- [x] @langfuse/langchain

### Changelog notes

- Fixed `@langfuse/langchain` not including tools (`invocation_params.tools`) and
  `ToolMessage` metadata (`role`, `tool_call_id`) in the generation input,
  aligning behavior with the Python SDK.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This patch fixes the LangChain callback handler to include tool definitions (`invocation_params.tools`) and `ToolMessage` metadata (`role`, `tool_call_id`) in the Langfuse generation input, aligning the JS SDK with Python SDK behavior.

- **Tool definitions**: `handleGenerationStart` now reads `invocation_params.tools` and appends each entry as a `{role: "tool", content: tool}` message in the generation input.
- **ToolMessage**: `extractChatMessageContent` now correctly sets `role: "tool"` and propagates `tool_call_id` for tool-type messages; previously `role` was set to `message.name` and `tool_call_id` was dropped.
- **Types**: `LlmMessage` and `AnonymousLlmMessage` gain an optional `tool_call_id` field, and two integration tests verify both new behaviors end-to-end via span attribute assertions.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is narrowly scoped to display/serialization of tool metadata and does not touch any API calls, data persistence, or authentication paths; it is safe to merge.

Both new behaviors are covered by integration tests and the logic is straightforward. The one open question is whether role:"tool" for tool definitions (function schemas from invocation_params.tools) could confuse users in the Langfuse UI, since the same role is also used for tool result messages — there is no runtime breakage, but the ambiguity is worth resolving before the release if trace readability matters.

packages/langchain/src/CallbackHandler.ts — specifically the role assigned to tool definitions appended in handleGenerationStart.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant LC as LangChain
    participant CH as CallbackHandler
    participant LF as Langfuse (OtelSpan)

    LC->>CH: handleChatModelStart(messages, extraParams)
    CH->>CH: extractChatMessageContent per message
    Note over CH: ToolMessage maps to role:tool + tool_call_id
    CH->>CH: handleGenerationStart(prompts, extraParams)
    CH->>CH: read invocation_params.tools
    alt tools present
        CH->>CH: append role:tool + content:toolDef for each tool
    end
    CH->>LF: startAndRegisterOtelSpan with inputMessages
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant LC as LangChain
    participant CH as CallbackHandler
    participant LF as Langfuse (OtelSpan)

    LC->>CH: handleChatModelStart(messages, extraParams)
    CH->>CH: extractChatMessageContent per message
    Note over CH: ToolMessage maps to role:tool + tool_call_id
    CH->>CH: handleGenerationStart(prompts, extraParams)
    CH->>CH: read invocation_params.tools
    alt tools present
        CH->>CH: append role:tool + content:toolDef for each tool
    end
    CH->>LF: startAndRegisterOtelSpan with inputMessages
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/langchain/src/CallbackHandler.ts:336-344
**`role: "tool"` used for tool definitions, not tool results**

`invocation_params.tools` contains function *definitions* (schemas the model can call), whereas `role: "tool"` conventionally means a tool *result* message (the output of executing a tool). Appending definitions under the same role as `ToolMessage` results makes them indistinguishable in the Langfuse UI — a user looking at the trace cannot tell whether a `role: "tool"` entry describes a callable function or an actual tool output. A more descriptive role like `"function_definition"` or `"tool_definition"` would avoid this ambiguity.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(langchain): serialize tools and Tool..."](https://github.com/langfuse/langfuse-js/commit/206748824bc6c8a055b80a3f6aa7f569e3a76ac0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42068776)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->