### PR TITLE
feat(tracing): support prompt linking via propagateAttributes

### DIFF
--- a/packages/core/src/propagation.ts
+++ b/packages/core/src/propagation.ts
@@ -26,7 +26,9 @@ type CorrelatedKey =
   | "metadata"
   | "version"
   | "tags"
-  | "traceName";
+  | "traceName"
+  | "promptName"
+  | "promptVersion";
 
 const experimentKeys = [
   "experimentId",
@@ -57,6 +59,8 @@ export const LangfuseOtelContextKeys: Record<PropagatedKey, symbol> = {
   version: createContextKey("langfuse_version"),
   tags: createContextKey("langfuse_tags"),
   traceName: createContextKey("langfuse_trace_name"),
+  promptName: createContextKey("langfuse_prompt_name"),
+  promptVersion: createContextKey("langfuse_prompt_version"),
 
   // Experiments
   experimentId: createContextKey("langfuse_experiment_id"),
@@ -124,6 +128,24 @@ export function setLangfuseTraceIdInBaggage(
 }
 
 /**
+ * Prompt-like input accepted by {@link propagateAttributes}.
+ *
+ * Satisfied by prompt clients returned from Langfuse prompt management
+ * (e.g. `langfuse.prompt.get(...)`) as well as plain objects exposing
+ * `name` and `version`.
+ *
+ * @public
+ */
+export type PropagatedPromptInput = {
+  /** Name of the prompt. Must be a non-empty string. */
+  name: string;
+  /** Version of the prompt. Must be an integer; digit-only strings (e.g. "5") are coerced. */
+  version: number | string;
+  /** Whether this is a fallback prompt. Fallback prompts are never linked. */
+  isFallback?: boolean;
+};
+
+/**
  * Parameters for propagateAttributes function.
  *
  * @public
@@ -167,6 +189,22 @@ export interface PropagateAttributesParams {
    * Must be a string ≤200 characters.
    */
   traceName?: string;
+
+  /**
+   * Langfuse prompt to link to observations created within this context.
+   *
+   * Accepts a prompt client returned by `langfuse.prompt.get(...)` or any plain
+   * object exposing `name` (non-empty string) and `version` (integer) — e.g.
+   * `{ name: "my-prompt", version: 3 }`. This is the recommended way to link
+   * prompts to generations emitted by auto-instrumentation libraries (e.g.
+   * OpenInference, other OTel instrumentations) where you don't create the
+   * generation via the Langfuse SDK yourself.
+   *
+   * The prompt link is only applied to generation-type observations by the
+   * Langfuse backend. Fallback prompts are never linked. An explicit `prompt`
+   * set directly on an observation takes precedence over the propagated one.
+   */
+  prompt?: PropagatedPromptInput;
 
   /**
    * If true, propagates attributes using OpenTelemetry baggage for
@@ -233,6 +271,27 @@ export interface PropagateAttributesParams {
  *     const gen = startObservation('completion', {}, { asType: 'generation' });
  *     // This span also inherits all attributes
  *     gen.end();
+ *   });
+ * });
+ * ```
+ *
+ * @example
+ * Prompt linking with auto-instrumented libraries:
+ *
+ * ```typescript
+ * import { LangfuseClient } from '@langfuse/client';
+ * import { propagateAttributes } from '@langfuse/tracing';
+ *
+ * const langfuse = new LangfuseClient();
+ * const prompt = await langfuse.prompt.get('my-prompt');
+ *
+ * await propagateAttributes({ prompt }, async () => {
+ *   // Generations emitted by auto-instrumentation (OpenInference,
+ *   // other OTel instrumentations, ...) within this context are
+ *   // linked to the prompt version.
+ *   const completion = await openai.chat.completions.create({
+ *     model: 'gpt-4o',
+ *     messages: [{ role: 'user', content: prompt.compile({ topic: 'chickens' }) }],
  *   });
  * });
  * ```
@@ -309,6 +368,7 @@ export function propagateAttributes<
     version,
     tags,
     traceName,
+    prompt,
     _internalExperiment,
   } = params;
 
@@ -426,6 +486,28 @@ export function propagateAttributes<
     }
   }
 
+  // Validate and set prompt
+  if (prompt) {
+    const propagatedPrompt = extractPropagatedPrompt(prompt);
+
+    if (propagatedPrompt) {
+      context = setPropagatedAttribute({
+        key: "promptName",
+        value: propagatedPrompt.name,
+        context,
+        span,
+        asBaggage,
+      });
+      context = setPropagatedAttribute({
+        key: "promptVersion",
+        value: propagatedPrompt.version,
+        context,
+        span,
+        asBaggage,
+      });
+    }
+  }
+
   // Handle experiment attributes
   if (_internalExperiment) {
     for (const [key, value] of Object.entries(_internalExperiment)) {
@@ -446,10 +528,56 @@ export function propagateAttributes<
   return otelContextApi.with(context, fn);
 }
 
+/**
+ * Extracts and validates `{ name, version }` from a prompt-like value.
+ *
+ * Accepts a prompt client or any plain object exposing `name` and `version`.
+ * Returns null (with a log) if the value is invalid or a fallback prompt.
+ *
+ * @internal
+ */
+function extractPropagatedPrompt(
+  prompt: PropagatedPromptInput,
+): { name: string; version: number } | null {
+  const logger = getGlobalLogger();
+  const { name, version: rawVersion, isFallback } = prompt;
+
+  if (isFallback) {
+    logger.debug(
+      "Propagated prompt is a fallback prompt. Skipping prompt linking.",
+    );
+
+    return null;
+  }
+
+  if (typeof name !== "string" || name.length === 0) {
+    logger.warn(
+      "Propagated 'prompt' has no valid 'name' (non-empty string required). Dropping prompt link.",
+    );
+
+    return null;
+  }
+
+  const version =
+    typeof rawVersion === "string" && /^\d+$/.test(rawVersion)
+      ? Number(rawVersion)
+      : rawVersion;
+
+  if (typeof version !== "number" || !Number.isInteger(version)) {
+    logger.warn(
+      "Propagated 'prompt' has no valid 'version' (integer required). Dropping prompt link.",
+    );
+
+    return null;
+  }
+
+  return { name, version };
+}
+
 export function getPropagatedAttributesFromContext(
   context: Context,
-): Record<string, string | string[]> {
-  const propagatedAttributes: Record<string, string | string[]> = {};
+): Record<string, string | string[] | number> {
+  const propagatedAttributes: Record<string, string | string[] | number> = {};
 
   // Handle baggage
   const baggage = propagation.getBaggage(context);
@@ -462,6 +590,17 @@ export function getPropagatedAttributesFromContext(
         const spanKey = getSpanKeyFromBaggageKey(baggageKey);
 
         if (spanKey) {
+          // Prompt version is an integer span attribute; restore it from its
+          // string representation in baggage
+          if (
+            spanKey === LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION &&
+            /^\d+$/.test(baggageEntry.value)
+          ) {
+            propagatedAttributes[spanKey] = Number(baggageEntry.value);
+
+            return;
+          }
+
           const isMergedTags =
             baggageKey == getBaggageKeyForPropagatedKey("tags");
 
@@ -509,6 +648,22 @@ export function getPropagatedAttributesFromContext(
     propagatedAttributes[spanKey] = tags;
   }
 
+  const promptName = context.getValue(LangfuseOtelContextKeys["promptName"]);
+  if (promptName && typeof promptName === "string") {
+    const spanKey = getSpanKeyForPropagatedKey("promptName");
+
+    propagatedAttributes[spanKey] = promptName;
+  }
+
+  const promptVersion = context.getValue(
+    LangfuseOtelContextKeys["promptVersion"],
+  );
+  if (typeof promptVersion === "number") {
+    const spanKey = getSpanKeyForPropagatedKey("promptVersion");
+
+    propagatedAttributes[spanKey] = promptVersion;
+  }
+
   const metadata = context.getValue(LangfuseOtelContextKeys["metadata"]);
   if (metadata && typeof metadata === "object" && metadata !== null) {
     for (const [k, v] of Object.entries(metadata)) {
@@ -548,8 +703,18 @@ type SetPropagatedAttributeParams = {
   asBaggage: boolean;
 } & (
   | {
-      key: "userId" | "sessionId" | "version" | "traceName" | ExperimentKey;
+      key:
+        | "userId"
+        | "sessionId"
+        | "version"
+        | "traceName"
+        | "promptName"
+        | ExperimentKey;
       value: string;
+    }
+  | {
+      key: "promptVersion";
+      value: number;
     }
   | {
       key: "metadata";
@@ -614,7 +779,9 @@ function setPropagatedAttribute(params: SetPropagatedAttributeParams): Context {
         value: mergedTags.join(LANGFUSE_BAGGAGE_TAGS_SEPARATOR),
       });
     } else {
-      baggage = baggage.setEntry(baggageKey, { value });
+      // Baggage values must be strings; integer values (prompt version) are
+      // restored to numbers when reading the baggage back
+      baggage = baggage.setEntry(baggageKey, { value: String(value) });
     }
 
     context = propagation.setBaggage(context, baggage);
@@ -696,6 +863,10 @@ function getSpanKeyForPropagatedKey(key: PropagatedKey): string {
       return LangfuseOtelSpanAttributes.TRACE_METADATA;
     case "tags":
       return LangfuseOtelSpanAttributes.TRACE_TAGS;
+    case "promptName":
+      return LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME;
+    case "promptVersion":
+      return LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION;
     case "experimentId":
       return LangfuseOtelSpanAttributes.EXPERIMENT_ID;
     case "experimentName":
@@ -734,6 +905,10 @@ function getBaggageKeyForPropagatedKey(key: PropagatedKey): string {
       return `${LANGFUSE_BAGGAGE_PREFIX}metadata`;
     case "tags":
       return `${LANGFUSE_BAGGAGE_PREFIX}tags`;
+    case "promptName":
+      return `${LANGFUSE_BAGGAGE_PREFIX}prompt_name`;
+    case "promptVersion":
+      return `${LANGFUSE_BAGGAGE_PREFIX}prompt_version`;
     case "experimentId":
       return `${LANGFUSE_BAGGAGE_PREFIX}experiment_id`;
     case "experimentName":
@@ -779,6 +954,10 @@ function getSpanKeyFromBaggageKey(baggageKey: string): string | undefined {
       return getSpanKeyForPropagatedKey("traceName");
     case "tags":
       return getSpanKeyForPropagatedKey("tags");
+    case "prompt_name":
+      return getSpanKeyForPropagatedKey("promptName");
+    case "prompt_version":
+      return getSpanKeyForPropagatedKey("promptVersion");
     case "experiment_id":
       return getSpanKeyForPropagatedKey("experimentId");
     case "experiment_name":

--- a/packages/otel/src/span-processor.ts
+++ b/packages/otel/src/span-processor.ts
@@ -347,11 +347,27 @@ export class LangfuseSpanProcessor implements SpanProcessor {
    * @override
    */
   public onStart(span: Span, parentContext: Context): void {
+    const propagatedAttributes =
+      getPropagatedAttributesFromContext(parentContext);
+
+    // An explicit prompt set at span creation takes precedence over a propagated one
+    if (
+      span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME] !=
+      null
+    ) {
+      delete propagatedAttributes[
+        LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME
+      ];
+      delete propagatedAttributes[
+        LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
+      ];
+    }
+
     // Set propagated attributes, environment and release attributes
     span.setAttributes({
       [LangfuseOtelSpanAttributes.ENVIRONMENT]: this.environment,
       [LangfuseOtelSpanAttributes.RELEASE]: this.release,
-      ...getPropagatedAttributesFromContext(parentContext),
+      ...propagatedAttributes,
     });
 
     try {

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -70,6 +70,7 @@ export {
 export {
   propagateAttributes,
   type PropagateAttributesParams,
+  type PropagatedPromptInput,
 } from "@langfuse/core";
 
 export { LangfuseOtelSpanAttributes } from "@langfuse/core";

--- a/tests/integration/propagation.integration.test.ts
+++ b/tests/integration/propagation.integration.test.ts
@@ -6,6 +6,7 @@
  * to all child spans within the context.
  */
 
+import { TextPromptClient } from "@langfuse/client";
 import {
   LangfuseOtelContextKeys,
   LangfuseOtelSpanAttributes,
@@ -1499,6 +1500,471 @@ describe("propagateAttributes", () => {
     });
   });
 
+  describe("Prompt Propagation", () => {
+    const makePromptClient = (params?: {
+      name?: string;
+      version?: number;
+      isFallback?: boolean;
+    }) =>
+      new TextPromptClient(
+        {
+          name: params?.name ?? "test-prompt",
+          version: params?.version ?? 3,
+          prompt: "Make me laugh",
+          type: "text",
+          labels: [],
+          config: {},
+          tags: [],
+        },
+        params?.isFallback ?? false,
+      );
+
+    it("should propagate prompt client name and version to child spans", async () => {
+      const tracer = otelTrace.getTracer("langfuse-sdk");
+      const prompt = makePromptClient({ name: "test-prompt", version: 3 });
+
+      await tracer.startActiveSpan("parent", async (parentSpan) => {
+        propagateAttributes({ prompt }, () => {
+          const child1 = startObservation("child-1");
+          child1.end();
+
+          const child2 = startObservation(
+            "child-2",
+            {},
+            { asType: "generation" },
+          );
+          child2.end();
+        });
+        parentSpan.end();
+      });
+
+      await waitForSpanExport(testEnv.mockExporter, 3);
+      const spans = testEnv.mockExporter.exportedSpans;
+
+      for (const name of ["child-1", "child-2"]) {
+        const child = spans.find((s) => s.name === name);
+
+        expect(
+          child?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME],
+        ).toBe("test-prompt");
+        expect(
+          child?.attributes[
+            LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
+          ],
+        ).toBe(3);
+      }
+    });
+
+    it("should support plain object prompt input", async () => {
+      const tracer = otelTrace.getTracer("langfuse-sdk");
+
+      await tracer.startActiveSpan("parent", async (parentSpan) => {
+        propagateAttributes(
+          { prompt: { name: "object-prompt", version: 7 } },
+          () => {
+            const child = startObservation("child");
+            child.end();
+          },
+        );
+        parentSpan.end();
+      });
+
+      await waitForSpanExport(testEnv.mockExporter, 2);
+      const spans = testEnv.mockExporter.exportedSpans;
+      const child = spans.find((s) => s.name === "child");
+
+      expect(
+        child?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME],
+      ).toBe("object-prompt");
+      expect(
+        child?.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
+        ],
+      ).toBe(7);
+    });
+
+    it("should coerce digit-only string version to integer", async () => {
+      const tracer = otelTrace.getTracer("langfuse-sdk");
+
+      await tracer.startActiveSpan("parent", async (parentSpan) => {
+        propagateAttributes(
+          { prompt: { name: "prompt", version: "5" } },
+          () => {
+            const child = startObservation("child");
+            child.end();
+          },
+        );
+        parentSpan.end();
+      });
+
+      await waitForSpanExport(testEnv.mockExporter, 2);
+      const spans = testEnv.mockExporter.exportedSpans;
+      const child = spans.find((s) => s.name === "child");
+
+      expect(
+        child?.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
+        ],
+      ).toBe(5);
+    });
+
+    it("should not link fallback prompts", async () => {
+      const tracer = otelTrace.getTracer("langfuse-sdk");
+      const prompt = makePromptClient({ isFallback: true });
+
+      await tracer.startActiveSpan("parent", async (parentSpan) => {
+        propagateAttributes({ prompt }, () => {
+          const child = startObservation("child");
+          child.end();
+        });
+        parentSpan.end();
+      });
+
+      await waitForSpanExport(testEnv.mockExporter, 2);
+      const spans = testEnv.mockExporter.exportedSpans;
+      const child = spans.find((s) => s.name === "child");
+
+      expect(
+        child?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME],
+      ).toBeUndefined();
+      expect(
+        child?.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
+        ],
+      ).toBeUndefined();
+    });
+
+    it("should drop prompt link when name is invalid", async () => {
+      const tracer = otelTrace.getTracer("langfuse-sdk");
+
+      await tracer.startActiveSpan("parent", async (parentSpan) => {
+        propagateAttributes({ prompt: { name: "", version: 3 } }, () => {
+          const child = startObservation("child");
+          child.end();
+        });
+        parentSpan.end();
+      });
+
+      await waitForSpanExport(testEnv.mockExporter, 2);
+      const spans = testEnv.mockExporter.exportedSpans;
+      const child = spans.find((s) => s.name === "child");
+
+      expect(
+        child?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME],
+      ).toBeUndefined();
+      expect(
+        child?.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
+        ],
+      ).toBeUndefined();
+    });
+
+    it("should drop prompt link when version is invalid", async () => {
+      const tracer = otelTrace.getTracer("langfuse-sdk");
+
+      await tracer.startActiveSpan("parent", async (parentSpan) => {
+        propagateAttributes(
+          { prompt: { name: "prompt", version: "not-a-number" } },
+          () => {
+            const child1 = startObservation("child-1");
+            child1.end();
+          },
+        );
+
+        propagateAttributes(
+          { prompt: { name: "prompt", version: 1.5 } },
+          () => {
+            const child2 = startObservation("child-2");
+            child2.end();
+          },
+        );
+        parentSpan.end();
+      });
+
+      await waitForSpanExport(testEnv.mockExporter, 3);
+      const spans = testEnv.mockExporter.exportedSpans;
+
+      for (const name of ["child-1", "child-2"]) {
+        const child = spans.find((s) => s.name === name);
+
+        expect(
+          child?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME],
+        ).toBeUndefined();
+        expect(
+          child?.attributes[
+            LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
+          ],
+        ).toBeUndefined();
+      }
+    });
+
+    it("should let an explicit observation prompt win over the propagated one", async () => {
+      const tracer = otelTrace.getTracer("langfuse-sdk");
+      const propagatedPrompt = makePromptClient({
+        name: "propagated-prompt",
+        version: 3,
+      });
+
+      await tracer.startActiveSpan("parent", async (parentSpan) => {
+        propagateAttributes({ prompt: propagatedPrompt }, () => {
+          const generation = startObservation(
+            "generation",
+            {
+              prompt: {
+                name: "explicit-prompt",
+                version: 10,
+                isFallback: false,
+              },
+            },
+            { asType: "generation" },
+          );
+          generation.end();
+
+          const child = startObservation("child");
+          child.end();
+        });
+        parentSpan.end();
+      });
+
+      await waitForSpanExport(testEnv.mockExporter, 3);
+      const spans = testEnv.mockExporter.exportedSpans;
+      const generation = spans.find((s) => s.name === "generation");
+      const child = spans.find((s) => s.name === "child");
+
+      expect(
+        generation?.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME
+        ],
+      ).toBe("explicit-prompt");
+      expect(
+        generation?.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
+        ],
+      ).toBe(10);
+
+      // Sibling without explicit prompt still gets the propagated one
+      expect(
+        child?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME],
+      ).toBe("propagated-prompt");
+      expect(
+        child?.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
+        ],
+      ).toBe(3);
+    });
+
+    it("should let creation-time prompt attributes win over the propagated one", async () => {
+      const tracer = otelTrace.getTracer("langfuse-sdk");
+      const propagatedPrompt = makePromptClient({
+        name: "propagated-prompt",
+        version: 3,
+      });
+
+      await tracer.startActiveSpan("parent", async (parentSpan) => {
+        propagateAttributes({ prompt: propagatedPrompt }, () => {
+          // Simulates third-party instrumentations that pass attributes at
+          // span creation time (before the span processor's onStart)
+          const rawSpan = tracer.startSpan("raw-span", {
+            attributes: {
+              [LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME]:
+                "explicit-prompt",
+              [LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION]: 10,
+            },
+          });
+          rawSpan.end();
+        });
+        parentSpan.end();
+      });
+
+      await waitForSpanExport(testEnv.mockExporter, 2);
+      const spans = testEnv.mockExporter.exportedSpans;
+      const rawSpan = spans.find((s) => s.name === "raw-span");
+
+      expect(
+        rawSpan?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME],
+      ).toBe("explicit-prompt");
+      expect(
+        rawSpan?.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
+        ],
+      ).toBe(10);
+    });
+
+    it("should shadow outer prompt in nested contexts and restore on exit", async () => {
+      const tracer = otelTrace.getTracer("langfuse-sdk");
+
+      await tracer.startActiveSpan("parent", async (parentSpan) => {
+        propagateAttributes(
+          { prompt: { name: "outer-prompt", version: 1 } },
+          () => {
+            const spanOuter1 = startObservation("span-outer-1");
+            spanOuter1.end();
+
+            propagateAttributes(
+              { prompt: { name: "inner-prompt", version: 2 } },
+              () => {
+                const spanInner = startObservation("span-inner");
+                spanInner.end();
+              },
+            );
+
+            // Back to outer context
+            const spanOuter2 = startObservation("span-outer-2");
+            spanOuter2.end();
+          },
+        );
+        parentSpan.end();
+      });
+
+      await waitForSpanExport(testEnv.mockExporter, 4);
+      const spans = testEnv.mockExporter.exportedSpans;
+      const spanOuter1 = spans.find((s) => s.name === "span-outer-1");
+      const spanInner = spans.find((s) => s.name === "span-inner");
+      const spanOuter2 = spans.find((s) => s.name === "span-outer-2");
+
+      expect(
+        spanOuter1?.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME
+        ],
+      ).toBe("outer-prompt");
+      expect(
+        spanOuter1?.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
+        ],
+      ).toBe(1);
+
+      expect(
+        spanInner?.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME
+        ],
+      ).toBe("inner-prompt");
+      expect(
+        spanInner?.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
+        ],
+      ).toBe(2);
+
+      expect(
+        spanOuter2?.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME
+        ],
+      ).toBe("outer-prompt");
+      expect(
+        spanOuter2?.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
+        ],
+      ).toBe(1);
+    });
+
+    it("should compose with other propagated attributes", async () => {
+      const tracer = otelTrace.getTracer("langfuse-sdk");
+
+      await tracer.startActiveSpan("parent", async (parentSpan) => {
+        propagateAttributes(
+          { userId: "user_123", sessionId: "session_abc" },
+          () => {
+            propagateAttributes(
+              { prompt: { name: "test-prompt", version: 3 } },
+              () => {
+                const spanInner = startObservation("span-inner");
+                spanInner.end();
+              },
+            );
+
+            // After inner context exits, prompt is gone but outer attrs remain
+            const spanOuter = startObservation("span-outer");
+            spanOuter.end();
+          },
+        );
+        parentSpan.end();
+      });
+
+      await waitForSpanExport(testEnv.mockExporter, 3);
+      const spans = testEnv.mockExporter.exportedSpans;
+      const spanInner = spans.find((s) => s.name === "span-inner");
+      const spanOuter = spans.find((s) => s.name === "span-outer");
+
+      expect(
+        spanInner?.attributes[LangfuseOtelSpanAttributes.TRACE_USER_ID],
+      ).toBe("user_123");
+      expect(
+        spanInner?.attributes[LangfuseOtelSpanAttributes.TRACE_SESSION_ID],
+      ).toBe("session_abc");
+      expect(
+        spanInner?.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME
+        ],
+      ).toBe("test-prompt");
+      expect(
+        spanInner?.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
+        ],
+      ).toBe(3);
+
+      expect(
+        spanOuter?.attributes[LangfuseOtelSpanAttributes.TRACE_USER_ID],
+      ).toBe("user_123");
+      expect(
+        spanOuter?.attributes[LangfuseOtelSpanAttributes.TRACE_SESSION_ID],
+      ).toBe("session_abc");
+      expect(
+        spanOuter?.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME
+        ],
+      ).toBeUndefined();
+      expect(
+        spanOuter?.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
+        ],
+      ).toBeUndefined();
+    });
+
+    it("should propagate prompt in baggage mode", async () => {
+      const tracer = otelTrace.getTracer("langfuse-sdk");
+
+      await tracer.startActiveSpan("parent", async (parentSpan) => {
+        propagateAttributes(
+          { prompt: { name: "test-prompt", version: 3 }, asBaggage: true },
+          () => {
+            const currentContext = otelContext.active();
+            const baggage = propagation.getBaggage(currentContext);
+
+            expect(baggage).toBeDefined();
+            const entries = Array.from(baggage!.getAllEntries());
+            const nameEntry = entries.find(
+              ([key]) => key === "langfuse_prompt_name",
+            );
+            const versionEntry = entries.find(
+              ([key]) => key === "langfuse_prompt_version",
+            );
+
+            expect(nameEntry?.[1].value).toBe("test-prompt");
+            // Baggage values are strings
+            expect(versionEntry?.[1].value).toBe("3");
+
+            const child = startObservation("child");
+            child.end();
+          },
+        );
+        parentSpan.end();
+      });
+
+      await waitForSpanExport(testEnv.mockExporter, 2);
+      const spans = testEnv.mockExporter.exportedSpans;
+      const child = spans.find((s) => s.name === "child");
+
+      expect(
+        child?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME],
+      ).toBe("test-prompt");
+      // Version is restored to an integer when reading back from baggage
+      expect(
+        child?.attributes[
+          LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
+        ],
+      ).toBe(3);
+    });
+  });
+
   describe("getPropagatedAttributesFromContext", () => {
     it("should read userId from context", () => {
       const context = ROOT_CONTEXT.setValue(
@@ -1562,6 +2028,39 @@ describe("propagateAttributes", () => {
       expect(
         attributes[`${LangfuseOtelSpanAttributes.TRACE_METADATA}.key2`],
       ).toBe("value2");
+    });
+
+    it("should read prompt from context", () => {
+      const context = ROOT_CONTEXT.setValue(
+        LangfuseOtelContextKeys["promptName"],
+        "context-prompt",
+      ).setValue(LangfuseOtelContextKeys["promptVersion"], 4);
+      const attributes = getPropagatedAttributesFromContext(context);
+
+      expect(
+        attributes[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME],
+      ).toBe("context-prompt");
+      expect(
+        attributes[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION],
+      ).toBe(4);
+    });
+
+    it("should restore integer prompt version from baggage", () => {
+      let baggage = propagation.createBaggage();
+      baggage = baggage.setEntry("langfuse_prompt_name", {
+        value: "baggage-prompt",
+      });
+      baggage = baggage.setEntry("langfuse_prompt_version", { value: "12" });
+
+      const context = propagation.setBaggage(ROOT_CONTEXT, baggage);
+      const attributes = getPropagatedAttributesFromContext(context);
+
+      expect(
+        attributes[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME],
+      ).toBe("baggage-prompt");
+      expect(
+        attributes[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION],
+      ).toBe(12);
     });
 
     it("should read attributes from baggage", () => {


### PR DESCRIPTION
## Summary

Adds a `prompt` parameter to `propagateAttributes` that links a Langfuse prompt to all observations created within the context by writing two span attributes via OTel context propagation:

- `langfuse.observation.prompt.name` (string)
- `langfuse.observation.prompt.version` (integer)

This enables prompt↔trace linking for generations emitted by auto-instrumentation libraries (e.g. OpenInference, other OTel instrumentations) where the generation is never created via the Langfuse SDK. The server applies the prompt link to GENERATION-type observations only (see langfuse/langfuse#14962), so stamping every span in scope is safe.

JS port of langfuse/langfuse-python#1750.

## Usage

```typescript
import { LangfuseClient } from "@langfuse/client";
import { propagateAttributes } from "@langfuse/tracing";

const langfuse = new LangfuseClient();
const prompt = await langfuse.prompt.get("my-prompt");

await propagateAttributes({ prompt }, async () => {
  // Generations emitted by auto-instrumentation within this context
  // are linked to the prompt version.
  const completion = await openai.chat.completions.create({
    model: "gpt-4o",
    messages: [{ role: "user", content: prompt.compile({ topic: "chickens" }) }],
  });
});

// Plain objects work too:
await propagateAttributes({ prompt: { name: "my-prompt", version: 3 } }, async () => {
  /* ... */
});
```

## Semantics

- **Input**: accepts a prompt client (`TextPromptClient` / `ChatPromptClient`) or any plain object exposing `name` (non-empty string) and `version` (integer). Digit-only string versions (e.g. `"5"`) are coerced to integers. Invalid name/version drops the prompt link entirely with a logged warning.
- **Fallback prompts** (`isFallback: true`) are never linked (debug log).
- **Integer version**: the version attribute is written as an integer, not a string.
- **Precedence**: an explicit `prompt` set directly on an observation (`startObservation(..., { prompt }, ...)` / `updateActiveObservation`) wins over the propagated one. SDK-created observations set their attributes after the processor's `onStart`, so they win naturally; a guard in `LangfuseSpanProcessor.onStart` additionally protects spans that carry `langfuse.observation.prompt.name` from creation-time attributes (third-party instrumentations).
- **Composition**: falls out of the existing propagation mechanism — outer `sessionId`/`userId` etc. are untouched, nested prompt contexts shadow within scope and restore on exit.
- **Baggage**: with `asBaggage: true`, the prompt is propagated cross-process via the `langfuse_prompt_name` / `langfuse_prompt_version` baggage keys (snake_case, matching the Python SDK). Baggage values are strings; the version is restored to an integer when read back.

## Release note

Release should follow the server-side deploy of langfuse/langfuse#14962, which gates prompt linking to generation observations.

## Tests / checks

Added to `tests/integration/propagation.integration.test.ts` (12 new tests):
- prompt client input, plain object input, digit-string version coercion
- fallback prompt skipped; invalid name/version dropped (both attributes absent)
- explicit per-observation prompt wins over propagated (SDK path and creation-time-attributes path)
- nested prompt contexts: inner shadows, outer restored
- composition: outer `userId`/`sessionId` + inner prompt → span has all; after inner exit prompt gone, outer attrs remain
- baggage round-trip (string in baggage, integer restored on read) + `getPropagatedAttributesFromContext` context/baggage reads

Checks run: `pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, unit suite (99 passed), full integration suite (301 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR ports the Python SDK's `propagateAttributes` prompt-linking feature to the JS SDK, adding a `prompt` parameter that writes `langfuse.observation.prompt.name` and `langfuse.observation.prompt.version` span attributes via OTel context propagation so that auto-instrumented generations (OpenInference, etc.) can be linked to a Langfuse prompt version without going through the Langfuse SDK directly.

- **`propagation.ts`**: Adds `promptName`/`promptVersion` as new `PropagatedKey` entries with context storage, baggage encoding/decoding (`langfuse_prompt_name` / `langfuse_prompt_version`, snake_case matching the Python SDK), and a dedicated `extractPropagatedPrompt` validator that handles fallback prompts, empty names, non-integer versions, and digit-only string coercion.
- **`span-processor.ts`**: Adds a precedence guard in `onStart` that drops propagated prompt attributes when the span already carries `OBSERVATION_PROMPT_NAME` at creation time, protecting third-party instrumentation attributes.
- **Tests**: 12 new integration tests cover all described semantics, including baggage round-trip, nested context shadowing, composition, and both SDK-path and creation-time-attribute precedence scenarios.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the common path; two edge cases in the guard logic and baggage round-trip for negative version integers may cause subtle attribute mismatches in unusual scenarios.

The core propagation logic, validation, and baggage encoding are sound and well-tested. The two flagged gaps are confined to uncommon inputs and do not affect the primary use case.

packages/otel/src/span-processor.ts (precedence guard) and packages/core/src/propagation.ts (version validation vs. baggage regex alignment)
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/otel/src/span-processor.ts:354-363
**Precedence guard checks only `PROMPT_NAME`, missing `PROMPT_VERSION`**

The guard fires when `span.attributes[OBSERVATION_PROMPT_NAME] != null`, then removes both `PROMPT_NAME` and `PROMPT_VERSION` from propagated attributes. However, if a third-party instrumentation sets only `OBSERVATION_PROMPT_VERSION` at span creation (without `OBSERVATION_PROMPT_NAME`), the guard won't trigger, and the subsequent `span.setAttributes({...propagatedAttributes})` call will overwrite the creation-time version with the propagated one while also adding the propagated name — exactly the opposite of the intended precedence. Adding `|| span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION] != null` to the guard condition would close this gap.

### Issue 2 of 2
packages/core/src/propagation.ts:561-572
**Negative integers pass validation but break the baggage round-trip**

`extractPropagatedPrompt` accepts any `Number.isInteger` value, which includes negative numbers (e.g. `version: -3`). In non-baggage mode this produces an integer span attribute as expected, but when `asBaggage: true` the value is stored as `String(-3) = "-3"`, and the restoration regex `/^\d+$/` requires only digit characters, so `"-3"` falls through to be stored as a string attribute. The span then carries a string version rather than a number, which can silently cause a server-side type mismatch. Adding `|| version < 1` to the integer check would emit the existing warning and drop the link before the inconsistency is written to baggage.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(tracing): support prompt linking vi..."](https://github.com/langfuse/langfuse-js/commit/23f87b4c906bd5a76df7672a5cc26b4a73d9e9da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43260363)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->