### PR TITLE
fix(docs): update JS SDK reference link

### DIFF
--- a/typedoc.config.cjs
+++ b/typedoc.config.cjs
@@ -14,6 +14,6 @@ module.exports = {
   name: "Langfuse JS/TS SDKs",
   navigationLinks: {
     GitHub: "http://github.com/langfuse/langfuse-js",
-    Docs: "https://langfuse.com/docs/sdk/typescript",
+    Docs: "https://langfuse.com/docs/observability/sdk/typescript/overview",
   },
 };


### PR DESCRIPTION
## Summary

- Update the JS SDK TypeDoc Docs navigation link to the canonical TypeScript SDK overview.
- Replace the legacy SDK URL so generated reference docs no longer point to the retired staging deployment.

## Validation

- `pnpm format:check`
- `pnpm run docs` (`Tasks: 8 successful, 8 total`)
- Pre-commit checks (`Tasks: 3 successful, 3 total`)

## Impacted packages

- Documentation generation (TypeDoc root configuration)