### PR TITLE
fix(langchain): normalize prompt template outputs

### DIFF
--- a/packages/langchain/src/CallbackHandler.ts
+++ b/packages/langchain/src/CallbackHandler.ts
@@ -389,17 +389,15 @@ export class CallbackHandler extends BaseCallbackHandler {
     try {
       this.logger.debug(`Chain end with ID: ${runId}`);
 
-      let finalOutput = this.extractChainOutput(outputs);
-      if (
-        typeof outputs === "object" &&
-        "output" in outputs &&
-        (typeof outputs["output"] === "string" ||
-          this.isStringPromptValue(outputs["output"]) ||
-          (Array.isArray(outputs["output"]) &&
-            outputs["output"].every((value: unknown) => isBaseMessage(value))))
-      ) {
-        finalOutput = this.extractChainOutput(outputs["output"]);
-      }
+      const output = outputs["output"];
+      const shouldUnwrapOutput =
+        typeof output === "string" ||
+        this.isStringPromptValue(output) ||
+        (Array.isArray(output) &&
+          output.every((value: unknown) => isBaseMessage(value)));
+      const finalOutput = this.extractChainOutput(
+        shouldUnwrapOutput ? output : outputs,
+      );
 
       this.handleOtelSpanEnd({
         runId,
@@ -955,6 +953,8 @@ export class CallbackHandler extends BaseCallbackHandler {
       value?: unknown;
     };
 
+    // lc_id is used intentionally because consumers can load multiple compatible
+    // @langchain/core versions, making instanceof checks unreliable across them.
     return (
       Array.isArray(promptValue.lc_id) &&
       promptValue.lc_id.at(-1) === "StringPromptValue" &&

--- a/packages/langchain/src/CallbackHandler.ts
+++ b/packages/langchain/src/CallbackHandler.ts
@@ -6,6 +6,7 @@ import {
   AIMessage,
   AIMessageChunk,
   BaseMessage,
+  isBaseMessage,
   type UsageMetadata,
   type BaseMessageFields,
   type MessageContent,
@@ -388,24 +389,16 @@ export class CallbackHandler extends BaseCallbackHandler {
     try {
       this.logger.debug(`Chain end with ID: ${runId}`);
 
-      let finalOutput: ChainValues | string = outputs;
+      let finalOutput = this.extractChainOutput(outputs);
       if (
         typeof outputs === "object" &&
         "output" in outputs &&
-        typeof outputs["output"] === "string"
+        (typeof outputs["output"] === "string" ||
+          this.isStringPromptValue(outputs["output"]) ||
+          (Array.isArray(outputs["output"]) &&
+            outputs["output"].every((value: unknown) => isBaseMessage(value))))
       ) {
-        finalOutput = outputs["output"];
-      } else if (
-        typeof outputs === "object" &&
-        "messages" in outputs &&
-        Array.isArray(outputs["messages"]) &&
-        outputs["messages"].every((m: unknown) => m instanceof BaseMessage)
-      ) {
-        finalOutput = {
-          messages: outputs.messages.map((message: BaseMessage) =>
-            this.extractChatMessageContent(message),
-          ),
-        };
+        finalOutput = this.extractChainOutput(outputs["output"]);
       }
 
       this.handleOtelSpanEnd({
@@ -919,6 +912,54 @@ export class CallbackHandler extends BaseCallbackHandler {
         ? generation["message"].response_metadata.model_name
         : undefined;
     } catch {}
+  }
+
+  private extractChainOutput(output: unknown): unknown {
+    if (this.isStringPromptValue(output)) {
+      return output.value;
+    }
+
+    if (isBaseMessage(output)) {
+      return this.extractChatMessageContent(output);
+    }
+
+    if (Array.isArray(output)) {
+      return output.map((value) => this.extractChainOutput(value));
+    }
+
+    if (
+      output !== null &&
+      typeof output === "object" &&
+      Object.getPrototypeOf(output) === Object.prototype
+    ) {
+      return Object.fromEntries(
+        Object.entries(output).map(([key, value]) => [
+          key,
+          this.extractChainOutput(value),
+        ]),
+      );
+    }
+
+    return output;
+  }
+
+  private isStringPromptValue(
+    value: unknown,
+  ): value is { lc_id: string[]; value: string } {
+    if (value === null || typeof value !== "object") {
+      return false;
+    }
+
+    const promptValue = value as {
+      lc_id?: unknown;
+      value?: unknown;
+    };
+
+    return (
+      Array.isArray(promptValue.lc_id) &&
+      promptValue.lc_id.at(-1) === "StringPromptValue" &&
+      typeof promptValue.value === "string"
+    );
   }
 
   private extractChatMessageContent(

--- a/tests/integration/langchain.integration.test.ts
+++ b/tests/integration/langchain.integration.test.ts
@@ -1,3 +1,10 @@
+import {
+  AIMessagePromptTemplate,
+  HumanMessagePromptTemplate,
+  PromptTemplate,
+  SystemMessagePromptTemplate,
+} from "@langchain/core/prompts";
+import { RunnableMap } from "@langchain/core/runnables";
 import { DynamicTool } from "@langchain/core/tools";
 import { CallbackHandler } from "@langfuse/langchain";
 import { LangfuseOtelSpanAttributes } from "@langfuse/tracing";
@@ -63,5 +70,56 @@ describe("LangChain callback handler integration tests", () => {
       LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT,
       "The result is: 100",
     );
+  });
+
+  it("should extract display-ready prompt template outputs", async () => {
+    const handler = new CallbackHandler();
+    const map = RunnableMap.from({
+      String: PromptTemplate.fromTemplate("Tell me a joke about {topic}."),
+      Human: HumanMessagePromptTemplate.fromTemplate(
+        "Tell me a joke about {topic}.",
+      ),
+      AI: AIMessagePromptTemplate.fromTemplate("Tell me a joke about {topic}."),
+      System: SystemMessagePromptTemplate.fromTemplate(
+        "Tell me a joke about {topic}.",
+      ),
+    });
+
+    await map.invoke({ topic: "bears" }, { callbacks: [handler] });
+    await waitForSpanExport(testEnv.mockExporter, 5);
+
+    const getOutput = (spanName: string) => {
+      const span = testEnv.mockExporter.getSpanByName(spanName);
+      const output =
+        span?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT];
+
+      if (
+        typeof output === "string" &&
+        (output.startsWith("{") || output.startsWith("["))
+      ) {
+        return JSON.parse(output);
+      }
+
+      return output;
+    };
+
+    const expectedMessages = {
+      Human: [{ role: "user", content: "Tell me a joke about bears." }],
+      AI: [{ role: "assistant", content: "Tell me a joke about bears." }],
+      System: [{ role: "system", content: "Tell me a joke about bears." }],
+    };
+
+    expect(getOutput("PromptTemplate")).toBe("Tell me a joke about bears.");
+    expect(getOutput("HumanMessagePromptTemplate")).toEqual(
+      expectedMessages.Human,
+    );
+    expect(getOutput("AIMessagePromptTemplate")).toEqual(expectedMessages.AI);
+    expect(getOutput("SystemMessagePromptTemplate")).toEqual(
+      expectedMessages.System,
+    );
+    expect(getOutput("RunnableMap")).toEqual({
+      String: "Tell me a joke about bears.",
+      ...expectedMessages,
+    });
   });
 });


### PR DESCRIPTION
Fixes langfuse/langfuse#1214

## Summary

* unwrap `StringPromptValue` outputs to plain strings
* normalize human, AI, and system messages into role/content objects
* recursively normalize nested `RunnableMap` outputs
* add regression coverage for all cases

## Root cause

`handleChainEnd` only handled primitive strings and a limited message shape, so prompt values, nested outputs, and message arrays reached Langfuse unprocessed. Message detection also relied on fragile class identity checks.

The new extraction logic uses LangChain’s cross-version message predicate, structurally detects `StringPromptValue`, and only recursively traverses plain objects.

## Impact

Langfuse now stores prompt-template outputs in display-ready formats: plain text, normalized role/content messages, and cleaned nested `RunnableMap` values.

## Validation

* verified the issue before and after the fix
* integration test added
* 303 integration tests passed
* lint, typecheck, formatting, and pre-commit checks passed

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes prompt-template output normalization in the LangChain callback handler so that `StringPromptValue` objects, individual message templates (human/AI/system), and nested `RunnableMap` outputs are stored in Langfuse as display-ready plain strings or role/content objects instead of raw LangChain class instances.

- Replaces the fragile ad-hoc output detection in `handleChainEnd` with a recursive `extractChainOutput` helper that correctly handles StringPromptValues, `BaseMessage` instances, arrays, and plain objects; the `shouldUnwrapOutput` ternary cleanly selects between unwrapping `outputs[\"output\"]` directly versus recursively processing the whole outputs dict.
- Adds `isStringPromptValue` as a duck-typed predicate using `lc_id` (with an explanatory comment) to avoid cross-version `instanceof` brittleness when consumers load multiple compatible `@langchain/core` versions.
- Adds a regression integration test covering all four prompt-template types inside a `RunnableMap`, asserting the expected normalized shapes for each span.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is scoped to telemetry output normalization, is fully wrapped in the existing try/catch, and leaves all non-matching output shapes unmodified.

The recursive normalization logic is correct for all stated cases, the shouldUnwrapOutput gate and the extractChainOutput dispatch are well-structured, and the integration test exercises every code path added. No regressions were found in how pre-existing output shapes are handled.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["handleChainEnd(outputs)"] --> B["output = outputs.output"]
    B --> C{"shouldUnwrapOutput?"}
    C -->|"string"| D["extractChainOutput(output)"]
    C -->|"StringPromptValue"| D
    C -->|"BaseMessage array"| D
    C -->|"anything else"| E["extractChainOutput(outputs)"]
    D --> F{"extractChainOutput(x)"}
    E --> F
    F -->|"isStringPromptValue"| G["return x.value"]
    F -->|"isBaseMessage"| H["extractChatMessageContent returns role/content"]
    F -->|"Array"| I["map each element recursively"]
    F -->|"plain object"| J["fromEntries: recurse into each value"]
    F -->|"other"| K["return as-is"]
    G --> L["Normalized output stored in Langfuse"]
    H --> L
    I --> L
    J --> L
    K --> L
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["handleChainEnd(outputs)"] --> B["output = outputs.output"]
    B --> C{"shouldUnwrapOutput?"}
    C -->|"string"| D["extractChainOutput(output)"]
    C -->|"StringPromptValue"| D
    C -->|"BaseMessage array"| D
    C -->|"anything else"| E["extractChainOutput(outputs)"]
    D --> F{"extractChainOutput(x)"}
    E --> F
    F -->|"isStringPromptValue"| G["return x.value"]
    F -->|"isBaseMessage"| H["extractChatMessageContent returns role/content"]
    F -->|"Array"| I["map each element recursively"]
    F -->|"plain object"| J["fromEntries: recurse into each value"]
    F -->|"other"| K["return as-is"]
    G --> L["Normalized output stored in Langfuse"]
    H --> L
    I --> L
    J --> L
    K --> L
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(langchain): streamline output n..."](https://github.com/langfuse/langfuse-js/commit/ea33f6cccfec7696a48486eebaa52c7dc156e473) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43884649)</sub>

<!-- /greptile_comment -->