### PR TITLE
feat(tracing): propagate environment attributes

### DIFF
--- a/packages/core/src/propagation.ts
+++ b/packages/core/src/propagation.ts
@@ -2,8 +2,8 @@
  * Attribute propagation utilities for Langfuse OpenTelemetry integration.
  *
  * This module provides the `propagateAttributes` function for setting trace-level
- * attributes (userId, sessionId, metadata) that automatically propagate to all child spans
- * within the context.
+ * attributes (userId, sessionId, environment, metadata) that automatically propagate
+ * to all child spans within the context.
  */
 
 import {
@@ -27,6 +27,7 @@ type CorrelatedKey =
   | "version"
   | "tags"
   | "traceName"
+  | "environment"
   | "promptName"
   | "promptVersion";
 
@@ -59,6 +60,7 @@ export const LangfuseOtelContextKeys: Record<PropagatedKey, symbol> = {
   version: createContextKey("langfuse_version"),
   tags: createContextKey("langfuse_tags"),
   traceName: createContextKey("langfuse_trace_name"),
+  environment: createContextKey("langfuse_environment"),
   promptName: createContextKey("langfuse_prompt_name"),
   promptVersion: createContextKey("langfuse_prompt_version"),
 
@@ -191,6 +193,19 @@ export interface PropagateAttributesParams {
   traceName?: string;
 
   /**
+   * Langfuse environment to associate with all spans in this context.
+   *
+   * Must be a lowercase alphanumeric string with optional hyphens or underscores,
+   * must be ≤40 characters, and must not start with `langfuse`. This maps to the
+   * first-class `langfuse.environment` attribute, not to trace metadata.
+   *
+   * A propagated environment takes precedence over the default configured on
+   * `LangfuseSpanProcessor` or via `LANGFUSE_TRACING_ENVIRONMENT` while this
+   * propagation scope is active.
+   */
+  environment?: string;
+
+  /**
    * Langfuse prompt to link to observations created within this context.
    *
    * Accepts a prompt client returned by `langfuse.prompt.get(...)` or any plain
@@ -234,8 +249,9 @@ export interface PropagateAttributesParams {
  *
  * This function sets attributes on the currently active span AND automatically
  * propagates them to all new child spans created within the callback. This is the
- * recommended way to set trace-level attributes like userId, sessionId, and metadata
- * dimensions that should be consistently applied across all observations in a trace.
+ * recommended way to set trace-level attributes like userId, sessionId, environment,
+ * and metadata dimensions that should be consistently applied across all observations
+ * in a trace.
  *
  * **IMPORTANT**: Call this as early as possible within your trace/workflow. Only the
  * currently active span and spans created after entering this context will have these
@@ -261,11 +277,12 @@ export interface PropagateAttributesParams {
  *   await propagateAttributes({
  *     userId: 'user_123',
  *     sessionId: 'session_abc',
- *     metadata: { experiment: 'variant_a', environment: 'production' }
+ *     environment: 'production',
+ *     metadata: { experiment: 'variant_a' }
  *   }, async () => {
- *     // All spans created here will have userId, sessionId, and metadata
+ *     // All spans created here will have userId, sessionId, environment, and metadata
  *     const llmSpan = startObservation('llm_call', { input: 'Hello' });
- *     // This span inherits: userId, sessionId, experiment, environment
+ *     // This span inherits userId, sessionId, environment, and experiment metadata
  *     llmSpan.end();
  *
  *     const gen = startObservation('completion', {}, { asType: 'generation' });
@@ -327,11 +344,12 @@ export interface PropagateAttributesParams {
  *   await propagateAttributes({
  *     userId: 'user_123',
  *     sessionId: 'session_abc',
+ *     environment: 'staging',
  *     asBaggage: true  // Propagate via HTTP headers
  *   }, async () => {
  *     // Make HTTP request to Service B
  *     const response = await fetch('https://service-b.example.com/api');
- *     // userId and sessionId are now in HTTP headers
+ *     // userId, sessionId, and environment are now in HTTP headers
  *   });
  * });
  *
@@ -341,9 +359,10 @@ export interface PropagateAttributesParams {
  * ```
  *
  * @remarks
- * - **Validation**: All attribute values (userId, sessionId, metadata values)
- *   must be strings ≤200 characters. Invalid values will be dropped with a
- *   warning logged. Ensure values meet constraints before calling.
+ * - **Validation**: Attribute values (userId, sessionId, metadata values) must be
+ *   strings ≤200 characters. Environment must be a lowercase alphanumeric string
+ *   with optional hyphens or underscores, must be ≤40 characters, and must not start
+ *   with `langfuse`. Invalid values will be dropped with a warning logged.
  * - **OpenTelemetry**: This uses OpenTelemetry context propagation under the hood,
  *   making it compatible with other OTel-instrumented libraries.
  * - **Baggage Security**: When `asBaggage=true`, attribute values are added to HTTP
@@ -368,6 +387,7 @@ export function propagateAttributes<
     version,
     tags,
     traceName,
+    environment,
     prompt,
     _internalExperiment,
   } = params;
@@ -437,6 +457,17 @@ export function propagateAttributes<
         asBaggage,
       });
     }
+  }
+
+  // Validate and set environment
+  if (environment !== undefined && isValidEnvironment(environment)) {
+    context = setPropagatedAttribute({
+      key: "environment",
+      value: environment,
+      context,
+      span,
+      asBaggage,
+    });
   }
 
   // Validate and set tags
@@ -590,6 +621,14 @@ export function getPropagatedAttributesFromContext(
         const spanKey = getSpanKeyFromBaggageKey(baggageKey);
 
         if (spanKey) {
+          if (spanKey === LangfuseOtelSpanAttributes.ENVIRONMENT) {
+            if (isValidEnvironment(baggageEntry.value)) {
+              propagatedAttributes[spanKey] = baggageEntry.value;
+            }
+
+            return;
+          }
+
           // Prompt version is an integer span attribute; restore it from its
           // string representation in baggage
           if (
@@ -639,6 +678,11 @@ export function getPropagatedAttributesFromContext(
     const spanKey = getSpanKeyForPropagatedKey("traceName");
 
     propagatedAttributes[spanKey] = traceName;
+  }
+
+  const environment = context.getValue(LangfuseOtelContextKeys["environment"]);
+  if (isValidEnvironment(environment)) {
+    propagatedAttributes[LangfuseOtelSpanAttributes.ENVIRONMENT] = environment;
   }
 
   const tags = context.getValue(LangfuseOtelContextKeys["tags"]);
@@ -708,6 +752,7 @@ type SetPropagatedAttributeParams = {
         | "sessionId"
         | "version"
         | "traceName"
+        | "environment"
         | "promptName"
         | ExperimentKey;
       value: string;
@@ -845,6 +890,40 @@ function isValidPropagatedString(params: {
   return true;
 }
 
+const ENVIRONMENT_VALUE_PATTERN = /^(?!langfuse)[a-z0-9_-]+$/;
+
+function isValidEnvironment(value: unknown): value is string {
+  const logger = getGlobalLogger();
+
+  if (typeof value !== "string") {
+    if (value !== undefined) {
+      logger.warn(
+        "Propagated attribute 'environment' must be a string. Dropping value.",
+      );
+    }
+
+    return false;
+  }
+
+  if (value.length > 40) {
+    logger.warn(
+      `Propagated attribute 'environment' value is over 40 characters (${value.length} chars). Dropping value.`,
+    );
+
+    return false;
+  }
+
+  if (!ENVIRONMENT_VALUE_PATTERN.test(value)) {
+    logger.warn(
+      "Propagated attribute 'environment' must be a lowercase alphanumeric string with optional hyphens or underscores and must not start with 'langfuse'. Dropping value.",
+    );
+
+    return false;
+  }
+
+  return true;
+}
+
 function getContextKeyForPropagatedKey(key: PropagatedKey): symbol {
   return LangfuseOtelContextKeys[key];
 }
@@ -859,6 +938,8 @@ function getSpanKeyForPropagatedKey(key: PropagatedKey): string {
       return LangfuseOtelSpanAttributes.VERSION;
     case "traceName":
       return LangfuseOtelSpanAttributes.TRACE_NAME;
+    case "environment":
+      return LangfuseOtelSpanAttributes.ENVIRONMENT;
     case "metadata":
       return LangfuseOtelSpanAttributes.TRACE_METADATA;
     case "tags":
@@ -901,6 +982,8 @@ function getBaggageKeyForPropagatedKey(key: PropagatedKey): string {
       return `${LANGFUSE_BAGGAGE_PREFIX}version`;
     case "traceName":
       return `${LANGFUSE_BAGGAGE_PREFIX}trace_name`;
+    case "environment":
+      return `${LANGFUSE_BAGGAGE_PREFIX}environment`;
     case "metadata":
       return `${LANGFUSE_BAGGAGE_PREFIX}metadata`;
     case "tags":
@@ -952,6 +1035,8 @@ function getSpanKeyFromBaggageKey(baggageKey: string): string | undefined {
       return getSpanKeyForPropagatedKey("version");
     case "trace_name":
       return getSpanKeyForPropagatedKey("traceName");
+    case "environment":
+      return getSpanKeyForPropagatedKey("environment");
     case "tags":
       return getSpanKeyForPropagatedKey("tags");
     case "prompt_name":

--- a/packages/tracing/README.md
+++ b/packages/tracing/README.md
@@ -140,7 +140,7 @@ Key exports:
 
 - `startObservation` / `startActiveObservation` — create spans, generations, agents, tools, and other observation types
 - `observe()` — wrap any existing function with tracing
-- `propagateAttributes()` — set `userId`, `sessionId`, `tags`, `metadata`, `version`, and prompt links on all spans created within a callback
+- `propagateAttributes()` — set `userId`, `sessionId`, `environment`, `tags`, `metadata`, `version`, and prompt links on all spans created within a callback
 - `createTraceId()` — deterministic trace IDs for correlating external IDs
 - `updateActiveObservation`, `getActiveTraceId`, `setActiveTraceAsPublic`
 

--- a/tests/integration/propagation.integration.test.ts
+++ b/tests/integration/propagation.integration.test.ts
@@ -2,8 +2,8 @@
  * Comprehensive tests for propagateAttributes functionality.
  *
  * This module tests the propagateAttributes function that allows setting
- * trace-level attributes (userId, sessionId, version, metadata) that automatically propagate
- * to all child spans within the context.
+ * trace-level attributes (userId, sessionId, environment, version, metadata) that
+ * automatically propagate to all child spans within the context.
  */
 
 import { TextPromptClient } from "@langfuse/client";
@@ -307,6 +307,136 @@ describe("propagateAttributes", () => {
       expect(
         child?.attributes[`${LangfuseOtelSpanAttributes.TRACE_METADATA}.env`],
       ).toBe("prod");
+    });
+  });
+
+  describe("Environment Propagation", () => {
+    it("should propagate environment as a first-class attribute", async () => {
+      const tracer = otelTrace.getTracer("langfuse-sdk");
+
+      await tracer.startActiveSpan("parent", async (parentSpan) => {
+        propagateAttributes({ environment: "staging" }, () => {
+          const child = startObservation("child");
+          child.end();
+        });
+        parentSpan.end();
+      });
+
+      await waitForSpanExport(testEnv.mockExporter, 2);
+      const spans = testEnv.mockExporter.exportedSpans;
+      const parent = spans.find((s) => s.name === "parent");
+      const child = spans.find((s) => s.name === "child");
+
+      expect(parent?.attributes[LangfuseOtelSpanAttributes.ENVIRONMENT]).toBe(
+        "staging",
+      );
+      expect(child?.attributes[LangfuseOtelSpanAttributes.ENVIRONMENT]).toBe(
+        "staging",
+      );
+    });
+
+    it("should override the processor default and restore nested scopes", async () => {
+      await teardownTestEnvironment(testEnv);
+      testEnv = await setupTestEnvironment({
+        spanProcessorConfig: { environment: "default" },
+      });
+
+      const before = startObservation("before");
+      before.end();
+
+      propagateAttributes({ environment: "outer", asBaggage: true }, () => {
+        const outer1 = startObservation("outer-1");
+        outer1.end();
+
+        expect(
+          propagation
+            .getBaggage(otelContext.active())
+            ?.getEntry("langfuse_environment")?.value,
+        ).toBe("outer");
+
+        propagateAttributes({ environment: "inner", asBaggage: true }, () => {
+          expect(
+            propagation
+              .getBaggage(otelContext.active())
+              ?.getEntry("langfuse_environment")?.value,
+          ).toBe("inner");
+
+          const inner = startObservation("inner");
+          inner.end();
+        });
+
+        expect(
+          propagation
+            .getBaggage(otelContext.active())
+            ?.getEntry("langfuse_environment")?.value,
+        ).toBe("outer");
+
+        const outer2 = startObservation("outer-2");
+        outer2.end();
+      });
+
+      const after = startObservation("after");
+      after.end();
+
+      await waitForSpanExport(testEnv.mockExporter, 5);
+      const spans = testEnv.mockExporter.exportedSpans;
+      const getEnvironment = (name: string) =>
+        spans.find((span) => span.name === name)?.attributes[
+          LangfuseOtelSpanAttributes.ENVIRONMENT
+        ];
+
+      expect(getEnvironment("before")).toBe("default");
+      expect(getEnvironment("outer-1")).toBe("outer");
+      expect(getEnvironment("inner")).toBe("inner");
+      expect(getEnvironment("outer-2")).toBe("outer");
+      expect(getEnvironment("after")).toBe("default");
+    });
+
+    it.each(["", "Production", "prod.eu", "langfuse-prod", "x".repeat(41)])(
+      "should drop invalid environment %j",
+      async (environment) => {
+        propagateAttributes({ environment }, () => {
+          const child = startObservation(`child-${environment}`);
+          child.end();
+        });
+
+        await waitForSpanExport(testEnv.mockExporter, 1);
+        const [child] = testEnv.mockExporter.exportedSpans;
+
+        expect(
+          child.attributes[LangfuseOtelSpanAttributes.ENVIRONMENT],
+        ).toBeUndefined();
+      },
+    );
+
+    it("should drop a non-string environment", async () => {
+      propagateAttributes({ environment: 123 as unknown as string }, () => {
+        const child = startObservation("child");
+        child.end();
+      });
+
+      await waitForSpanExport(testEnv.mockExporter, 1);
+      const [child] = testEnv.mockExporter.exportedSpans;
+
+      expect(
+        child.attributes[LangfuseOtelSpanAttributes.ENVIRONMENT],
+      ).toBeUndefined();
+    });
+
+    it("should accept a 40-character environment", async () => {
+      const environment = "e".repeat(40);
+
+      propagateAttributes({ environment }, () => {
+        const child = startObservation("child");
+        child.end();
+      });
+
+      await waitForSpanExport(testEnv.mockExporter, 1);
+      const [child] = testEnv.mockExporter.exportedSpans;
+
+      expect(child.attributes[LangfuseOtelSpanAttributes.ENVIRONMENT]).toBe(
+        environment,
+      );
     });
   });
 
@@ -2012,6 +2142,18 @@ describe("propagateAttributes", () => {
       );
     });
 
+    it("should read environment from context", () => {
+      const context = ROOT_CONTEXT.setValue(
+        LangfuseOtelContextKeys["environment"],
+        "context-env",
+      );
+      const attributes = getPropagatedAttributesFromContext(context);
+
+      expect(attributes[LangfuseOtelSpanAttributes.ENVIRONMENT]).toBe(
+        "context-env",
+      );
+    });
+
     it("should read metadata from context", () => {
       const context = ROOT_CONTEXT.setValue(
         LangfuseOtelContextKeys["metadata"],
@@ -2073,6 +2215,9 @@ describe("propagateAttributes", () => {
       baggage = baggage.setEntry("langfuse_trace_name", {
         value: "baggage-trace",
       });
+      baggage = baggage.setEntry("langfuse_environment", {
+        value: "baggage-env",
+      });
       baggage = baggage.setEntry("langfuse_metadata_env", { value: "prod" });
 
       const context = propagation.setBaggage(ROOT_CONTEXT, baggage);
@@ -2088,9 +2233,25 @@ describe("propagateAttributes", () => {
       expect(attributes[LangfuseOtelSpanAttributes.TRACE_NAME]).toBe(
         "baggage-trace",
       );
+      expect(attributes[LangfuseOtelSpanAttributes.ENVIRONMENT]).toBe(
+        "baggage-env",
+      );
       expect(
         attributes[`${LangfuseOtelSpanAttributes.TRACE_METADATA}.env`],
       ).toBe("prod");
+    });
+
+    it("should drop invalid environment from baggage", () => {
+      const baggage = propagation
+        .createBaggage()
+        .setEntry("langfuse_environment", { value: "Production" });
+      const context = propagation.setBaggage(ROOT_CONTEXT, baggage);
+
+      const attributes = getPropagatedAttributesFromContext(context);
+
+      expect(
+        attributes[LangfuseOtelSpanAttributes.ENVIRONMENT],
+      ).toBeUndefined();
     });
 
     it("should return empty object for context with no propagated attributes", () => {


### PR DESCRIPTION
## Summary

- add an optional `environment` field to `propagateAttributes`
- validate and propagate it as the first-class `langfuse.environment` OpenTelemetry attribute
- support `asBaggage`, nested-scope restoration, and precedence over the span processor default
- document the public API and add focused integration coverage

## Why

JavaScript users could set an environment directly on an observation, but could not set one once per request and have it inherited by later spans. This closes the verified parity gap with the Python SDK for shared proxies and multi-environment workloads.

Linear: [LFE-14512](https://linear.app/clickhouse/issue/LFE-14512/propagate-request-scoped-environment-in-the-js-sdk)

## Impacted packages

- `@langfuse/core`
- `@langfuse/tracing`

## Validation

- `TURBO_CACHE_DIR=/private/tmp/langfuse-js-lfe-14512-turbo-cache pnpm build`
- `pnpm vitest run --project=integration tests/integration/propagation.integration.test.ts` (75 passed)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format:check`
- repository pre-commit checks

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds request-scoped environment propagation to the tracing API.
- Adds validation and OpenTelemetry context/baggage mapping for `langfuse.environment`.
- Ensures propagated environments override processor defaults and restore across nested scopes.
- Documents the new public option and adds focused integration coverage.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified in the changed behavior.

Environment values are consistently validated before entering or leaving propagation context, mapped to the canonical span attribute and baggage key, and applied after the processor default so request-scoped values take precedence.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(tracing): propagate environment att..."](https://github.com/langfuse/langfuse-js/commit/1830a70f5b1ddd33fde938afcca8c6ac4d2e2d68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47572704)</sub>

**Context used:**

- Knowledge Base — [@langfuse/core: shared primitives for the SDK](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-js/-/docs/core.md)
- Knowledge Base — [@langfuse/tracing: OTel-based observation instrumentation](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-js/-/docs/tracing.md)

<!-- /greptile_comment -->