### PR TITLE
fix(client): apply timeout to score ingestion

### DIFF
--- a/packages/client/src/LangfuseClient.ts
+++ b/packages/client/src/LangfuseClient.ts
@@ -314,7 +314,10 @@ export class LangfuseClient {
 
     this.prompt = new PromptManager({ apiClient: this.api });
     this.dataset = new DatasetManager({ langfuseClient: this });
-    this.score = new ScoreManager({ apiClient: this.api });
+    this.score = new ScoreManager({
+      apiClient: this.api,
+      timeoutSeconds,
+    });
     this.media = new MediaManager({ apiClient: this.api });
     this.experiment = new ExperimentManager({ langfuseClient: this });
 

--- a/packages/client/src/score/index.ts
+++ b/packages/client/src/score/index.ts
@@ -30,15 +30,21 @@ export class ScoreManager {
   private flushTimer: any = null;
   private flushAtCount: number;
   private flushIntervalSeconds: number;
+  private timeoutSeconds: number;
 
   /**
    * Creates a new ScoreManager instance.
    *
-   * @param params - Configuration object containing the API client
+   * @param params - Configuration object containing the API client and request timeout
    * @internal
    */
-  constructor(params: { apiClient: LangfuseAPIClient }) {
+  constructor(params: {
+    apiClient: LangfuseAPIClient;
+    timeoutSeconds?: number;
+  }) {
     this.apiClient = params.apiClient;
+    this.timeoutSeconds =
+      params.timeoutSeconds ?? Number(getEnv("LANGFUSE_TIMEOUT") ?? 5);
 
     const envFlushAtCount = getEnv("LANGFUSE_FLUSH_AT");
     const envFlushIntervalSeconds = getEnv("LANGFUSE_FLUSH_INTERVAL");
@@ -283,7 +289,7 @@ export class ScoreManager {
 
         promises.push(
           this.apiClient.ingestion
-            .batch({ batch })
+            .batch({ batch }, { timeoutInSeconds: this.timeoutSeconds })
             .then((res) => {
               if (res.errors?.length > 0) {
                 this.logger.error("Error ingesting scores:", res.errors);

--- a/tests/unit/LangfuseClient.test.ts
+++ b/tests/unit/LangfuseClient.test.ts
@@ -76,3 +76,31 @@ describe("LangfuseClient deprecated dataset aliases", () => {
     }
   });
 });
+
+describe("LangfuseClient score ingestion", () => {
+  it("passes LANGFUSE_TIMEOUT to ingestion requests", async () => {
+    vi.stubEnv("LANGFUSE_TIMEOUT", "0.25");
+
+    try {
+      const client = new LangfuseClient({
+        publicKey: "pk-test",
+        secretKey: "sk-test",
+        baseUrl: "http://localhost:3000",
+      });
+      const batch = vi.fn().mockResolvedValue({ success: true });
+      client.api.ingestion.batch = batch;
+
+      client.score.create({ name: "timeout-test", value: 1 });
+      await client.flush();
+
+      expect(batch).toHaveBeenCalledWith(
+        {
+          batch: [expect.objectContaining({ type: "score-create" })],
+        },
+        { timeoutInSeconds: 0.25 },
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Score ingestion ignored `LANGFUSE_TIMEOUT` and `LangfuseClient({ timeout })` because `ScoreManager` did not receive the client's resolved timeout. Generated ingestion requests therefore used their 60-second fallback during flush and shutdown.

Fixes #883.

## Changes

- Pass the resolved client timeout into `ScoreManager`.
- Apply it to score ingestion batch request options.
- Preserve the existing environment/default fallback for direct `ScoreManager` construction.
- Add regression coverage for the `LANGFUSE_TIMEOUT` path.

## Verification

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` (the repository-wide command includes server-backed E2E)
- [x] `pnpm test:integration`
- [ ] `pnpm test:e2e` (requires the Docker-based Langfuse server stack; delegated to CI)
- [x] `pnpm format:check`
- [x] `pnpm test:unit`
- [x] `pnpm build`

## Release info

### Bump level

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

- [ ] All of them
- [ ] @langfuse/core
- [ ] @langfuse/client
- [ ] @langfuse/tracing
- [ ] @langfuse/otel
- [ ] @langfuse/openai
- [ ] @langfuse/langchain

### Changelog notes

- Apply configured request timeouts to score ingestion batches.
