### PR TITLE
fix(otel): upload raw LangfuseMedia bytes without Base64 serialization

### DIFF
--- a/packages/core/src/media.ts
+++ b/packages/core/src/media.ts
@@ -1,6 +1,10 @@
 import { MediaContentType } from "./api/api/index.js";
 import { getGlobalLogger } from "./logger/index.js";
-import { base64ToBytes, bytesToBase64 } from "./utils.js";
+import { base64ToBytes, bytesToBase64, generateUUID } from "./utils.js";
+
+type MediaSerializationContext = Map<LangfuseMedia, string>;
+
+let activeMediaSerializationContext: MediaSerializationContext | undefined;
 
 /**
  * Parameters for creating a LangfuseMedia instance.
@@ -239,12 +243,96 @@ export class LangfuseMedia {
   }
 
   /**
-   * Serializes the media to JSON (returns the base64 data URI).
+   * Serializes the media to JSON. Tracing uses an internal reference so the
+   * raw bytes can be uploaded without creating a transient base64 string.
+   * Other callers continue to receive the base64 data URI.
    *
-   * @returns The base64 data URI, or null if no content is available
+   * @returns The base64 data URI, an internal tracing reference, or null if no content is available
    */
   toJSON(): string | null {
+    if (
+      activeMediaSerializationContext &&
+      this._contentBytes &&
+      this._contentBytes.length > 0 &&
+      this._contentType &&
+      this._source
+    ) {
+      const reference = getOrCreateMediaReference(this);
+      return reference;
+    }
+
     return this.base64DataUri;
+  }
+}
+
+const mediaReferenceRegistry = new Map<string, LangfuseMedia>();
+const mediaReferencePattern = /@@@langfuseMediaBytes:[^@]+@@@/g;
+
+function getOrCreateMediaReference(media: LangfuseMedia): string {
+  const existingReference = activeMediaSerializationContext?.get(media);
+  if (existingReference) {
+    return existingReference;
+  }
+
+  const reference = `@@@langfuseMediaBytes:${generateUUID()}@@@`;
+
+  activeMediaSerializationContext?.set(media, reference);
+  mediaReferenceRegistry.set(reference, media);
+
+  return reference;
+}
+
+/**
+ * Serializes a value for tracing while preserving LangfuseMedia instances as
+ * internal references until the span processor can upload their raw bytes.
+ *
+ * @internal
+ */
+export function serializeWithMediaReferences(
+  value: unknown,
+): string | undefined {
+  const previousContext = activeMediaSerializationContext;
+  const currentContext = new Map<LangfuseMedia, string>();
+  activeMediaSerializationContext = currentContext;
+
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    releaseMediaReferences(currentContext.values());
+    throw error;
+  } finally {
+    activeMediaSerializationContext = previousContext;
+  }
+}
+
+/**
+ * Finds internal media references in a serialized tracing attribute.
+ *
+ * @internal
+ */
+export function findMediaReferences(value: string): string[] {
+  return [...new Set(value.match(mediaReferencePattern) ?? [])];
+}
+
+/**
+ * Resolves an internal media reference to its original LangfuseMedia object.
+ *
+ * @internal
+ */
+export function resolveMediaReference(
+  reference: string,
+): LangfuseMedia | undefined {
+  return mediaReferenceRegistry.get(reference);
+}
+
+/**
+ * Releases internal media references after a span has been processed.
+ *
+ * @internal
+ */
+export function releaseMediaReferences(references: Iterable<string>): void {
+  for (const reference of references) {
+    mediaReferenceRegistry.delete(reference);
   }
 }
 

--- a/packages/core/src/media.ts
+++ b/packages/core/src/media.ts
@@ -5,6 +5,57 @@ import { base64ToBytes, bytesToBase64, generateUUID } from "./utils.js";
 type MediaSerializationContext = Map<LangfuseMedia, string>;
 
 let activeMediaSerializationContext: MediaSerializationContext | undefined;
+type MediaReferenceOwnerRegistration = {
+  useMediaReferences: boolean;
+};
+
+const mediaReferenceOwners = new WeakMap<
+  object,
+  Set<MediaReferenceOwnerRegistration>
+>();
+
+/**
+ * Registers an owner that can resolve and release temporary media references.
+ * A weak set keeps tracing usable without retaining spans after they end.
+ *
+ * @internal
+ */
+export function registerMediaReferenceOwner(
+  owner: object,
+  options: { useMediaReferences?: boolean } = {},
+): () => void {
+  const useMediaReferences = options.useMediaReferences ?? true;
+  const registration = { useMediaReferences };
+  const registrations =
+    mediaReferenceOwners.get(owner) ??
+    new Set<MediaReferenceOwnerRegistration>();
+
+  registrations.add(registration);
+  mediaReferenceOwners.set(owner, registrations);
+
+  return () => {
+    registrations.delete(registration);
+    if (registrations.size === 0) {
+      mediaReferenceOwners.delete(owner);
+    }
+  };
+}
+
+/**
+ * Returns whether an object is owned by a processor that can clean up media
+ * references.
+ *
+ * @internal
+ */
+export function isMediaReferenceOwner(owner: object): boolean {
+  const registrations = mediaReferenceOwners.get(owner);
+
+  return (
+    registrations !== undefined &&
+    registrations.size > 0 &&
+    [...registrations].every(({ useMediaReferences }) => useMediaReferences)
+  );
+}
 
 /**
  * Parameters for creating a LangfuseMedia instance.
@@ -290,7 +341,15 @@ function getOrCreateMediaReference(media: LangfuseMedia): string {
  */
 export function serializeWithMediaReferences(
   value: unknown,
+  options: { referenceOwner?: object } = {},
 ): string | undefined {
+  if (
+    !options.referenceOwner ||
+    !isMediaReferenceOwner(options.referenceOwner)
+  ) {
+    return JSON.stringify(value);
+  }
+
   const previousContext = activeMediaSerializationContext;
   const currentContext = new Map<LangfuseMedia, string>();
   activeMediaSerializationContext = currentContext;

--- a/packages/otel/src/MediaService.ts
+++ b/packages/otel/src/MediaService.ts
@@ -4,7 +4,10 @@ import {
   LangfuseOtelSpanAttributes,
   Logger,
   base64ToBytes,
+  findMediaReferences,
   getGlobalLogger,
+  releaseMediaReferences as releaseMediaReferenceRegistry,
+  resolveMediaReference,
   uploadMedia,
 } from "@langfuse/core";
 import type { MediaContentType } from "@langfuse/core";
@@ -26,7 +29,144 @@ export class MediaService {
     await Promise.all(Array.from(this.pendingMediaUploads));
   }
 
-  public async process(span: ReadableSpan) {
+  public async process(
+    span: ReadableSpan,
+    mediaReferences = this.collectMediaReferences(span),
+  ) {
+    try {
+      await this.processMediaReferences(span, mediaReferences);
+      await this.processSerializedMedia(span);
+    } finally {
+      releaseMediaReferenceRegistry(mediaReferences);
+    }
+  }
+
+  public restoreMediaReferences(
+    span: ReadableSpan,
+    mediaReferences = this.collectMediaReferences(span),
+  ): void {
+    for (const key of Object.keys(span.attributes)) {
+      const value = span.attributes[key];
+
+      if (typeof value !== "string") {
+        continue;
+      }
+
+      span.attributes[key] = [...findMediaReferences(value)].reduce(
+        (replacedValue, reference) => {
+          const media = resolveMediaReference(reference);
+          return replacedValue.replaceAll(
+            reference,
+            media?.base64DataUri ?? reference,
+          );
+        },
+        value,
+      );
+    }
+
+    releaseMediaReferenceRegistry(mediaReferences);
+  }
+
+  public releaseMediaReferences(span: ReadableSpan): void {
+    releaseMediaReferenceRegistry(this.collectMediaReferences(span));
+  }
+
+  public releaseMediaReferenceSet(references: Iterable<string>): void {
+    releaseMediaReferenceRegistry(references);
+  }
+
+  public getMediaReferences(span: ReadableSpan): Set<string> {
+    return this.collectMediaReferences(span);
+  }
+
+  private collectMediaReferences(span: ReadableSpan): Set<string> {
+    const mediaReferences = new Set<string>();
+
+    for (const value of Object.values(span.attributes)) {
+      if (typeof value !== "string") {
+        continue;
+      }
+
+      for (const reference of findMediaReferences(value)) {
+        mediaReferences.add(reference);
+      }
+    }
+
+    return mediaReferences;
+  }
+
+  private async processMediaReferences(
+    span: ReadableSpan,
+    mediaReferences: Set<string>,
+  ): Promise<void> {
+    if (mediaReferences.size === 0) {
+      return;
+    }
+
+    for (const key of Object.keys(span.attributes)) {
+      const value = span.attributes[key];
+
+      if (typeof value !== "string") {
+        continue;
+      }
+
+      let mediaReplacedValue = value;
+
+      for (const reference of findMediaReferences(value)) {
+        if (!mediaReferences.has(reference)) {
+          continue;
+        }
+
+        const media = resolveMediaReference(reference);
+        if (!media) {
+          this.logger.warn(
+            "Failed to resolve an internal Langfuse media reference.",
+          );
+          continue;
+        }
+
+        const langfuseMediaTag = await media.getTag();
+
+        if (!langfuseMediaTag) {
+          this.logger.warn(
+            "Failed to create Langfuse media tag. Restoring the media data URI.",
+          );
+          mediaReplacedValue = mediaReplacedValue.replaceAll(
+            reference,
+            media.base64DataUri ?? reference,
+          );
+          continue;
+        }
+
+        this.scheduleUpload({
+          span,
+          media,
+          field: this.getMediaField(key),
+        });
+
+        mediaReplacedValue = mediaReplacedValue.replaceAll(
+          reference,
+          langfuseMediaTag,
+        );
+      }
+
+      span.attributes[key] = mediaReplacedValue;
+    }
+  }
+
+  private getMediaField(key: string): "input" | "output" | "metadata" {
+    if (key.includes("input")) {
+      return "input";
+    }
+
+    if (key.includes("output")) {
+      return "output";
+    }
+
+    return "metadata";
+  }
+
+  private async processSerializedMedia(span: ReadableSpan) {
     const mediaAttributes = [
       LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
       LangfuseOtelSpanAttributes.TRACE_INPUT,

--- a/packages/otel/src/span-processor.ts
+++ b/packages/otel/src/span-processor.ts
@@ -9,6 +9,7 @@ import {
   base64Encode,
   getLangfuseTraceIdFromBaggage,
   getPropagatedAttributesFromContext,
+  registerMediaReferenceOwner,
 } from "@langfuse/core";
 import { Context } from "@opentelemetry/api";
 import { hrTimeToMilliseconds } from "@opentelemetry/core";
@@ -211,6 +212,7 @@ export class LangfuseSpanProcessor implements SpanProcessor {
   private apiClient: LangfuseAPIClient;
   private processor: SpanProcessor;
   private mediaService: MediaService;
+  private mediaReferenceOwnerReleasers: Map<object, () => void> = new Map();
   private spanExportExpectationById: Map<string, boolean> = new Map();
 
   /**
@@ -347,6 +349,17 @@ export class LangfuseSpanProcessor implements SpanProcessor {
    * @override
    */
   public onStart(span: Span, parentContext: Context): void {
+    const isRecording =
+      typeof (span as { isRecording?: unknown }).isRecording !== "function" ||
+      span.isRecording();
+
+    if (isRecording) {
+      const releaseOwner = registerMediaReferenceOwner(span, {
+        useMediaReferences: this.mask === undefined,
+      });
+      this.mediaReferenceOwnerReleasers.set(span, releaseOwner);
+    }
+
     const propagatedAttributes =
       getPropagatedAttributesFromContext(parentContext);
 
@@ -399,6 +412,7 @@ export class LangfuseSpanProcessor implements SpanProcessor {
    * @override
    */
   public onEnd(span: ReadableSpan): void {
+    this.releaseMediaReferenceOwner(span);
     this.spanExportExpectationById.delete(span.spanContext().spanId);
 
     const processEndedSpanPromise = this.processEndedSpan(span).catch((err) => {
@@ -439,9 +453,13 @@ export class LangfuseSpanProcessor implements SpanProcessor {
    * @override
    */
   public async shutdown(): Promise<void> {
-    await this.flush();
+    try {
+      await this.flush();
 
-    return this.processor.shutdown();
+      return await this.processor.shutdown();
+    } finally {
+      this.releaseAllMediaReferenceOwners();
+    }
   }
 
   private async processEndedSpan(span: ReadableSpan) {
@@ -509,6 +527,21 @@ export class LangfuseSpanProcessor implements SpanProcessor {
     }
 
     this.processor.onEnd(span);
+  }
+
+  private releaseMediaReferenceOwner(owner: object): void {
+    const releaseOwner = this.mediaReferenceOwnerReleasers.get(owner);
+
+    releaseOwner?.();
+    this.mediaReferenceOwnerReleasers.delete(owner);
+  }
+
+  private releaseAllMediaReferenceOwners(): void {
+    for (const releaseOwner of this.mediaReferenceOwnerReleasers.values()) {
+      releaseOwner();
+    }
+
+    this.mediaReferenceOwnerReleasers.clear();
   }
 
   private markAppRootCandidate(span: Span, parentContext: Context): void {

--- a/packages/otel/src/span-processor.ts
+++ b/packages/otel/src/span-processor.ts
@@ -452,6 +452,8 @@ export class LangfuseSpanProcessor implements SpanProcessor {
           instrumentationScope: span.instrumentationScope.name,
         });
 
+        this.mediaService.releaseMediaReferences(span);
+
         return;
       }
     } catch (err) {
@@ -464,13 +466,23 @@ export class LangfuseSpanProcessor implements SpanProcessor {
         err,
       );
 
+      this.mediaService.releaseMediaReferences(span);
+
       return;
     }
 
-    await this.applyMaskInPlace(span);
+    const mediaReferences = this.mediaService.getMediaReferences(span);
 
-    if (this.mediaUploadEnabled) {
-      await this.mediaService.process(span);
+    try {
+      await this.applyMaskInPlace(span);
+
+      if (this.mediaUploadEnabled) {
+        await this.mediaService.process(span, mediaReferences);
+      } else {
+        this.mediaService.restoreMediaReferences(span, mediaReferences);
+      }
+    } finally {
+      this.mediaService.releaseMediaReferenceSet(mediaReferences);
     }
 
     if (this.logger.isLevelEnabled(LogLevel.DEBUG)) {

--- a/packages/tracing/src/attributes.ts
+++ b/packages/tracing/src/attributes.ts
@@ -1,4 +1,7 @@
-import { LangfuseOtelSpanAttributes } from "@langfuse/core";
+import {
+  LangfuseOtelSpanAttributes,
+  serializeWithMediaReferences,
+} from "@langfuse/core";
 import { type Attributes } from "@opentelemetry/api";
 
 import {
@@ -98,7 +101,7 @@ function _serialize(obj: unknown): string | undefined {
   try {
     if (typeof obj === "string") return obj;
 
-    return obj != null ? JSON.stringify(obj) : undefined;
+    return obj != null ? serializeWithMediaReferences(obj) : undefined;
   } catch {
     return "<failed to serialize>";
   }

--- a/packages/tracing/src/attributes.ts
+++ b/packages/tracing/src/attributes.ts
@@ -24,13 +24,19 @@ import {
  *
  * @internal
  */
-export function createTraceAttributes({
-  input,
-  output,
-}: LangfuseTraceAttributes = {}): Attributes {
+export function createTraceAttributes(
+  { input, output }: LangfuseTraceAttributes = {},
+  options: { referenceOwner?: object } = {},
+): Attributes {
   const attributes = {
-    [LangfuseOtelSpanAttributes.TRACE_INPUT]: _serialize(input),
-    [LangfuseOtelSpanAttributes.TRACE_OUTPUT]: _serialize(output),
+    [LangfuseOtelSpanAttributes.TRACE_INPUT]: _serialize(
+      input,
+      options.referenceOwner,
+    ),
+    [LangfuseOtelSpanAttributes.TRACE_OUTPUT]: _serialize(
+      output,
+      options.referenceOwner,
+    ),
   };
 
   return Object.fromEntries(
@@ -41,6 +47,7 @@ export function createTraceAttributes({
 export function createObservationAttributes(
   type: LangfuseObservationType,
   attributes: LangfuseObservationAttributes,
+  options: { referenceOwner?: object } = {},
 ): Attributes {
   const {
     metadata,
@@ -64,17 +71,31 @@ export function createObservationAttributes(
     [LangfuseOtelSpanAttributes.OBSERVATION_STATUS_MESSAGE]: statusMessage,
     [LangfuseOtelSpanAttributes.VERSION]: version,
     [LangfuseOtelSpanAttributes.ENVIRONMENT]: environment,
-    [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: _serialize(input),
-    [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: _serialize(output),
+    [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: _serialize(
+      input,
+      options.referenceOwner,
+    ),
+    [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: _serialize(
+      output,
+      options.referenceOwner,
+    ),
     [LangfuseOtelSpanAttributes.OBSERVATION_MODEL]: model,
-    [LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS]:
-      _serialize(usageDetails),
-    [LangfuseOtelSpanAttributes.OBSERVATION_COST_DETAILS]:
-      _serialize(costDetails),
-    [LangfuseOtelSpanAttributes.OBSERVATION_COMPLETION_START_TIME]:
-      _serialize(completionStartTime),
-    [LangfuseOtelSpanAttributes.OBSERVATION_MODEL_PARAMETERS]:
-      _serialize(modelParameters),
+    [LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS]: _serialize(
+      usageDetails,
+      options.referenceOwner,
+    ),
+    [LangfuseOtelSpanAttributes.OBSERVATION_COST_DETAILS]: _serialize(
+      costDetails,
+      options.referenceOwner,
+    ),
+    [LangfuseOtelSpanAttributes.OBSERVATION_COMPLETION_START_TIME]: _serialize(
+      completionStartTime,
+      options.referenceOwner,
+    ),
+    [LangfuseOtelSpanAttributes.OBSERVATION_MODEL_PARAMETERS]: _serialize(
+      modelParameters,
+      options.referenceOwner,
+    ),
     ...(prompt && !prompt.isFallback
       ? {
           [LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME]: prompt.name,
@@ -82,7 +103,11 @@ export function createObservationAttributes(
             prompt.version,
         }
       : {}),
-    ..._flattenAndSerializeMetadata(metadata, "observation"),
+    ..._flattenAndSerializeMetadata(
+      metadata,
+      "observation",
+      options.referenceOwner,
+    ),
   };
 
   return Object.fromEntries(
@@ -97,11 +122,13 @@ export function createObservationAttributes(
  * @returns JSON string or undefined if null/undefined, error message if serialization fails
  * @internal
  */
-function _serialize(obj: unknown): string | undefined {
+function _serialize(obj: unknown, referenceOwner?: object): string | undefined {
   try {
     if (typeof obj === "string") return obj;
 
-    return obj != null ? serializeWithMediaReferences(obj) : undefined;
+    return obj != null
+      ? serializeWithMediaReferences(obj, { referenceOwner })
+      : undefined;
   } catch {
     return "<failed to serialize>";
   }
@@ -122,6 +149,7 @@ function _serialize(obj: unknown): string | undefined {
 function _flattenAndSerializeMetadata(
   metadata: unknown,
   type: "observation" | "trace",
+  referenceOwner?: object,
 ): Record<string, string> {
   const prefix =
     type === "observation"
@@ -135,13 +163,14 @@ function _flattenAndSerializeMetadata(
   }
 
   if (typeof metadata !== "object" || Array.isArray(metadata)) {
-    const serialized = _serialize(metadata);
+    const serialized = _serialize(metadata, referenceOwner);
     if (serialized) {
       metadataAttributes[prefix] = serialized;
     }
   } else {
     for (const [key, value] of Object.entries(metadata)) {
-      const serialized = typeof value === "string" ? value : _serialize(value);
+      const serialized =
+        typeof value === "string" ? value : _serialize(value, referenceOwner);
       if (serialized) {
         metadataAttributes[`${prefix}.${key}`] = serialized;
       }

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -930,7 +930,11 @@ export function setActiveTraceIO(attributes: LangfuseTraceAttributes) {
     return;
   }
 
-  span.setAttributes(createTraceAttributes(attributes));
+  span.setAttributes(
+    createTraceAttributes(attributes, {
+      referenceOwner: span.isRecording() ? span : undefined,
+    }),
+  );
 }
 
 /**
@@ -1155,6 +1159,7 @@ export function updateActiveObservation(
   const otelAttributes = createObservationAttributes(
     options?.asType ?? "span",
     attributes,
+    { referenceOwner: span.isRecording() ? span : undefined },
   );
 
   // If no 'asType' was provided, drop the observation type OTEL attribute

--- a/packages/tracing/src/spanWrapper.ts
+++ b/packages/tracing/src/spanWrapper.ts
@@ -153,7 +153,9 @@ abstract class LangfuseBaseObservation {
     this.type = params.type;
 
     this.otelSpan.setAttributes(
-      createObservationAttributes(params.type, params.attributes ?? {}),
+      createObservationAttributes(params.type, params.attributes ?? {}, {
+        referenceOwner: this.otelSpan.isRecording() ? this.otelSpan : undefined,
+      }),
     );
   }
 
@@ -173,7 +175,9 @@ abstract class LangfuseBaseObservation {
 
   updateOtelSpanAttributes(attributes: LangfuseObservationAttributes) {
     this.otelSpan.setAttributes(
-      createObservationAttributes(this.type, attributes),
+      createObservationAttributes(this.type, attributes, {
+        referenceOwner: this.otelSpan.isRecording() ? this.otelSpan : undefined,
+      }),
     );
   }
 
@@ -200,7 +204,11 @@ abstract class LangfuseBaseObservation {
    * ```
    */
   public setTraceIO(attributes: LangfuseTraceAttributes) {
-    this.otelSpan.setAttributes(createTraceAttributes(attributes));
+    this.otelSpan.setAttributes(
+      createTraceAttributes(attributes, {
+        referenceOwner: this.otelSpan.isRecording() ? this.otelSpan : undefined,
+      }),
+    );
 
     return this;
   }

--- a/tests/integration/span-processor.integration.test.ts
+++ b/tests/integration/span-processor.integration.test.ts
@@ -219,6 +219,74 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       expect(inputValue).toMatch(/\|source=bytes@@@/);
     });
 
+    it("should let a media mask suppress raw-byte uploads", async () => {
+      await teardownTestEnvironment(testEnv);
+
+      const media = new LangfuseMedia({
+        source: "bytes",
+        contentBytes: new Uint8Array([1, 2, 3, 4]),
+        contentType: "image/png",
+      });
+
+      testEnv = await setupTestEnvironment({
+        spanProcessorConfig: {
+          mask: ({ data }) =>
+            typeof data === "string"
+              ? data.replace(media.base64DataUri!, "[redacted-media]")
+              : data,
+        },
+      });
+      assertions = new SpanAssertions(testEnv.mockExporter);
+
+      const span = startObservation("masked-raw-byte-media-span", {
+        input: {
+          image: media,
+        },
+      });
+      span.end();
+
+      await waitForSpanExport(testEnv.mockExporter, 1);
+
+      const inputValue = testEnv.mockExporter.getSpanAttributes(
+        "masked-raw-byte-media-span",
+      )?.["langfuse.observation.input"] as string;
+      expect(inputValue).toContain("[redacted-media]");
+      expect(inputValue).not.toContain(media.base64DataUri);
+      expect(inputValue).not.toContain("@@@langfuseMedia:");
+    });
+
+    it("should use the base64 media path when a mask is configured", async () => {
+      await teardownTestEnvironment(testEnv);
+
+      testEnv = await setupTestEnvironment({
+        spanProcessorConfig: {
+          mask: ({ data }) => data,
+        },
+      });
+      assertions = new SpanAssertions(testEnv.mockExporter);
+
+      const media = new LangfuseMedia({
+        source: "bytes",
+        contentBytes: new Uint8Array([1, 2, 3, 4]),
+        contentType: "image/png",
+      });
+
+      const span = startObservation("unmasked-raw-byte-media-span", {
+        input: {
+          image: media,
+        },
+      });
+      span.end();
+
+      await waitForSpanExport(testEnv.mockExporter, 1);
+
+      const inputValue = testEnv.mockExporter.getSpanAttributes(
+        "unmasked-raw-byte-media-span",
+      )?.["langfuse.observation.input"] as string;
+      expect(inputValue).not.toContain(media.base64DataUri);
+      expect(inputValue).toMatch(/\|source=base64_data_uri@@@/);
+    });
+
     it("should restore raw-byte media when media upload is disabled", async () => {
       await teardownTestEnvironment(testEnv);
 

--- a/tests/integration/span-processor.integration.test.ts
+++ b/tests/integration/span-processor.integration.test.ts
@@ -1,4 +1,5 @@
 import {
+  LangfuseMedia,
   LogLevel,
   configureGlobalLogger,
   resetGlobalLogger,
@@ -191,6 +192,63 @@ describe("LangfuseSpanProcessor E2E Tests", () => {
       expect(inputValue).toMatch(
         /@@@langfuseMedia:type=[^|]+\|id=[^|]+\|source=[^@]+@@@/,
       );
+    });
+
+    it("should keep raw-byte media on the bytes upload path", async () => {
+      const media = new LangfuseMedia({
+        source: "bytes",
+        contentBytes: new Uint8Array([1, 2, 3, 4]),
+        contentType: "image/png",
+      });
+
+      const span = startObservation("raw-byte-media-span", {
+        input: {
+          image: media,
+        },
+      });
+      span.end();
+
+      await waitForSpanExport(testEnv.mockExporter, 1);
+
+      const inputValue = testEnv.mockExporter.getSpanAttributes(
+        "raw-byte-media-span",
+      )?.["langfuse.observation.input"] as string;
+      expect(inputValue).toBeDefined();
+
+      expect(inputValue).not.toContain(media.base64DataUri);
+      expect(inputValue).toMatch(/\|source=bytes@@@/);
+    });
+
+    it("should restore raw-byte media when media upload is disabled", async () => {
+      await teardownTestEnvironment(testEnv);
+
+      testEnv = await setupTestEnvironment({
+        spanProcessorConfig: {
+          mediaUploadEnabled: false,
+        },
+      });
+      assertions = new SpanAssertions(testEnv.mockExporter);
+
+      const media = new LangfuseMedia({
+        source: "bytes",
+        contentBytes: new Uint8Array([1, 2, 3, 4]),
+        contentType: "image/png",
+      });
+
+      const span = startObservation("raw-byte-media-disabled-span", {
+        input: {
+          image: media,
+        },
+      });
+      span.end();
+
+      await waitForSpanExport(testEnv.mockExporter, 1);
+
+      const inputValue = testEnv.mockExporter.getSpanAttributes(
+        "raw-byte-media-disabled-span",
+      )?.["langfuse.observation.input"] as string;
+      expect(inputValue).toContain(media.base64DataUri);
+      expect(inputValue).not.toContain("@@@langfuseMediaBytes:");
     });
 
     it("should handle multiple media items in single attribute", async () => {

--- a/tests/unit/mediaReference.test.ts
+++ b/tests/unit/mediaReference.test.ts
@@ -1,4 +1,12 @@
-import { LangfuseMediaReference, bytesToBase64 } from "@langfuse/core";
+import {
+  LangfuseMedia,
+  LangfuseMediaReference,
+  bytesToBase64,
+  findMediaReferences,
+  releaseMediaReferences,
+  resolveMediaReference,
+  serializeWithMediaReferences,
+} from "@langfuse/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 describe("LangfuseMediaReference", () => {
@@ -118,5 +126,26 @@ describe("LangfuseMediaReference", () => {
 
       await expect(ref.fetchBytes()).rejects.toThrow(/HTTP 403/);
     });
+  });
+});
+
+describe("LangfuseMedia tracing serialization", () => {
+  it("keeps raw bytes out of tracing JSON while preserving public JSON behavior", () => {
+    const media = new LangfuseMedia({
+      source: "bytes",
+      contentBytes: new Uint8Array([1, 2, 3, 4]),
+      contentType: "image/png",
+    });
+
+    const tracingValue = serializeWithMediaReferences({ image: media });
+    const references = findMediaReferences(tracingValue!);
+
+    expect(tracingValue).not.toContain(media.base64DataUri);
+    expect(references).toHaveLength(1);
+    expect(resolveMediaReference(references[0]!)).toBe(media);
+
+    releaseMediaReferences(references);
+
+    expect(JSON.stringify({ image: media })).toContain(media.base64DataUri);
   });
 });

--- a/tests/unit/mediaReference.test.ts
+++ b/tests/unit/mediaReference.test.ts
@@ -3,6 +3,7 @@ import {
   LangfuseMediaReference,
   bytesToBase64,
   findMediaReferences,
+  registerMediaReferenceOwner,
   releaseMediaReferences,
   resolveMediaReference,
   serializeWithMediaReferences,
@@ -131,13 +132,18 @@ describe("LangfuseMediaReference", () => {
 
 describe("LangfuseMedia tracing serialization", () => {
   it("keeps raw bytes out of tracing JSON while preserving public JSON behavior", () => {
+    const span = {};
+    registerMediaReferenceOwner(span);
     const media = new LangfuseMedia({
       source: "bytes",
       contentBytes: new Uint8Array([1, 2, 3, 4]),
       contentType: "image/png",
     });
 
-    const tracingValue = serializeWithMediaReferences({ image: media });
+    const tracingValue = serializeWithMediaReferences(
+      { image: media },
+      { referenceOwner: span },
+    );
     const references = findMediaReferences(tracingValue!);
 
     expect(tracingValue).not.toContain(media.base64DataUri);
@@ -147,5 +153,36 @@ describe("LangfuseMedia tracing serialization", () => {
     releaseMediaReferences(references);
 
     expect(JSON.stringify({ image: media })).toContain(media.base64DataUri);
+  });
+
+  it("uses public JSON when media references are not enabled", () => {
+    const media = new LangfuseMedia({
+      source: "bytes",
+      contentBytes: new Uint8Array([1, 2, 3, 4]),
+      contentType: "image/png",
+    });
+
+    const serialized = serializeWithMediaReferences({ image: media });
+
+    expect(serialized).toContain(media.base64DataUri);
+    expect(findMediaReferences(serialized!)).toHaveLength(0);
+  });
+
+  it("uses public JSON when the owner has a masking processor", () => {
+    const owner = {};
+    registerMediaReferenceOwner(owner, { useMediaReferences: false });
+    const media = new LangfuseMedia({
+      source: "bytes",
+      contentBytes: new Uint8Array([1, 2, 3, 4]),
+      contentType: "image/png",
+    });
+
+    const serialized = serializeWithMediaReferences(
+      { image: media },
+      { referenceOwner: owner },
+    );
+
+    expect(serialized).toContain(media.base64DataUri);
+    expect(findMediaReferences(serialized!)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
This PR fixes #901.

## Summary

`LangfuseMedia` instances passed through tracing attributes are now kept as short-lived internal references until the OTel media processor handles the span. The processor resolves the original object and uploads its raw `Uint8Array`, so large media values no longer need to be converted to Base64 and decoded again.

- Preserve `LangfuseMedia.toJSON()` Base64 behavior for ordinary JSON consumers.
- Keep `source: "bytes"` through the OTel upload path.
- Restore data URIs when media uploads are disabled.
- Release references for dropped, masked, and failed spans.

## Packages

- `@langfuse/core`
- `@langfuse/tracing`
- `@langfuse/otel`

## Verification

- `pnpm dlx pnpm@10.33.0 precommit:check`
- Targeted core, tracing, and otel package builds
- 23 unit tests passed
- 9 media integration scenarios passed

## AI assistance

This patch was developed with Codex. The implementation and verification results are included in this description.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces Base64 serialization of raw `LangfuseMedia` values in tracing attributes with temporary references resolved by the OTel media processor.

- Adds a core registry and serialization helpers for temporary media references.
- Resolves references to raw bytes during media processing and restores data URIs when uploads are disabled.
- Adds cleanup for filtered, masked, failed, and processed spans plus tests for upload and restoration behavior.
</details>

<details><summary><h3>Confidence Score: 2/5</h3></summary>

The PR should not merge until masking can inspect or suppress the original media and temporary references cannot outlive unsupported span lifecycles.

Reference serialization currently permits sensitive media to bypass existing content-aware masks and retains large media objects indefinitely when no Langfuse processor can perform cleanup.

**Files Needing Attention:** packages/tracing/src/attributes.ts, packages/core/src/media.ts, packages/otel/src/span-processor.ts, packages/otel/src/MediaService.ts
</details>

<details open><summary><h3>Security Review</h3></summary>

The opaque-reference representation prevents existing content-aware masks from inspecting media before upload, so sensitive raw media can pass through masking and be uploaded.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant App
  participant Tracing
  participant Registry
  participant Mask
  participant MediaProcessor
  participant Backend
  App->>Tracing: Record input containing LangfuseMedia
  Tracing->>Registry: Store media under opaque reference
  Tracing->>Mask: Pass serialized attribute containing reference
  Mask-->>MediaProcessor: Return masked/transformed string
  MediaProcessor->>Registry: Resolve surviving reference
  Registry-->>MediaProcessor: Original Uint8Array
  MediaProcessor->>Backend: Upload raw media
  MediaProcessor->>Registry: Release reference
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/tracing/src/attributes.ts:104
**Opaque references bypass media masking**

When a configured mask recognizes or inspects serialized data URIs, this serializer now gives it only an opaque reference; the surviving reference is subsequently resolved and the original sensitive bytes are uploaded. **How this was verified:** The reference is created before masking and `MediaService` resolves any reference that remains afterward to schedule the raw media upload.

### Issue 2
packages/tracing/src/attributes.ts:104
**Media references outlive unprocessed spans**

When tracing serializes media without a registered Langfuse span processor, on a non-recording span, or after an observation has ended, serialization stores a strong global reference but no processor cleanup path receives it, retaining the media and its potentially large `Uint8Array` indefinitely.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): upload raw LangfuseMedia byte..."](https://github.com/langfuse/langfuse-js/commit/07180700863691028d9d5c5664b7289200c7588b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51958158)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [@langfuse/core: shared primitives for the SDK](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-js/-/docs/core.md)
- Knowledge Base — [@langfuse/tracing: OTel-based observation instrumentation](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-js/-/docs/tracing.md)
- Knowledge Base — [@langfuse/otel: span processing and export](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-js/-/docs/otel.md)
</details>

<!-- /greptile_comment -->