### PR TITLE
feat(skill): skills management manager, cache and client

### DIFF
--- a/packages/client/src/LangfuseClient.ts
+++ b/packages/client/src/LangfuseClient.ts
@@ -10,6 +10,7 @@ import { ExperimentManager } from "./experiment/ExperimentManager.js";
 import { MediaManager } from "./media/index.js";
 import { PromptManager } from "./prompt/index.js";
 import { ScoreManager } from "./score/index.js";
+import { SkillManager } from "./skill/index.js";
 
 /**
  * Configuration parameters for initializing a LangfuseClient instance.
@@ -56,6 +57,7 @@ export interface LangfuseClientParams {
  *
  * The LangfuseClient provides access to all Langfuse functionality including:
  * - Prompt management and retrieval
+ * - Skill management and retrieval
  * - Dataset operations
  * - Score creation and management
  * - Media upload and handling
@@ -76,6 +78,9 @@ export interface LangfuseClientParams {
  * // Use the client
  * const prompt = await langfuse.prompt.get("my-prompt");
  * const compiledPrompt = prompt.compile({ variable: "value" });
+ *
+ * const skill = await langfuse.skill.get("my-skill");
+ * const compiledSkill = skill.compile({ variable: "value" });
  * ```
  *
  * @public
@@ -91,6 +96,11 @@ export class LangfuseClient {
    * Manager for prompt operations including creation, retrieval, and caching.
    */
   public prompt: PromptManager;
+
+  /**
+   * Manager for skill operations including creation, retrieval, and caching.
+   */
+  public skill: SkillManager;
 
   /**
    * Manager for dataset operations including retrieval and item linking.
@@ -239,6 +249,19 @@ export class LangfuseClient {
   public resolveMediaReferences: typeof MediaManager.prototype.resolveReferences;
 
   /**
+   * Convenience alias for skill.get.
+   */
+  public getSkill: typeof SkillManager.prototype.get;
+  /**
+   * Convenience alias for skill.create.
+   */
+  public createSkill: typeof SkillManager.prototype.create;
+  /**
+   * Convenience alias for skill.update.
+   */
+  public updateSkill: typeof SkillManager.prototype.update;
+
+  /**
    * Creates a new LangfuseClient instance.
    *
    * @param params - Configuration parameters. If not provided, will use environment variables.
@@ -300,6 +323,7 @@ export class LangfuseClient {
     });
 
     this.prompt = new PromptManager({ apiClient: this.api });
+    this.skill = new SkillManager({ apiClient: this.api });
     this.dataset = new DatasetManager({ langfuseClient: this });
     this.score = new ScoreManager({ apiClient: this.api });
     this.media = new MediaManager({ apiClient: this.api });
@@ -309,6 +333,9 @@ export class LangfuseClient {
     this.getPrompt = this.prompt.get.bind(this.prompt); // keep correct this context for cache access
     this.createPrompt = this.prompt.create.bind(this.prompt);
     this.updatePrompt = this.prompt.update.bind(this.prompt);
+    this.getSkill = this.skill.get.bind(this.skill); // keep correct this context for cache access
+    this.createSkill = this.skill.create.bind(this.skill);
+    this.updateSkill = this.skill.update.bind(this.skill);
     this.getDataset = this.dataset.get.bind(this.dataset);
     this.fetchTrace = this.api.trace.get.bind(this.api.trace);
     this.fetchTraces = this.api.trace.list.bind(this.api.trace);

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./LangfuseClient.js";
 export * from "./prompt/index.js";
+export * from "./skill/index.js";
 export * from "./score/index.js";
 export * from "./dataset/index.js";
 export * from "./media/index.js";

--- a/packages/client/src/skill/index.ts
+++ b/packages/client/src/skill/index.ts
@@ -1,0 +1,3 @@
+export { SkillManager } from "./skillManager.js";
+export { SkillClient } from "./skillClient.js";
+export * from "./types.js";

--- a/packages/client/src/skill/skillCache.ts
+++ b/packages/client/src/skill/skillCache.ts
@@ -1,0 +1,91 @@
+import { getGlobalLogger } from "@langfuse/core";
+
+import type { SkillClient } from "./skillClient.js";
+
+export const DEFAULT_SKILL_CACHE_TTL_SECONDS = 60;
+
+class LangfuseSkillCacheItem {
+  private _expiry: number;
+
+  constructor(
+    public value: SkillClient,
+    ttlSeconds: number,
+  ) {
+    this._expiry = Date.now() + ttlSeconds * 1000;
+  }
+
+  get isExpired(): boolean {
+    return Date.now() > this._expiry;
+  }
+}
+export class LangfuseSkillCache {
+  private _cache: Map<string, LangfuseSkillCacheItem>;
+  private _defaultTtlSeconds: number;
+  private _refreshingKeys: Map<string, Promise<void>>;
+
+  constructor() {
+    this._cache = new Map<string, LangfuseSkillCacheItem>();
+    this._defaultTtlSeconds = DEFAULT_SKILL_CACHE_TTL_SECONDS;
+    this._refreshingKeys = new Map<string, Promise<void>>();
+  }
+
+  public getIncludingExpired(key: string): LangfuseSkillCacheItem | null {
+    return this._cache.get(key) ?? null;
+  }
+
+  public createKey(params: {
+    name: string;
+    version?: number;
+    label?: string;
+  }): string {
+    const { name, version, label } = params;
+    const parts = [name];
+
+    if (version !== undefined) {
+      parts.push("version:" + version.toString());
+    } else if (label !== undefined) {
+      parts.push("label:" + label);
+    } else {
+      parts.push("label:production");
+    }
+
+    return parts.join("-");
+  }
+
+  public set(key: string, value: SkillClient, ttlSeconds?: number): void {
+    const effectiveTtlSeconds = ttlSeconds ?? this._defaultTtlSeconds;
+    this._cache.set(
+      key,
+      new LangfuseSkillCacheItem(value, effectiveTtlSeconds),
+    );
+  }
+
+  public addRefreshingPromise(key: string, promise: Promise<any>): void {
+    this._refreshingKeys.set(key, promise);
+    promise
+      .then(() => {
+        this._refreshingKeys.delete(key);
+      })
+      .catch(() => {
+        this._refreshingKeys.delete(key);
+      });
+  }
+
+  public isRefreshing(key: string): boolean {
+    return this._refreshingKeys.has(key);
+  }
+
+  public invalidate(skillName: string): void {
+    getGlobalLogger().debug(
+      "Invalidating cache keys for",
+      skillName,
+      this._cache.keys(),
+    );
+
+    for (const key of this._cache.keys()) {
+      if (key.startsWith(skillName)) {
+        this._cache.delete(key);
+      }
+    }
+  }
+}

--- a/packages/client/src/skill/skillCache.ts
+++ b/packages/client/src/skill/skillCache.ts
@@ -83,7 +83,7 @@ export class LangfuseSkillCache {
     );
 
     for (const key of this._cache.keys()) {
-      if (key.startsWith(skillName)) {
+      if (key.startsWith(skillName + "-")) {
         this._cache.delete(key);
       }
     }

--- a/packages/client/src/skill/skillClient.ts
+++ b/packages/client/src/skill/skillClient.ts
@@ -1,0 +1,102 @@
+import { Skill } from "@langfuse/core";
+import mustache from "mustache";
+
+mustache.escape = function (text) {
+  return text;
+};
+
+/**
+ * Client for working with skills.
+ *
+ * Provides access to the fields of a skill and a {@link SkillClient.compile}
+ * helper that substitutes `{{variable}}` placeholders in the skill's
+ * instructions. Skills have no text/chat split, so a single client class wraps
+ * every skill response.
+ *
+ * @public
+ */
+export class SkillClient {
+  /** The original skill response from the API */
+  public readonly skillResponse: Skill;
+  /** The name of the skill */
+  public readonly name: string;
+  /** The version number of the skill */
+  public readonly version: number;
+  /** Human-readable description of the skill */
+  public readonly description: string;
+  /** The instructions body of the skill (supports {{variable}} placeholders) */
+  public readonly instructions: string;
+  /** Arbitrary metadata associated with the skill */
+  public readonly metadata: unknown;
+  /** Tools the skill is allowed to use */
+  public readonly allowedTools: string[];
+  /** Labels associated with the skill */
+  public readonly labels: string[];
+  /** Tags associated with the skill */
+  public readonly tags: string[];
+  /** Optional commit message for the skill version */
+  public readonly commitMessage: string | null | undefined;
+  /** Whether this skill client is using fallback content */
+  public readonly isFallback: boolean;
+
+  /**
+   * Creates a new SkillClient instance.
+   *
+   * @param skill - The skill data returned from the API
+   * @param isFallback - Whether this is fallback content
+   * @internal
+   */
+  constructor(skill: Skill, isFallback = false) {
+    this.skillResponse = skill;
+    this.name = skill.name;
+    this.version = skill.version;
+    this.description = skill.description;
+    this.instructions = skill.instructions;
+    this.metadata = skill.metadata;
+    this.allowedTools = skill.allowedTools;
+    this.labels = skill.labels;
+    this.tags = skill.tags;
+    this.commitMessage = skill.commitMessage;
+    this.isFallback = isFallback;
+  }
+
+  /**
+   * Compiles the skill instructions by substituting variables.
+   *
+   * Uses Mustache templating to replace `{{variable}}` placeholders in the
+   * instructions with the provided values.
+   *
+   * @param variables - Key-value pairs for variable substitution
+   * @returns The compiled instructions with variables substituted
+   *
+   * @example
+   * ```typescript
+   * const skill = await langfuse.skill.get("my-skill");
+   * const compiled = skill.compile({ name: "Alice" });
+   * // If instructions are "Hello {{name}}!", result is "Hello Alice!"
+   * ```
+   */
+  compile(variables?: Record<string, string>): string {
+    return mustache.render(this.instructions, variables ?? {});
+  }
+
+  /**
+   * Serializes the skill client to JSON.
+   *
+   * @returns JSON string representation of the skill
+   */
+  public toJSON(): string {
+    return JSON.stringify({
+      name: this.name,
+      version: this.version,
+      description: this.description,
+      instructions: this.instructions,
+      metadata: this.metadata,
+      allowedTools: this.allowedTools,
+      labels: this.labels,
+      tags: this.tags,
+      commitMessage: this.commitMessage,
+      isFallback: this.isFallback,
+    });
+  }
+}

--- a/packages/client/src/skill/skillManager.ts
+++ b/packages/client/src/skill/skillManager.ts
@@ -1,0 +1,325 @@
+import {
+  getGlobalLogger,
+  LangfuseAPIClient,
+  Skill,
+  SkillMetaListResponse,
+  CreateSkillRequest,
+} from "@langfuse/core";
+
+import { LangfuseSkillCache } from "./skillCache.js";
+import { SkillClient } from "./skillClient.js";
+
+/**
+ * Manager for skill operations in Langfuse.
+ *
+ * Provides methods to create, retrieve, list, update, and delete skills with
+ * built-in caching for optimal performance. Skills bundle instructions,
+ * metadata, and a set of allowed tools that an agent may use.
+ *
+ * @public
+ */
+export class SkillManager {
+  private cache: LangfuseSkillCache;
+  private apiClient: LangfuseAPIClient;
+
+  /**
+   * Creates a new SkillManager instance.
+   *
+   * @param params - Configuration object containing the API client
+   * @internal
+   */
+  constructor(params: { apiClient: LangfuseAPIClient }) {
+    const { apiClient } = params;
+
+    this.apiClient = apiClient;
+    this.cache = new LangfuseSkillCache();
+  }
+
+  get logger() {
+    return getGlobalLogger();
+  }
+
+  /**
+   * Creates a new skill in Langfuse.
+   *
+   * @param body - The skill data to create
+   * @returns Promise that resolves to a SkillClient
+   *
+   * @example
+   * ```typescript
+   * const skill = await langfuse.skill.create({
+   *   name: "summarizer",
+   *   description: "Summarizes documents",
+   *   instructions: "Summarize the following document: {{document}}",
+   *   allowedTools: ["search"],
+   *   labels: ["production"],
+   * });
+   * ```
+   */
+  async create(body: CreateSkillRequest): Promise<SkillClient> {
+    const skillResponse = await this.apiClient.skills.create(body);
+
+    return new SkillClient(skillResponse);
+  }
+
+  /**
+   * Updates the labels of an existing skill version.
+   *
+   * @param params - Update parameters
+   * @param params.name - Name of the skill to update
+   * @param params.version - Version number of the skill to update
+   * @param params.newLabels - New labels to apply to the skill version
+   *
+   * @returns Promise that resolves to the updated skill
+   *
+   * @example
+   * ```typescript
+   * const updatedSkill = await langfuse.skill.update({
+   *   name: "my-skill",
+   *   version: 1,
+   *   newLabels: ["production", "v2"]
+   * });
+   * ```
+   */
+  async update(params: {
+    name: string;
+    version: number;
+    newLabels: string[];
+  }): Promise<Skill> {
+    const { name, version, newLabels } = params;
+
+    const newSkill = await this.apiClient.skillVersion.update(name, version, {
+      newLabels,
+    });
+
+    this.cache.invalidate(name);
+
+    return newSkill;
+  }
+
+  /**
+   * Lists skills with optional filtering.
+   *
+   * @param query - Optional filtering and pagination parameters
+   * @returns Promise that resolves to the list of skill metadata
+   *
+   * @example
+   * ```typescript
+   * const skills = await langfuse.skill.list({ label: "production" });
+   * ```
+   */
+  async list(query?: {
+    /** Filter by skill name */
+    name?: string;
+    /** Filter by label */
+    label?: string;
+    /** Filter by tag */
+    tag?: string;
+    /** Page number for pagination */
+    page?: number;
+    /** Number of items per page */
+    limit?: number;
+    /** Filter for skills updated on or after this timestamp */
+    fromUpdatedAt?: string;
+    /** Filter for skills updated on or before this timestamp */
+    toUpdatedAt?: string;
+  }): Promise<SkillMetaListResponse> {
+    return await this.apiClient.skills.list(query ?? {});
+  }
+
+  /**
+   * Delete skill versions. If neither version nor label is specified, all versions of the skill are deleted.
+   *
+   * The Langfuse SDK skill cache is invalidated for all cached versions with the specified name.
+   *
+   * @param name - Name of the skill to delete
+   * @param options - Optional deletion configuration
+   * @param options.version - Optional version to delete. If specified, deletes only this specific version
+   * @param options.label - Optional label to filter deletion. If specified, deletes all skill versions with this label
+   *
+   * @returns Promise that resolves when deletion is complete
+   *
+   * @throws {LangfuseAPI.NotFoundError} If the skill does not exist
+   * @throws {LangfuseAPI.Error} If the API request fails
+   *
+   * @example
+   * ```typescript
+   * // Delete all versions of a skill
+   * await langfuse.skill.delete("my-skill");
+   *
+   * // Delete specific version
+   * await langfuse.skill.delete("my-skill", { version: 2 });
+   *
+   * // Delete all versions with a specific label
+   * await langfuse.skill.delete("my-skill", { label: "staging" });
+   * ```
+   */
+  async delete(
+    name: string,
+    options?: {
+      /** Optional version to delete. If specified, deletes only this specific version */
+      version?: number;
+      /** Optional label to filter deletion. If specified, deletes all skill versions with this label */
+      label?: string;
+    },
+  ): Promise<void> {
+    await this.apiClient.skills.delete(name, {
+      version: options?.version,
+      label: options?.label,
+    });
+
+    this.cache.invalidate(name);
+  }
+
+  /**
+   * Retrieves a skill by name with intelligent caching.
+   *
+   * This method implements sophisticated caching behavior:
+   * - Fresh skills are returned immediately from cache
+   * - Expired skills are returned from cache while being refreshed in background
+   * - Cache misses trigger immediate fetch with optional fallback support
+   *
+   * @param name - Name of the skill to retrieve
+   * @param options - Optional retrieval configuration
+   * @returns Promise that resolves to a SkillClient
+   *
+   * @example
+   * ```typescript
+   * // Get latest version with caching
+   * const skill = await langfuse.skill.get("my-skill");
+   *
+   * // Get specific version
+   * const v2Skill = await langfuse.skill.get("my-skill", { version: 2 });
+   *
+   * // Get with label filter
+   * const prodSkill = await langfuse.skill.get("my-skill", {
+   *   label: "production"
+   * });
+   *
+   * // Get with fallback instructions
+   * const skillWithFallback = await langfuse.skill.get("my-skill", {
+   *   fallback: "Summarize the following document: {{document}}"
+   * });
+   * ```
+   */
+  async get(
+    name: string,
+    options?: {
+      /** Specific version to retrieve (defaults to latest) */
+      version?: number;
+      /** Label to filter by */
+      label?: string;
+      /** Cache TTL in seconds (0 to disable caching) */
+      cacheTtlSeconds?: number;
+      /** Fallback instructions if skill fetch fails */
+      fallback?: string;
+      /** Maximum retry attempts for failed requests */
+      maxRetries?: number;
+      /** Request timeout in milliseconds */
+      fetchTimeoutMs?: number;
+    },
+  ): Promise<SkillClient> {
+    const cacheKey = this.cache.createKey({
+      name,
+      label: options?.label,
+      version: options?.version,
+    });
+    const cachedSkill = this.cache.getIncludingExpired(cacheKey);
+    if (!cachedSkill || options?.cacheTtlSeconds === 0) {
+      try {
+        return await this.fetchSkillAndUpdateCache({
+          name,
+          version: options?.version,
+          label: options?.label,
+          cacheTtlSeconds: options?.cacheTtlSeconds,
+          maxRetries: options?.maxRetries,
+          fetchTimeoutMs: options?.fetchTimeoutMs,
+        });
+      } catch (err) {
+        if (options?.fallback) {
+          const fallbackSkill: Skill = {
+            name,
+            version: options?.version ?? 0,
+            description: "",
+            instructions: options.fallback,
+            metadata: {},
+            allowedTools: [],
+            labels: options.label ? [options.label] : [],
+            tags: [],
+          };
+
+          return new SkillClient(fallbackSkill, true);
+        }
+
+        throw err;
+      }
+    }
+
+    if (cachedSkill.isExpired) {
+      // If the cache is not currently being refreshed, start refreshing it and register the promise in the cache
+      if (!this.cache.isRefreshing(cacheKey)) {
+        const refreshSkillPromise = this.fetchSkillAndUpdateCache({
+          name,
+          version: options?.version,
+          label: options?.label,
+          cacheTtlSeconds: options?.cacheTtlSeconds,
+          maxRetries: options?.maxRetries,
+          fetchTimeoutMs: options?.fetchTimeoutMs,
+        }).catch(() => {
+          this.logger.warn(
+            `Failed to refresh skill cache '${cacheKey}', stale cache will be used until next refresh succeeds.`,
+          );
+        });
+        this.cache.addRefreshingPromise(cacheKey, refreshSkillPromise);
+      }
+
+      return cachedSkill.value;
+    }
+
+    return cachedSkill.value;
+  }
+
+  private async fetchSkillAndUpdateCache(params: {
+    name: string;
+    version?: number;
+    cacheTtlSeconds?: number;
+    label?: string;
+    maxRetries?: number;
+    fetchTimeoutMs?: number;
+  }): Promise<SkillClient> {
+    const cacheKey = this.cache.createKey(params);
+
+    try {
+      const {
+        name,
+        version,
+        cacheTtlSeconds,
+        label,
+        maxRetries,
+        fetchTimeoutMs,
+      } = params;
+
+      const data = await this.apiClient.skills.get(
+        name,
+        {
+          version,
+          label,
+        },
+        {
+          maxRetries,
+          timeoutInSeconds: fetchTimeoutMs ? fetchTimeoutMs / 1_000 : undefined,
+        },
+      );
+
+      const skill = new SkillClient(data);
+
+      this.cache.set(cacheKey, skill, cacheTtlSeconds);
+
+      return skill;
+    } catch (error) {
+      this.logger.error(`Error fetching skill '${cacheKey}':`, error);
+
+      throw error;
+    }
+  }
+}

--- a/packages/client/src/skill/types.ts
+++ b/packages/client/src/skill/types.ts
@@ -1,0 +1,9 @@
+/**
+ * Options for compiling a skill's instructions.
+ *
+ * Keys are variable names and values are the strings substituted for the
+ * matching `{{variable}}` placeholders in the skill instructions.
+ *
+ * @public
+ */
+export type SkillCompileOptions = Record<string, string>;

--- a/tests/unit/skill.test.ts
+++ b/tests/unit/skill.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import { LangfuseSkillCache } from "../../packages/client/src/skill/skillCache.js";
+import { SkillClient } from "../../packages/client/src/skill/skillClient.js";
+
+// `Skill` is a type from the auto-generated `@langfuse/core` API client which is
+// not present in this checkout yet. It is erased at runtime, so we build plain
+// objects that satisfy its expected shape.
+function makeSkill(overrides: Record<string, unknown> = {}): any {
+  return {
+    name: "my-skill",
+    version: 1,
+    description: "A test skill",
+    instructions: "Hello {{name}}!",
+    metadata: {},
+    allowedTools: ["search"],
+    labels: ["production"],
+    tags: ["test"],
+    commitMessage: "initial",
+    ...overrides,
+  };
+}
+
+describe("SkillClient", () => {
+  it("exposes the skill fields", () => {
+    const client = new SkillClient(makeSkill());
+
+    expect(client.name).toBe("my-skill");
+    expect(client.version).toBe(1);
+    expect(client.description).toBe("A test skill");
+    expect(client.instructions).toBe("Hello {{name}}!");
+    expect(client.allowedTools).toEqual(["search"]);
+    expect(client.labels).toEqual(["production"]);
+    expect(client.tags).toEqual(["test"]);
+    expect(client.commitMessage).toBe("initial");
+    expect(client.isFallback).toBe(false);
+  });
+
+  it("compiles {{variable}} placeholders in instructions", () => {
+    const client = new SkillClient(makeSkill());
+
+    expect(client.compile({ name: "Alice" })).toBe("Hello Alice!");
+  });
+
+  it("leaves unreferenced placeholders empty when no variable is provided", () => {
+    const client = new SkillClient(makeSkill());
+
+    expect(client.compile()).toBe("Hello !");
+  });
+
+  it("does not escape HTML entities during substitution", () => {
+    const client = new SkillClient(
+      makeSkill({ instructions: "value: {{value}}" }),
+    );
+
+    expect(client.compile({ value: "<a> & 'b'" })).toBe("value: <a> & 'b'");
+  });
+
+  it("round-trips through toJSON", () => {
+    const client = new SkillClient(makeSkill());
+    const parsed = JSON.parse(client.toJSON());
+
+    expect(parsed.name).toBe("my-skill");
+    expect(parsed.instructions).toBe("Hello {{name}}!");
+    expect(parsed.allowedTools).toEqual(["search"]);
+    expect(parsed.isFallback).toBe(false);
+  });
+});
+
+describe("LangfuseSkillCache", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("builds cache keys from name/version/label", () => {
+    const cache = new LangfuseSkillCache();
+
+    expect(cache.createKey({ name: "s" })).toBe("s-label:production");
+    expect(cache.createKey({ name: "s", version: 3 })).toBe("s-version:3");
+    expect(cache.createKey({ name: "s", label: "staging" })).toBe(
+      "s-label:staging",
+    );
+  });
+
+  it("returns a fresh (non-expired) item within its TTL", () => {
+    const cache = new LangfuseSkillCache();
+    const client = new SkillClient(makeSkill());
+    const key = cache.createKey({ name: "my-skill" });
+
+    cache.set(key, client, 60);
+
+    const item = cache.getIncludingExpired(key);
+    expect(item).not.toBeNull();
+    expect(item?.isExpired).toBe(false);
+    expect(item?.value).toBe(client);
+  });
+
+  it("marks an item expired once its TTL elapses", () => {
+    const cache = new LangfuseSkillCache();
+    const client = new SkillClient(makeSkill());
+    const key = cache.createKey({ name: "my-skill" });
+
+    cache.set(key, client, 1);
+
+    vi.advanceTimersByTime(1_001);
+
+    const item = cache.getIncludingExpired(key);
+    expect(item?.isExpired).toBe(true);
+    // Stale-while-revalidate still returns the cached value.
+    expect(item?.value).toBe(client);
+  });
+
+  it("invalidates every key that shares the skill name prefix", () => {
+    const cache = new LangfuseSkillCache();
+    const client = new SkillClient(makeSkill());
+
+    cache.set(cache.createKey({ name: "my-skill" }), client, 60);
+    cache.set(cache.createKey({ name: "my-skill", version: 2 }), client, 60);
+    cache.set(cache.createKey({ name: "other-skill" }), client, 60);
+
+    cache.invalidate("my-skill");
+
+    expect(
+      cache.getIncludingExpired(cache.createKey({ name: "my-skill" })),
+    ).toBeNull();
+    expect(
+      cache.getIncludingExpired(
+        cache.createKey({ name: "my-skill", version: 2 }),
+      ),
+    ).toBeNull();
+    expect(
+      cache.getIncludingExpired(cache.createKey({ name: "other-skill" })),
+    ).not.toBeNull();
+  });
+
+  it("tracks in-flight refresh promises", async () => {
+    const cache = new LangfuseSkillCache();
+    const key = cache.createKey({ name: "my-skill" });
+
+    expect(cache.isRefreshing(key)).toBe(false);
+
+    let resolveRefresh: () => void = () => {};
+    const refresh = new Promise<void>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    cache.addRefreshingPromise(key, refresh);
+
+    expect(cache.isRefreshing(key)).toBe(true);
+
+    resolveRefresh();
+    await refresh;
+    // Allow the .then() cleanup callback to run.
+    await Promise.resolve();
+
+    expect(cache.isRefreshing(key)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Skills management (JS SDK)

Hand-written high-level skills API mirroring the prompt manager:

- `SkillManager` — `get` (caching + stale-while-revalidate + fallback + retry), `create`, `update` (labels), `list`, `delete`
- `LangfuseSkillCache` (TTL + prefix invalidation)
- `SkillClient` with `{{variable}}` compilation of the `instructions` body (single client — skills have no chat/text split)
- wired onto `LangfuseClient` as `.skill` + `getSkill`/`createSkill`/`updateSkill`
- unit tests for cache TTL and client compilation (10 passing)

**Depends on** the auto-generated `@langfuse/core` skills client from the `api-spec-bot` regeneration of the Fern contract in langfuse/langfuse (https://github.com/langfuse/langfuse/pull/14838). Typechecks/builds once that client lands.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a hand-written `SkillManager` / `SkillClient` / `LangfuseSkillCache` layer for skills management, closely mirroring the existing `PromptManager` implementation. It wires the manager onto `LangfuseClient` as `.skill` with convenience aliases (`getSkill`, `createSkill`, `updateSkill`), and ships unit tests for cache TTL behaviour and Mustache template compilation.

- **SkillManager** implements `get` (TTL cache + stale-while-revalidate + fallback + retry), `create`, `update` (labels), `list`, and `delete`, all following the same patterns as `PromptManager`.
- **SkillClient** wraps the API response, exposes skill fields as readonly properties, and provides a `compile()` helper for `{{variable}}` substitution via Mustache (HTML-escaping disabled).
- The cache `invalidate()` method uses `key.startsWith(skillName)` without a `-` separator, which is a logic error copied from `LangfusePromptCache`: skill names that are a prefix of another skill name (e.g., `"foo"` vs `"foobar"`) will cause false cache evictions.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The skill manager logic is sound and closely tracks the existing prompt manager. One real defect in the cache invalidation logic — using a bare prefix match without a separator — can silently evict unrelated skills from cache in applications where skill names share a common prefix.

The invalidation method deletes every cache entry whose key starts with the supplied skill name, but the key format always places a '-' immediately after the name. Without anchoring the check to skillName + '-', a skill named 'foo' incorrectly evicts all cached entries for 'foobar' when either is deleted or its labels are updated. Any application with skills following a naming convention (e.g., 'agent', 'agent-v2', 'agent-v3') would experience unexpected cache misses and extra API calls. The same defect exists verbatim in LangfusePromptCache and was carried forward unchanged here.

packages/client/src/skill/skillCache.ts — the invalidate method's prefix match needs the '-' separator fix. The same one-line change is also worth applying to packages/client/src/prompt/promptCache.ts.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant LangfuseClient
    participant SkillManager
    participant LangfuseSkillCache
    participant LangfuseAPIClient

    Caller->>LangfuseClient: getSkill("my-skill", options)
    LangfuseClient->>SkillManager: get("my-skill", options)
    SkillManager->>LangfuseSkillCache: "createKey({name, version, label})"
    LangfuseSkillCache-->>SkillManager: cacheKey
    SkillManager->>LangfuseSkillCache: getIncludingExpired(cacheKey)

    alt "Cache miss or cacheTtlSeconds === 0"
        LangfuseSkillCache-->>SkillManager: null
        SkillManager->>LangfuseAPIClient: "skills.get(name, {version, label}, opts)"
        LangfuseAPIClient-->>SkillManager: Skill data
        SkillManager->>LangfuseSkillCache: set(cacheKey, SkillClient, ttl)
        SkillManager-->>LangfuseClient: SkillClient
    else Cache hit (fresh)
        LangfuseSkillCache-->>SkillManager: CacheItem (not expired)
        SkillManager-->>LangfuseClient: SkillClient (from cache)
    else Cache hit (stale)
        LangfuseSkillCache-->>SkillManager: CacheItem (expired)
        SkillManager->>LangfuseSkillCache: isRefreshing(cacheKey)?
        LangfuseSkillCache-->>SkillManager: false
        SkillManager->>LangfuseAPIClient: skills.get(...) [background]
        SkillManager->>LangfuseSkillCache: addRefreshingPromise(cacheKey, promise)
        SkillManager-->>LangfuseClient: SkillClient (stale, refreshing in background)
    end

    LangfuseClient-->>Caller: SkillClient
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant LangfuseClient
    participant SkillManager
    participant LangfuseSkillCache
    participant LangfuseAPIClient

    Caller->>LangfuseClient: getSkill("my-skill", options)
    LangfuseClient->>SkillManager: get("my-skill", options)
    SkillManager->>LangfuseSkillCache: "createKey({name, version, label})"
    LangfuseSkillCache-->>SkillManager: cacheKey
    SkillManager->>LangfuseSkillCache: getIncludingExpired(cacheKey)

    alt "Cache miss or cacheTtlSeconds === 0"
        LangfuseSkillCache-->>SkillManager: null
        SkillManager->>LangfuseAPIClient: "skills.get(name, {version, label}, opts)"
        LangfuseAPIClient-->>SkillManager: Skill data
        SkillManager->>LangfuseSkillCache: set(cacheKey, SkillClient, ttl)
        SkillManager-->>LangfuseClient: SkillClient
    else Cache hit (fresh)
        LangfuseSkillCache-->>SkillManager: CacheItem (not expired)
        SkillManager-->>LangfuseClient: SkillClient (from cache)
    else Cache hit (stale)
        LangfuseSkillCache-->>SkillManager: CacheItem (expired)
        SkillManager->>LangfuseSkillCache: isRefreshing(cacheKey)?
        LangfuseSkillCache-->>SkillManager: false
        SkillManager->>LangfuseAPIClient: skills.get(...) [background]
        SkillManager->>LangfuseSkillCache: addRefreshingPromise(cacheKey, promise)
        SkillManager-->>LangfuseClient: SkillClient (stale, refreshing in background)
    end

    LangfuseClient-->>Caller: SkillClient
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/client/src/skill/skillCache.ts:85-89
Cache invalidation prefix collision: `startsWith(skillName)` without a separator will incorrectly evict entries for any skill whose name begins with the same characters. For example, calling `invalidate("foo")` will also delete the cached entries for a skill named `"foobar"` because `"foobar-label:production".startsWith("foo")` is `true`. The key format always appends `-` before the version/label segment, so anchoring the prefix check to `skillName + "-"` prevents these false invalidations. Note: the identical issue is present in `LangfusePromptCache.invalidate`.

```suggestion
    for (const key of this._cache.keys()) {
      if (key.startsWith(skillName + "-")) {
        this._cache.delete(key);
      }
    }
```

### Issue 2 of 3
packages/client/src/skill/skillCache.ts:63
The `promise` parameter is typed as `Promise<any>`, but the internal `_refreshingKeys` map is typed `Map<string, Promise<void>>`. Typing the parameter as `Promise<void>` (or at minimum `Promise<unknown>`) makes the contract more precise and aligns with the map's declared type.

```suggestion
  public addRefreshingPromise(key: string, promise: Promise<void>): void {
```

### Issue 3 of 3
packages/client/src/skill/skillManager.ts:228
**`cacheTtlSeconds: 0` still writes to cache**: When `cacheTtlSeconds` is explicitly `0` (caching disabled), `fetchSkillAndUpdateCache` is still called, which stores the result with TTL 0. This creates an immediately-expired entry. On the very next `get()` call that does *not* pass `cacheTtlSeconds: 0`, `getIncludingExpired` will find this stale entry and trigger the stale-while-revalidate path, returning stale data rather than fetching synchronously. The same behaviour exists in `PromptManager`, but it may be surprising to callers who used `cacheTtlSeconds: 0` expecting a complete bypass.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(skill): add skills management manag..."](https://github.com/langfuse/langfuse-js/commit/7d691dca48b5ab92364fa3da14d3509675353152) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42345975)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->