### PR TITLE
fix(core): clean up abort listeners after requests

### DIFF
--- a/packages/core/src/api/core/fetcher/BinaryResponse.ts
+++ b/packages/core/src/api/core/fetcher/BinaryResponse.ts
@@ -1,4 +1,5 @@
 import { ResponseWithBody } from "./ResponseWithBody.js";
+import { withCleanup } from "./withCleanup.js";
 
 export type BinaryResponse = {
   /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
@@ -19,17 +20,39 @@ export type BinaryResponse = {
   bytes?(): Promise<Uint8Array>;
 };
 
-export function getBinaryResponse(response: ResponseWithBody): BinaryResponse {
+export function getBinaryResponse(
+  response: ResponseWithBody,
+  cleanup?: () => void,
+): BinaryResponse {
+  let stream: ReadableStream<Uint8Array> | undefined;
   const binaryResponse: BinaryResponse = {
     get bodyUsed() {
       return response.bodyUsed;
     },
-    stream: () => response.body,
-    arrayBuffer: response.arrayBuffer.bind(response),
-    blob: response.blob.bind(response),
+    stream: () => (stream ??= withCleanup(response.body, cleanup)),
+    arrayBuffer: async () => {
+      try {
+        return await response.arrayBuffer();
+      } finally {
+        cleanup?.();
+      }
+    },
+    blob: async () => {
+      try {
+        return await response.blob();
+      } finally {
+        cleanup?.();
+      }
+    },
   };
   if ("bytes" in response && typeof response.bytes === "function") {
-    binaryResponse.bytes = response.bytes.bind(response);
+    binaryResponse.bytes = async () => {
+      try {
+        return await response.bytes!();
+      } finally {
+        cleanup?.();
+      }
+    };
   }
 
   return binaryResponse;

--- a/packages/core/src/api/core/fetcher/Fetcher.ts
+++ b/packages/core/src/api/core/fetcher/Fetcher.ts
@@ -106,9 +106,10 @@ export async function fetcherImpl<R = unknown>(
     type: args.requestType === "json" ? "json" : "other",
   });
   const fetchFn = await getFetchFn();
+  let cleanup: (() => void) | undefined;
 
   try {
-    const response = await requestWithRetries(
+    const request = await requestWithRetries(
       async () =>
         makeRequest(
           fetchFn,
@@ -123,11 +124,17 @@ export async function fetcherImpl<R = unknown>(
         ),
       args.maxRetries,
     );
+    const response = request.response;
+    cleanup = request.cleanup;
 
     if (response.status >= 200 && response.status < 400) {
       return {
         ok: true,
-        body: (await getResponseBody(response, args.responseType)) as R,
+        body: (await getResponseBody(
+          response,
+          args.responseType,
+          cleanup,
+        )) as R,
         headers: response.headers,
         rawResponse: toRawResponse(response),
       };
@@ -137,12 +144,13 @@ export async function fetcherImpl<R = unknown>(
         error: {
           reason: "status-code",
           statusCode: response.status,
-          body: await getErrorResponseBody(response),
+          body: await getErrorResponseBody(response, cleanup),
         },
         rawResponse: toRawResponse(response),
       };
     }
   } catch (error) {
+    cleanup?.();
     if (args.abortSignal != null && args.abortSignal.aborted) {
       return {
         ok: false,

--- a/packages/core/src/api/core/fetcher/getErrorResponseBody.ts
+++ b/packages/core/src/api/core/fetcher/getErrorResponseBody.ts
@@ -3,35 +3,41 @@ import { getResponseBody } from "./getResponseBody.js";
 
 export async function getErrorResponseBody(
   response: Response,
+  cleanup?: () => void,
 ): Promise<unknown> {
-  let contentType = response.headers.get("Content-Type")?.toLowerCase();
-  if (contentType == null || contentType.length === 0) {
-    return getResponseBody(response);
-  }
+  try {
+    let contentType = response.headers.get("Content-Type")?.toLowerCase();
+    if (contentType == null || contentType.length === 0) {
+      return getResponseBody(response, undefined, cleanup);
+    }
 
-  if (contentType.indexOf(";") !== -1) {
-    contentType = contentType.split(";")[0]?.trim() ?? "";
-  }
-  switch (contentType) {
-    case "application/hal+json":
-    case "application/json":
-    case "application/ld+json":
-    case "application/problem+json":
-    case "application/vnd.api+json":
-    case "text/json":
-      const text = await response.text();
-      return text.length > 0 ? fromJson(text) : undefined;
-    default:
-      if (
-        contentType.startsWith("application/vnd.") &&
-        contentType.endsWith("+json")
-      ) {
+    if (contentType.indexOf(";") !== -1) {
+      contentType = contentType.split(";")[0]?.trim() ?? "";
+    }
+    switch (contentType) {
+      case "application/hal+json":
+      case "application/json":
+      case "application/ld+json":
+      case "application/problem+json":
+      case "application/vnd.api+json":
+      case "text/json": {
         const text = await response.text();
         return text.length > 0 ? fromJson(text) : undefined;
       }
+      default:
+        if (
+          contentType.startsWith("application/vnd.") &&
+          contentType.endsWith("+json")
+        ) {
+          const text = await response.text();
+          return text.length > 0 ? fromJson(text) : undefined;
+        }
 
-      // Fallback to plain text if content type is not recognized
-      // Even if no body is present, the response will be an empty string
-      return await response.text();
+        // Fallback to plain text if content type is not recognized
+        // Even if no body is present, the response will be an empty string
+        return await response.text();
+    }
+  } finally {
+    cleanup?.();
   }
 }

--- a/packages/core/src/api/core/fetcher/getResponseBody.ts
+++ b/packages/core/src/api/core/fetcher/getResponseBody.ts
@@ -1,46 +1,65 @@
 import { getBinaryResponse } from "./BinaryResponse.js";
 import { isResponseWithBody } from "./ResponseWithBody.js";
 import { fromJson } from "../json.js";
+import { withCleanup } from "./withCleanup.js";
 
 export async function getResponseBody(
   response: Response,
   responseType?: string,
+  cleanup?: () => void,
 ): Promise<unknown> {
   if (!isResponseWithBody(response)) {
+    cleanup?.();
     return undefined;
   }
   switch (responseType) {
     case "binary-response":
-      return getBinaryResponse(response);
+      return getBinaryResponse(response, cleanup);
     case "blob":
-      return await response.blob();
+      try {
+        return await response.blob();
+      } finally {
+        cleanup?.();
+      }
     case "arrayBuffer":
-      return await response.arrayBuffer();
+      try {
+        return await response.arrayBuffer();
+      } finally {
+        cleanup?.();
+      }
     case "sse":
-      return response.body;
+      return withCleanup(response.body, cleanup);
     case "streaming":
-      return response.body;
+      return withCleanup(response.body, cleanup);
 
     case "text":
-      return await response.text();
+      try {
+        return await response.text();
+      } finally {
+        cleanup?.();
+      }
   }
 
   // if responseType is "json" or not specified, try to parse as JSON
-  const text = await response.text();
-  if (text.length > 0) {
-    try {
-      let responseBody = fromJson(text);
-      return responseBody;
-    } catch (err) {
-      return {
-        ok: false,
-        error: {
-          reason: "non-json",
-          statusCode: response.status,
-          rawBody: text,
-        },
-      };
+  try {
+    const text = await response.text();
+    if (text.length > 0) {
+      try {
+        let responseBody = fromJson(text);
+        return responseBody;
+      } catch (err) {
+        return {
+          ok: false,
+          error: {
+            reason: "non-json",
+            statusCode: response.status,
+            rawBody: text,
+          },
+        };
+      }
     }
+    return undefined;
+  } finally {
+    cleanup?.();
   }
-  return undefined;
 }

--- a/packages/core/src/api/core/fetcher/makeRequest.ts
+++ b/packages/core/src/api/core/fetcher/makeRequest.ts
@@ -1,5 +1,10 @@
 import { anySignal, getTimeoutSignal } from "./signals.js";
 
+export interface MadeRequest {
+  response: Response;
+  cleanup: () => void;
+}
+
 export const makeRequest = async (
   fetchFn: (url: string, init: RequestInit) => Promise<Response>,
   url: string,
@@ -10,7 +15,7 @@ export const makeRequest = async (
   abortSignal?: AbortSignal,
   withCredentials?: boolean,
   duplex?: "half",
-): Promise<Response> => {
+): Promise<MadeRequest> => {
   const signals: AbortSignal[] = [];
 
   // Add timeout signal
@@ -25,10 +30,26 @@ export const makeRequest = async (
   if (abortSignal != null) {
     signals.push(abortSignal);
   }
-  const { signal: newSignals, cleanup } = anySignal(signals);
+  const { signal: newSignals, cleanup: cleanupSignals } = anySignal(signals);
+  let isCleanedUp = false;
+  const cleanup = () => {
+    if (isCleanedUp) {
+      return;
+    }
+
+    isCleanedUp = true;
+    newSignals.removeEventListener("abort", abortListener);
+    cleanupSignals();
+    if (timeoutAbortId != null) {
+      clearTimeout(timeoutAbortId);
+    }
+  };
+  const abortListener = () => cleanup();
+  newSignals.addEventListener("abort", abortListener);
+
   try {
-    return await fetchFn(url, {
-      method: method,
+    const response = await fetchFn(url, {
+      method,
       headers,
       body: requestBody,
       signal: newSignals,
@@ -36,10 +57,9 @@ export const makeRequest = async (
       // @ts-ignore
       duplex,
     });
-  } finally {
+    return { response, cleanup };
+  } catch (error) {
     cleanup();
-    if (timeoutAbortId != null) {
-      clearTimeout(timeoutAbortId);
-    }
+    throw error;
   }
 };

--- a/packages/core/src/api/core/fetcher/makeRequest.ts
+++ b/packages/core/src/api/core/fetcher/makeRequest.ts
@@ -25,20 +25,21 @@ export const makeRequest = async (
   if (abortSignal != null) {
     signals.push(abortSignal);
   }
-  let newSignals = anySignal(signals);
-  const response = await fetchFn(url, {
-    method: method,
-    headers,
-    body: requestBody,
-    signal: newSignals,
-    credentials: withCredentials ? "include" : undefined,
-    // @ts-ignore
-    duplex,
-  });
-
-  if (timeoutAbortId != null) {
-    clearTimeout(timeoutAbortId);
+  const { signal: newSignals, cleanup } = anySignal(signals);
+  try {
+    return await fetchFn(url, {
+      method: method,
+      headers,
+      body: requestBody,
+      signal: newSignals,
+      credentials: withCredentials ? "include" : undefined,
+      // @ts-ignore
+      duplex,
+    });
+  } finally {
+    cleanup();
+    if (timeoutAbortId != null) {
+      clearTimeout(timeoutAbortId);
+    }
   }
-
-  return response;
 };

--- a/packages/core/src/api/core/fetcher/requestWithRetries.ts
+++ b/packages/core/src/api/core/fetcher/requestWithRetries.ts
@@ -1,3 +1,5 @@
+import type { MadeRequest } from "./makeRequest.js";
+
 const INITIAL_RETRY_DELAY = 1000; // in milliseconds
 const MAX_RETRY_DELAY = 60000; // in milliseconds
 const DEFAULT_MAX_RETRIES = 2;
@@ -58,21 +60,32 @@ function getRetryDelayFromHeaders(
 }
 
 export async function requestWithRetries(
-  requestFn: () => Promise<Response>,
+  requestFn: () => Promise<MadeRequest>,
   maxRetries: number = DEFAULT_MAX_RETRIES,
-): Promise<Response> {
-  let response: Response = await requestFn();
+): Promise<MadeRequest> {
+  let request = await requestFn();
 
   for (let i = 0; i < maxRetries; ++i) {
-    if ([408, 429].includes(response.status) || response.status >= 500) {
+    if (
+      [408, 429].includes(request.response.status) ||
+      request.response.status >= 500
+    ) {
       // Get delay with appropriate jitter applied
-      const delay = getRetryDelayFromHeaders(response, i);
+      const delay = getRetryDelayFromHeaders(request.response, i);
+
+      try {
+        await request.response.body?.cancel();
+      } catch {
+        // The response body is only being discarded before retrying.
+      } finally {
+        request.cleanup();
+      }
 
       await new Promise((resolve) => setTimeout(resolve, delay));
-      response = await requestFn();
+      request = await requestFn();
     } else {
       break;
     }
   }
-  return response!;
+  return request;
 }

--- a/packages/core/src/api/core/fetcher/signals.ts
+++ b/packages/core/src/api/core/fetcher/signals.ts
@@ -15,9 +15,10 @@ export function getTimeoutSignal(timeoutMs: number): {
  *
  * Requires at least node.js 18.
  */
-export function anySignal(
-  ...args: AbortSignal[] | [AbortSignal[]]
-): AbortSignal {
+export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): {
+  signal: AbortSignal;
+  cleanup: () => void;
+} {
   // Allowing signals to be passed either as array
   // of signals or as multiple arguments.
   const signals = (
@@ -25,6 +26,23 @@ export function anySignal(
   ) as AbortSignal[];
 
   const controller = new AbortController();
+  const listeners: Array<{
+    signal: AbortSignal;
+    listener: () => void;
+  }> = [];
+  let isCleanedUp = false;
+
+  const cleanup = () => {
+    if (isCleanedUp) {
+      return;
+    }
+
+    isCleanedUp = true;
+    for (const { signal, listener } of listeners) {
+      signal.removeEventListener("abort", listener);
+    }
+    listeners.length = 0;
+  };
 
   for (const signal of signals) {
     if (signal.aborted) {
@@ -34,16 +52,18 @@ export function anySignal(
       break;
     }
 
+    const listener = () => {
+      controller.abort((signal as any)?.reason);
+      cleanup();
+    };
+
     // Listening for signals and removing the listeners
     // when at least one symbol is aborted.
-    signal.addEventListener(
-      "abort",
-      () => controller.abort((signal as any)?.reason),
-      {
-        signal: controller.signal,
-      },
-    );
+    signal.addEventListener("abort", listener, {
+      signal: controller.signal,
+    });
+    listeners.push({ signal, listener });
   }
 
-  return controller.signal;
+  return { signal: controller.signal, cleanup };
 }

--- a/packages/core/src/api/core/fetcher/withCleanup.ts
+++ b/packages/core/src/api/core/fetcher/withCleanup.ts
@@ -1,0 +1,47 @@
+export function withCleanup<T>(
+  stream: ReadableStream<T>,
+  cleanup?: () => void,
+): ReadableStream<T> {
+  if (cleanup == null) {
+    return stream;
+  }
+
+  const reader = stream.getReader();
+  let isFinished = false;
+
+  const finish = () => {
+    if (isFinished) {
+      return;
+    }
+
+    isFinished = true;
+    cleanup();
+  };
+
+  return new ReadableStream<T>({
+    async pull(controller) {
+      try {
+        const result = await reader.read();
+        if (result.done) {
+          finish();
+          reader.releaseLock();
+          controller.close();
+        } else {
+          controller.enqueue(result.value);
+        }
+      } catch (error) {
+        finish();
+        reader.releaseLock();
+        controller.error(error);
+      }
+    },
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason);
+      } finally {
+        finish();
+        reader.releaseLock();
+      }
+    },
+  });
+}

--- a/tests/unit/fetcher-signals.test.ts
+++ b/tests/unit/fetcher-signals.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+
+import { getEventListeners } from "node:events";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { LangfuseAPIClient } from "@langfuse/core";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("API request abort signal lifecycle", () => {
+  it("removes the caller's abort listener after a successful request", async () => {
+    const callerController = new AbortController();
+    vi.stubGlobal(
+      "fetch",
+      async () =>
+        new Response(JSON.stringify({ data: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const client = new LangfuseAPIClient({
+      environment: "https://cloud.langfuse.com",
+      username: "public-key",
+      password: "secret-key",
+    });
+
+    await client.prompts.list(
+      {},
+      { abortSignal: callerController.signal, maxRetries: 0 },
+    );
+
+    expect(getEventListeners(callerController.signal, "abort")).toHaveLength(0);
+  });
+
+  it("removes the caller's abort listener when the request fails", async () => {
+    const callerController = new AbortController();
+    vi.stubGlobal("fetch", async () => {
+      throw new Error("network failure");
+    });
+    const client = new LangfuseAPIClient({
+      environment: "https://cloud.langfuse.com",
+      username: "public-key",
+      password: "secret-key",
+    });
+
+    await expect(
+      client.prompts.list(
+        {},
+        { abortSignal: callerController.signal, maxRetries: 0 },
+      ),
+    ).rejects.toThrow("network failure");
+
+    expect(getEventListeners(callerController.signal, "abort")).toHaveLength(0);
+  });
+});

--- a/tests/unit/fetcher-signals.test.ts
+++ b/tests/unit/fetcher-signals.test.ts
@@ -5,12 +5,173 @@ import { getEventListeners } from "node:events";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { LangfuseAPIClient } from "@langfuse/core";
+import { fetcher } from "../../packages/core/src/api/core/fetcher/index.js";
 
 afterEach(() => {
   vi.unstubAllGlobals();
 });
 
 describe("API request abort signal lifecycle", () => {
+  it("keeps the caller's abort signal connected until a streaming response is cancelled", async () => {
+    const callerController = new AbortController();
+    let requestSignal: AbortSignal | undefined;
+    let responseBodyController:
+      | ReadableStreamDefaultController<Uint8Array>
+      | undefined;
+    let bodyAbortObserved = false;
+    let bodyFinished = false;
+
+    const responseBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        responseBodyController = controller;
+      },
+    });
+
+    vi.stubGlobal("fetch", async (_url: string, init: RequestInit) => {
+      requestSignal = init.signal;
+      requestSignal?.addEventListener("abort", () => {
+        bodyAbortObserved = true;
+        if (!bodyFinished) {
+          bodyFinished = true;
+          responseBodyController?.error(
+            new DOMException("The operation was aborted.", "AbortError"),
+          );
+        }
+      });
+      return new Response(responseBody, { status: 200 });
+    });
+
+    const result = await fetcher({
+      url: "https://cloud.langfuse.com/api/test",
+      method: "GET",
+      responseType: "streaming",
+      abortSignal: callerController.signal,
+      maxRetries: 0,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    const reader = (result.body as ReadableStream<Uint8Array>).getReader();
+    const readPromise = reader.read();
+
+    try {
+      expect(getEventListeners(callerController.signal, "abort")).toHaveLength(
+        1,
+      );
+      callerController.abort();
+
+      expect(requestSignal?.aborted).toBe(true);
+      expect(bodyAbortObserved).toBe(true);
+      await expect(readPromise).rejects.toThrow("aborted");
+    } finally {
+      if (!bodyFinished) {
+        bodyFinished = true;
+        responseBodyController?.error(
+          new DOMException("The operation was aborted.", "AbortError"),
+        );
+      }
+      await readPromise.catch(() => undefined);
+      reader.releaseLock();
+    }
+
+    expect(getEventListeners(callerController.signal, "abort")).toHaveLength(0);
+  });
+
+  it("cleans up a binary response after its body is consumed", async () => {
+    const callerController = new AbortController();
+    vi.stubGlobal(
+      "fetch",
+      async () => new Response(new Uint8Array([1, 2, 3]), { status: 200 }),
+    );
+
+    const result = await fetcher({
+      url: "https://cloud.langfuse.com/api/test",
+      method: "GET",
+      responseType: "binary-response",
+      abortSignal: callerController.signal,
+      maxRetries: 0,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(getEventListeners(callerController.signal, "abort")).toHaveLength(1);
+    await expect(
+      (
+        result.body as { arrayBuffer: () => Promise<ArrayBuffer> }
+      ).arrayBuffer(),
+    ).resolves.toEqual(new Uint8Array([1, 2, 3]).buffer);
+    expect(getEventListeners(callerController.signal, "abort")).toHaveLength(0);
+  });
+
+  it("keeps the caller's abort signal connected while the response body is consumed", async () => {
+    const callerController = new AbortController();
+    let requestSignal: AbortSignal | undefined;
+    let responseBodyController:
+      | ReadableStreamDefaultController<Uint8Array>
+      | undefined;
+    let bodyAbortObserved = false;
+    let bodyFinished = false;
+
+    const responseBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        responseBodyController = controller;
+      },
+    });
+
+    vi.stubGlobal("fetch", async (_url: string, init: RequestInit) => {
+      requestSignal = init.signal;
+      requestSignal?.addEventListener("abort", () => {
+        bodyAbortObserved = true;
+        if (!bodyFinished) {
+          bodyFinished = true;
+          responseBodyController?.error(
+            new DOMException("The operation was aborted.", "AbortError"),
+          );
+        }
+      });
+      return new Response(responseBody, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const client = new LangfuseAPIClient({
+      environment: "https://cloud.langfuse.com",
+      username: "public-key",
+      password: "secret-key",
+    });
+
+    const request = client.prompts.list(
+      {},
+      { abortSignal: callerController.signal, maxRetries: 0 },
+    );
+
+    try {
+      await vi.waitFor(() => expect(requestSignal).toBeDefined());
+      callerController.abort();
+
+      expect(requestSignal?.aborted).toBe(true);
+      expect(bodyAbortObserved).toBe(true);
+      await expect(request).rejects.toBeDefined();
+    } finally {
+      if (!bodyFinished) {
+        bodyFinished = true;
+        responseBodyController?.error(
+          new DOMException("The operation was aborted.", "AbortError"),
+        );
+      }
+      await request.catch(() => undefined);
+    }
+
+    expect(getEventListeners(callerController.signal, "abort")).toHaveLength(0);
+  });
+
   it("removes the caller's abort listener after a successful request", async () => {
     const callerController = new AbortController();
     vi.stubGlobal(


### PR DESCRIPTION
## Problem

Fixes #858.

`anySignal()` adds an abort listener to the caller's `AbortSignal` for each request. The listener was only removed when the internal combined signal aborted, so successful requests kept accumulating listeners when the same caller signal was reused. Failed requests also skipped timeout cleanup.

## Changes

- Return an idempotent cleanup function alongside the combined signal.
- Clean up composed abort listeners and timeout handles in `makeRequest`'s `finally` block.
- Add regression coverage through the public `LangfuseAPIClient.prompts.list` request path for successful and failed requests.

## Verification

- [x] `pnpm lint` (equivalent: repository ESLint command)
- [x] `pnpm typecheck` (equivalent: `tsc -b --noEmit`)
- [x] `pnpm test` targeted regression and full unit suite (103 tests passed)
- [ ] `pnpm test:integration` (not needed for this core request lifecycle change)
- [ ] `pnpm test:e2e` (not needed; requires a Langfuse server)
- [x] `pnpm format:check` (repository Prettier check)

## Release info

### Bump level

- [x] Patch

### Libraries affected

- [x] @langfuse/core

### Changelog notes

- Clean up abort listeners after requests settle.

This contribution was prepared with AI assistance; maintainer review remains pending.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds explicit, idempotent cleanup for composed abort listeners and ensures request timeout handles are cleared on both successful and failed fetches.
- Returns a cleanup callback alongside composed abort signals.
- Runs listener and timeout cleanup from makeRequest's finally block.
- Adds public-client regression tests for listener cleanup after successful and failed requests.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The response-lifecycle cancellation regression should be fixed before merging because caller aborts can no longer stop body downloads after headers arrive.

Cleanup correctly prevents listener accumulation, but it occurs at fetch promise settlement rather than at completion or cancellation of response-body consumption.

**Files Needing Attention:** packages/core/src/api/core/fetcher/makeRequest.ts
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Request as makeRequest
    participant Fetch
    participant Parser as Response parser/stream
    Caller->>Request: request(caller AbortSignal)
    Request->>Fetch: fetch(composed signal)
    Fetch-->>Request: Response headers
    Request->>Request: cleanup abort listeners
    Request-->>Parser: Response
    Parser->>Fetch: consume body
    Caller-->>Request: abort
    Note over Request,Fetch: Caller signal is no longer connected
    Fetch-->>Parser: Body continues downloading
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/core/src/api/core/fetcher/makeRequest.ts:40
**Abort detaches before body consumption**

When the caller aborts after response headers arrive but while the body is still being parsed or streamed, `cleanup()` has already disconnected the caller signal from the signal supplied to `fetch`, causing the body download or stream to continue despite cancellation.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(core): clean up abort listeners afte..."](https://github.com/langfuse/langfuse-js/commit/478c4fdf0f362e533933eec0f43354ac23032b85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51973157)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->