### PR TITLE
fix(langchain): keep an agent run in a single trace

### DIFF
--- a/packages/langchain/src/CallbackHandler.ts
+++ b/packages/langchain/src/CallbackHandler.ts
@@ -1,4 +1,3 @@
-import type { AgentAction, AgentFinish } from "@langchain/core/agents";
 import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
 import type { Document } from "@langchain/core/documents";
 import type { Serialized } from "@langchain/core/load/serializable";
@@ -211,43 +210,14 @@ export class CallbackHandler extends BaseCallbackHandler {
     }
   }
 
-  async handleAgentAction(
-    action: AgentAction,
-    runId: string,
-    parentRunId?: string,
-  ): Promise<void> {
-    try {
-      this.logger.debug(`Agent action ${action.tool} with ID: ${runId}`);
-      this.startAndRegisterOtelSpan({
-        runId,
-        parentRunId,
-        runName: action.tool,
-        attributes: {
-          input: action,
-        },
-      });
-    } catch (e) {
-      this.logger.debug(e instanceof Error ? e.message : String(e));
-    }
-  }
-
-  async handleAgentEnd?(
-    action: AgentFinish,
-    runId: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    parentRunId?: string,
-  ): Promise<void> {
-    try {
-      this.logger.debug(`Agent finish with ID: ${runId}`);
-
-      this.handleOtelSpanEnd({
-        runId,
-        attributes: { output: action },
-      });
-    } catch (e) {
-      this.logger.debug(e instanceof Error ? e.message : String(e));
-    }
-  }
+  // handleAgentAction and handleAgentEnd are intentionally not implemented.
+  //
+  // AgentExecutor dispatches both with the running chain's own runId, not a run
+  // id of their own. Opening a span for the action under that runId overwrote
+  // the chain span already registered there and reparented it at the root, so
+  // the chain span was never ended and every span after the first action opened
+  // a second trace. The tool call is already captured by handleToolStart and
+  // the final output by handleChainEnd, so nothing is lost by leaving these out.
 
   async handleChainError(
     err: any,

--- a/tests/integration/langchain-agent.integration.test.ts
+++ b/tests/integration/langchain-agent.integration.test.ts
@@ -1,0 +1,115 @@
+import type { AgentAction, AgentFinish } from "@langchain/core/agents";
+import { HumanMessage } from "@langchain/core/messages";
+import type { Serialized } from "@langchain/core/load/serializable";
+import type { LLMResult } from "@langchain/core/outputs";
+import { CallbackHandler } from "@langfuse/langchain";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { SpanAssertions } from "./helpers/assertions.js";
+import {
+  setupTestEnvironment,
+  teardownTestEnvironment,
+  waitForSpanExport,
+  type TestEnvironment,
+} from "./helpers/testSetup.js";
+
+/**
+ * Regression test for the AgentExecutor trace split.
+ *
+ * AgentExecutor dispatches handleAgentAction and handleAgentEnd with the
+ * running chain's own runId. The handler used to open a span for the action
+ * under that runId, which overwrote the chain span already registered there and
+ * reparented it at the root, so the chain span was never ended and every span
+ * that followed the first action opened a second trace.
+ *
+ * The callbacks are driven directly here, in the exact order AgentExecutor
+ * emits them for a single tool call, so the test is deterministic and needs no
+ * model. See https://github.com/langfuse/langfuse-js/issues/867.
+ */
+describe("LangChain agent executor trace integrity", () => {
+  let testEnv: TestEnvironment;
+  let assertions: SpanAssertions;
+
+  beforeEach(async () => {
+    testEnv = await setupTestEnvironment();
+    assertions = new SpanAssertions(testEnv.mockExporter);
+  });
+
+  afterEach(async () => {
+    await teardownTestEnvironment(testEnv);
+  });
+
+  it("keeps an agent run in a single trace rooted at the chain", async () => {
+    const handler = new CallbackHandler();
+
+    const serialized = { lc: 1, type: "not_implemented", id: [] } as Serialized;
+    const CHAIN_RUN = "chain-run-id";
+    const GEN_RUN = "generation-run-id";
+    const TOOL_RUN = "tool-run-id";
+
+    const action: AgentAction = {
+      tool: "calculator",
+      toolInput: "2+2",
+      log: "",
+    };
+    const finish: AgentFinish = {
+      returnValues: { output: "4" },
+      log: "",
+    };
+    const llmResult: LLMResult = {
+      generations: [[{ text: "I should use the calculator" }]],
+    };
+
+    // The AgentExecutor callback sequence for one tool call then a finish.
+    await handler.handleChainStart(
+      serialized,
+      { input: "what is 2+2?" },
+      CHAIN_RUN,
+      undefined,
+      [],
+      {},
+      undefined,
+      "AgentExecutor",
+    );
+    await handler.handleChatModelStart(
+      serialized,
+      [[new HumanMessage("what is 2+2?")]],
+      GEN_RUN,
+      CHAIN_RUN,
+      { invocation_params: { model: "test-model" } },
+      [],
+      {},
+      "ChatModel",
+    );
+    await handler.handleLLMEnd(llmResult, GEN_RUN);
+    // LangChain dispatches the agent callbacks optionally, so the handler is
+    // free not to implement them. Mirror that here.
+    await handler.handleAgentAction?.(action, CHAIN_RUN, undefined);
+    await handler.handleToolStart(
+      serialized,
+      "2+2",
+      TOOL_RUN,
+      CHAIN_RUN,
+      [],
+      {},
+      "calculator",
+    );
+    await handler.handleToolEnd("4", TOOL_RUN);
+    await handler.handleAgentEnd?.(finish, CHAIN_RUN);
+    await handler.handleChainEnd({ output: "4" }, CHAIN_RUN);
+
+    // chain + generation + tool. Before the fix the chain span never ended, so
+    // it was never exported and this timed out at 3.
+    await waitForSpanExport(testEnv.mockExporter, 3);
+
+    // The bug's fingerprint: the chain span is gone and the run straddles two
+    // traces.
+    assertions.expectSpanWithName("AgentExecutor");
+    assertions.expectAllSpansInSameTrace();
+
+    assertions.expectSpanCount(3);
+    assertions.expectSpanHasNoParent("AgentExecutor");
+    assertions.expectSpanParent("ChatModel", "AgentExecutor");
+    assertions.expectSpanParent("calculator", "AgentExecutor");
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #867.

For any LangChain `AgentExecutor` run, a single execution produced **two traces, neither of them rooted**: the chain span was lost and every span after the agent's first action was reparented under a second trace.

`AgentExecutor` dispatches `handleAgentAction` and `handleAgentEnd` with the running chain's **own `runId`**, not a run id of their own. `handleAgentAction` called `startAndRegisterOtelSpan({ runId, ... })`, which:

1. overwrote the chain span already stored under that `runId` in `runMap`;
2. parented the action span at the root, because the `parentRunId` it was handed is the chain's parent (`undefined` for a top-level agent);

Then `handleAgentEnd` ended and deleted that entry, so `handleChainEnd` looked up the same `runId`, found nothing, logged `Span not found in runMap. Skipping operation`, and the chain span was never ended. Since the chain span was the trace root, its trace was exported without a root and the following spans opened a second trace.

## Fix

`handleAgentAction` and `handleAgentEnd` are removed. The tool call is already captured by `handleToolStart`/`handleToolEnd` (with the tool's own `runId`) and the final output by `handleChainEnd`, so no information is lost, and the chain span is no longer clobbered.

## Test

Adds `tests/integration/langchain-agent.integration.test.ts`, which drives the exact callback sequence an `AgentExecutor` emits for one tool call and asserts, via the existing `MockSpanExporter`/`SpanAssertions` harness, that the run stays in a single trace rooted at the chain (`expectAllSpansInSameTrace`, chain span present and root, generation and tool nested under it). The callbacks are invoked optionally (`handler.handleAgentAction?.(...)`) exactly as LangChain dispatches them, so the test is valid with and without the handlers. It fails on `main` (the chain span is never exported) and passes with this change.

## Impacted packages

- `@langfuse/langchain`

## Verification

```
pnpm lint            # clean
pnpm typecheck       # clean
pnpm precommit:check # check:lint + check:type + check:format, all pass
pnpm build
pnpm test --project=unit          # 99 passed
pnpm test --project=integration tests/integration/langchain-agent.integration.test.ts  # passes; fails when the fix is reverted
```

Full `--project=integration` run: the only failures are two pre-existing `span-processor` "Media handling" tests, which also fail on `main` in an environment without media upload, and are unrelated to this change.

I kept the change minimal on purpose. If you would rather preserve an agent-action observation (nested under the chain and ended in place), I am happy to adjust.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes `handleAgentAction` and `handleAgentEnd` from the LangChain `CallbackHandler` to fix a trace-split bug where `AgentExecutor` emits both callbacks with the chain's own `runId`, causing the chain span to be overwritten and never ended, producing two rootless traces. A regression integration test is added to lock in the correct behavior.

- **`packages/langchain/src/CallbackHandler.ts`**: Both handlers are removed and replaced with a detailed explanatory comment. Tool call data continues to be captured by `handleToolStart`/`handleToolEnd`, and final output by `handleChainEnd`, so no agent data is lost.
- **`tests/integration/langchain-agent.integration.test.ts`**: New deterministic test that replays the exact `AgentExecutor` callback sequence (one tool call) and asserts a single trace rooted at the chain span with generation and tool nested under it.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted removal of two broken callback handlers with a clear explanatory comment, and the new integration test reproduces the exact failure scenario.

The root cause analysis is accurate: AgentExecutor dispatches handleAgentAction and handleAgentEnd with the chain's own run ID, and the old implementation mutated runMap under that key, erasing the chain span. Removing both handlers eliminates the clobber with zero data loss since tool data is captured by handleToolStart/handleToolEnd and final output by handleChainEnd. The integration test is deterministic, drives the exact callback sequence LangChain emits, and fails on main while passing with the fix.

No files require special attention. The CallbackHandler.ts change is a clean deletion with a descriptive comment, and the new test file is well-structured.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant AE as AgentExecutor
    participant CB as CallbackHandler
    participant RM as runMap

    Note over AE,RM: BEFORE fix — two traces, chain span lost

    AE->>CB: "handleChainStart(CHAIN_RUN, parentRunId=undefined)"
    CB->>RM: runMap.set(CHAIN_RUN, chainSpan) [root span]

    AE->>CB: "handleAgentAction(CHAIN_RUN, parentRunId=undefined) ❌"
    CB->>RM: runMap.set(CHAIN_RUN, actionSpan) — OVERWRITES chainSpan!

    AE->>CB: "handleToolStart(TOOL_RUN, parentRunId=CHAIN_RUN)"
    CB->>RM: runMap.set(TOOL_RUN, toolSpan) [orphaned — no parent chain]

    AE->>CB: handleAgentEnd(CHAIN_RUN) ❌
    CB->>RM: runMap.delete(CHAIN_RUN) — deletes actionSpan

    AE->>CB: handleChainEnd(CHAIN_RUN)
    CB->>RM: runMap.get(CHAIN_RUN) → undefined → skip — chain never exported

    Note over AE,RM: AFTER fix — single trace, chain span preserved

    AE->>CB: "handleChainStart(CHAIN_RUN, parentRunId=undefined)"
    CB->>RM: runMap.set(CHAIN_RUN, chainSpan) [root span]

    AE->>CB: handleAgentAction(CHAIN_RUN) — no handler, no-op ✅

    AE->>CB: "handleToolStart(TOOL_RUN, parentRunId=CHAIN_RUN)"
    CB->>RM: runMap.set(TOOL_RUN, toolSpan ← child of chainSpan)

    AE->>CB: handleToolEnd(TOOL_RUN)
    CB->>RM: runMap.delete(TOOL_RUN)

    AE->>CB: handleAgentEnd(CHAIN_RUN) — no handler, no-op ✅

    AE->>CB: handleChainEnd(CHAIN_RUN)
    CB->>RM: chainSpan.end() → exported ✅ single trace
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant AE as AgentExecutor
    participant CB as CallbackHandler
    participant RM as runMap

    Note over AE,RM: BEFORE fix — two traces, chain span lost

    AE->>CB: "handleChainStart(CHAIN_RUN, parentRunId=undefined)"
    CB->>RM: runMap.set(CHAIN_RUN, chainSpan) [root span]

    AE->>CB: "handleAgentAction(CHAIN_RUN, parentRunId=undefined) ❌"
    CB->>RM: runMap.set(CHAIN_RUN, actionSpan) — OVERWRITES chainSpan!

    AE->>CB: "handleToolStart(TOOL_RUN, parentRunId=CHAIN_RUN)"
    CB->>RM: runMap.set(TOOL_RUN, toolSpan) [orphaned — no parent chain]

    AE->>CB: handleAgentEnd(CHAIN_RUN) ❌
    CB->>RM: runMap.delete(CHAIN_RUN) — deletes actionSpan

    AE->>CB: handleChainEnd(CHAIN_RUN)
    CB->>RM: runMap.get(CHAIN_RUN) → undefined → skip — chain never exported

    Note over AE,RM: AFTER fix — single trace, chain span preserved

    AE->>CB: "handleChainStart(CHAIN_RUN, parentRunId=undefined)"
    CB->>RM: runMap.set(CHAIN_RUN, chainSpan) [root span]

    AE->>CB: handleAgentAction(CHAIN_RUN) — no handler, no-op ✅

    AE->>CB: "handleToolStart(TOOL_RUN, parentRunId=CHAIN_RUN)"
    CB->>RM: runMap.set(TOOL_RUN, toolSpan ← child of chainSpan)

    AE->>CB: handleToolEnd(TOOL_RUN)
    CB->>RM: runMap.delete(TOOL_RUN)

    AE->>CB: handleAgentEnd(CHAIN_RUN) — no handler, no-op ✅

    AE->>CB: handleChainEnd(CHAIN_RUN)
    CB->>RM: chainSpan.end() → exported ✅ single trace
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(langchain): keep an agent run in a s..."](https://github.com/langfuse/langfuse-js/commit/41ef1fb319d97767205edcae4f860446983b695b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43333372)</sub>

<!-- /greptile_comment -->