### PR TITLE
fix(otel): stop base64 media regex from matching across commas

### DIFF
--- a/packages/otel/src/MediaService.ts
+++ b/packages/otel/src/MediaService.ts
@@ -52,9 +52,11 @@ export class MediaService {
           continue;
         }
 
-        // Find media base64 data URI
+        // Find media base64 data URI. The mediatype segment excludes commas
+        // (not just semicolons) so a plain-text "data:" mention earlier in the
+        // same payload can't greedily swallow a later, real data URI.
         let mediaReplacedValue = value;
-        const regex = /data:[^;]+;base64,[A-Za-z0-9+/]+=*/g;
+        const regex = /data:[^;,]+;base64,[A-Za-z0-9+/]+=*/g;
         const foundMedia = [...new Set(value.match(regex) ?? [])];
 
         if (foundMedia.length === 0) continue;

--- a/tests/unit/mediaService.test.ts
+++ b/tests/unit/mediaService.test.ts
@@ -1,0 +1,128 @@
+import { LangfuseOtelSpanAttributes } from "@langfuse/core";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { MediaService } from "../../packages/otel/src/MediaService";
+
+function makeSpan(attributes: Record<string, unknown>): ReadableSpan {
+  return {
+    attributes,
+    instrumentationScope: { name: "test" },
+    spanContext: () => ({ traceId: "trace-1", spanId: "span-1" }),
+  } as unknown as ReadableSpan;
+}
+
+function makeApiClient() {
+  return {
+    media: {
+      // Echo back the SDK-computed media ID so uploadMedia's integrity check
+      // (clientSideMediaId === server mediaId) passes.
+      getUploadUrl: vi.fn().mockImplementation(({ sha256Hash }) => ({
+        uploadUrl: "https://upload.example/put",
+        mediaId: sha256Hash
+          .replaceAll("+", "-")
+          .replaceAll("/", "_")
+          .slice(0, 22),
+      })),
+      patch: vi.fn().mockResolvedValue(undefined),
+    },
+  } as any;
+}
+
+describe("MediaService.process", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("extracts a well-formed base64 data URI", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ status: 200, text: async () => "" }),
+    );
+
+    const apiClient = makeApiClient();
+    const service = new MediaService({ apiClient });
+
+    const attributes = {
+      [LangfuseOtelSpanAttributes.TRACE_INPUT]: JSON.stringify([
+        {
+          role: "user",
+          content: [
+            {
+              type: "input_file",
+              file: "data:application/pdf;base64,JVBERi0xLjQK",
+            },
+          ],
+        },
+      ]),
+    };
+    const span = makeSpan(attributes);
+
+    await service.process(span);
+    await service.flush();
+
+    expect(apiClient.media.getUploadUrl).toHaveBeenCalledTimes(1);
+    expect(apiClient.media.getUploadUrl.mock.calls[0][0].contentType).toBe(
+      "application/pdf",
+    );
+    expect(attributes[LangfuseOtelSpanAttributes.TRACE_INPUT]).not.toContain(
+      ";base64,",
+    );
+  });
+
+  // Regression test for "[Langfuse SDK] [ERROR] Error parsing base64 data URI
+  // Error: Data is not base64 encoded": a plain-text "data:" mention earlier
+  // in the payload used to be greedily glued to a later, real data URI by
+  // the extraction regex, producing a bogus match that failed to parse.
+  it("does not glue a plain-text 'data:' mention to a later real data URI", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ status: 200, text: async () => "" }),
+    );
+
+    const apiClient = makeApiClient();
+    const service = new MediaService({ apiClient });
+
+    const attributes = {
+      [LangfuseOtelSpanAttributes.TRACE_INPUT]: JSON.stringify([
+        {
+          role: "user",
+          content:
+            "check data:image stuff, here is the file data:application/pdf;base64,JVBERi0xLjQK",
+        },
+      ]),
+    };
+    const span = makeSpan(attributes);
+
+    await service.process(span);
+    await service.flush();
+
+    expect(apiClient.media.getUploadUrl).toHaveBeenCalledTimes(1);
+    expect(apiClient.media.getUploadUrl.mock.calls[0][0].contentType).toBe(
+      "application/pdf",
+    );
+    expect(attributes[LangfuseOtelSpanAttributes.TRACE_INPUT]).not.toContain(
+      ";base64,",
+    );
+    expect(attributes[LangfuseOtelSpanAttributes.TRACE_INPUT]).toContain(
+      "check data:image stuff, here is the file",
+    );
+  });
+
+  it("skips attributes with no data URI without error", async () => {
+    const apiClient = makeApiClient();
+    const service = new MediaService({ apiClient });
+
+    const attributes = {
+      [LangfuseOtelSpanAttributes.TRACE_INPUT]: JSON.stringify([
+        { role: "user", content: "hello data:image stuff, no file here" },
+      ]),
+    };
+    const span = makeSpan(attributes);
+
+    await service.process(span);
+    await service.flush();
+
+    expect(apiClient.media.getUploadUrl).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
MediaService.process() scans span attributes for data URIs with /data:[^;]+;base64,.../g. The mediatype segment [^;]+ excludes only semicolons, so when a trace payload contains a plain-text 'data:' mention earlier in the same string (e.g. user message text), the regex greedily matches from that first 'data:' through unrelated text, including any commas, all the way to a later real ';base64,' data URI. The resulting bogus match fails to parse ('[Langfuse SDK] [ERROR] Error parsing base64 data URI Error: Data is not base64 encoded'), and the real media is silently dropped.

Exclude commas too ([^;,]+): real mediatypes (image/png, application/pdf, ...) never contain a comma, so legitimate matches are unaffected, but the regex can no longer span past one.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Verification

<!-- List the commands you ran, or explain why a relevant check could not run. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm test:integration`
- [ ] `pnpm test:e2e`
- [ ] `pnpm format:check`

## Release info

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] @langfuse/core
- [ ] @langfuse/client
- [ ] @langfuse/tracing
- [ ] @langfuse/otel
- [ ] @langfuse/openai
- [ ] @langfuse/langchain

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a greedy-regex bug in `MediaService.process()` where a plain-text `data:` mention earlier in a span attribute string could be stitched to a later, real `data:URI` by the extraction regex, producing a bogus match that failed base64 parsing and silently dropped the real media. The one-character change (`[^;]+` → `[^;,]+`) prevents cross-comma greedy matching; MIME types never contain commas, so no valid data URI is affected.

- **Regex fix** (`packages/otel/src/MediaService.ts`): adds `,` to the excluded character set in the mediatype segment, so the regex anchors tightly and cannot span past a comma into unrelated text.
- **Tests** (`tests/unit/mediaService.test.ts`): adds three unit tests covering a normal data URI extraction, the regression scenario (plain-text `data:` followed by a real URI in the same string), and the no-URI-present path.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a minimal, targeted regex fix in a single character class; the change cannot affect any valid MIME type and directly closes the greedy-match escape hatch that caused bogus URI parsing.

The one-character change is logically sound — MIME types never contain commas, so adding ',' to the negated class only restricts invalid matches. The three new unit tests directly exercise the fixed path, the regression scenario, and the no-URI path, giving good coverage of the changed behavior. No edge cases are introduced or regressed.

No files require special attention. The test mock returns getUploadUrl synchronously (not a Promise), which works fine in JS/TS but differs from the real API shape — worth keeping in mind if the test suite is later extended.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["span attribute value (string)"] --> B["Apply regex\n/data:[^;,]+;base64,[A-Za-z0-9+/]+=*/g"]
    B --> C{Matches found?}
    C -- No --> D[Skip attribute]
    C -- Yes --> E[Deduplicate matches via Set]
    E --> F["For each match: create LangfuseMedia\n(base64DataUri)"]
    F --> G["media.getTag() → langfuseMediaTag"]
    G --> H{Tag created?}
    H -- No --> I[Log warning, skip item]
    H -- Yes --> J[scheduleUpload in background]
    J --> K["Replace raw data URI in attribute\nwith @@@langfuse-media:... tag"]
    K --> L[Update span.attributes key]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["span attribute value (string)"] --> B["Apply regex\n/data:[^;,]+;base64,[A-Za-z0-9+/]+=*/g"]
    B --> C{Matches found?}
    C -- No --> D[Skip attribute]
    C -- Yes --> E[Deduplicate matches via Set]
    E --> F["For each match: create LangfuseMedia\n(base64DataUri)"]
    F --> G["media.getTag() → langfuseMediaTag"]
    G --> H{Tag created?}
    H -- No --> I[Log warning, skip item]
    H -- Yes --> J[scheduleUpload in background]
    J --> K["Replace raw data URI in attribute\nwith @@@langfuse-media:... tag"]
    K --> L[Update span.attributes key]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): stop base64 media regex from ..."](https://github.com/langfuse/langfuse-js/commit/bc289455e6bcda9445240c9ddf22db4fa226706d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44385620)</sub>

<!-- /greptile_comment -->