### PR TITLE
fix(langchain): preserve tool definitions in generation input

### DIFF
--- a/packages/langchain/src/CallbackHandler.ts
+++ b/packages/langchain/src/CallbackHandler.ts
@@ -339,17 +339,18 @@ export class CallbackHandler extends BaseCallbackHandler {
       this.deregisterLangfusePrompt(parentRunId);
     }
 
+    const tools = invocationParams?.tools;
+    const toolChoice = invocationParams?.tool_choice;
+    const hasTools =
+      tools != null && (!Array.isArray(tools) || tools.length > 0);
+    const hasToolChoice = toolChoice != null;
+
     const generationInput =
-      invocationParams &&
-      ("tools" in invocationParams || "tool_choice" in invocationParams)
+      hasTools || hasToolChoice
         ? {
             messages,
-            ...("tools" in invocationParams
-              ? { tools: invocationParams.tools }
-              : {}),
-            ...("tool_choice" in invocationParams
-              ? { tool_choice: invocationParams.tool_choice }
-              : {}),
+            ...(hasTools ? { tools } : {}),
+            ...(hasToolChoice ? { tool_choice: toolChoice } : {}),
           }
         : messages;
 

--- a/packages/langchain/src/CallbackHandler.ts
+++ b/packages/langchain/src/CallbackHandler.ts
@@ -288,34 +288,42 @@ export class CallbackHandler extends BaseCallbackHandler {
 
     const runName = name ?? llm.id.at(-1)?.toString() ?? "Langchain Generation";
 
+    interface InvocationParams {
+      _type?: string;
+      model?: string;
+      model_name?: string;
+      repo_id?: string;
+      temperature?: unknown;
+      max_tokens?: unknown;
+      top_p?: unknown;
+      frequency_penalty?: unknown;
+      presence_penalty?: unknown;
+      request_timeout?: unknown;
+      tools?: unknown;
+      tool_choice?: unknown;
+    }
+
+    const invocationParams = extraParams?.["invocation_params"] as
+      | InvocationParams
+      | undefined;
     const modelParameters: Record<string, any> = {};
-    const invocationParams = extraParams?.["invocation_params"];
 
     for (const [key, value] of Object.entries({
-      temperature: (invocationParams as any)?.temperature,
-      max_tokens: (invocationParams as any)?.max_tokens,
-      top_p: (invocationParams as any)?.top_p,
-      frequency_penalty: (invocationParams as any)?.frequency_penalty,
-      presence_penalty: (invocationParams as any)?.presence_penalty,
-      request_timeout: (invocationParams as any)?.request_timeout,
+      temperature: invocationParams?.temperature,
+      max_tokens: invocationParams?.max_tokens,
+      top_p: invocationParams?.top_p,
+      frequency_penalty: invocationParams?.frequency_penalty,
+      presence_penalty: invocationParams?.presence_penalty,
+      request_timeout: invocationParams?.request_timeout,
     })) {
       if (value !== undefined && value !== null) {
         modelParameters[key] = value;
       }
     }
 
-    interface InvocationParams {
-      _type?: string;
-      model?: string;
-      model_name?: string;
-      repo_id?: string;
-    }
-
     let extractedModelName: string | undefined;
-    if (extraParams) {
-      const invocationParamsModelName = (
-        extraParams.invocation_params as InvocationParams
-      ).model;
+    if (invocationParams) {
+      const invocationParamsModelName = invocationParams.model;
       const metadataModelName =
         metadata && "ls_model_name" in metadata
           ? (metadata["ls_model_name"] as string)
@@ -331,6 +339,20 @@ export class CallbackHandler extends BaseCallbackHandler {
       this.deregisterLangfusePrompt(parentRunId);
     }
 
+    const generationInput =
+      invocationParams &&
+      ("tools" in invocationParams || "tool_choice" in invocationParams)
+        ? {
+            messages,
+            ...("tools" in invocationParams
+              ? { tools: invocationParams.tools }
+              : {}),
+            ...("tool_choice" in invocationParams
+              ? { tool_choice: invocationParams.tool_choice }
+              : {}),
+          }
+        : messages;
+
     this.startAndRegisterOtelSpan({
       type: "generation",
       runId,
@@ -339,7 +361,7 @@ export class CallbackHandler extends BaseCallbackHandler {
       tags,
       runName,
       attributes: {
-        input: messages,
+        input: generationInput,
         model: extractedModelName,
         modelParameters: modelParameters,
         prompt: registeredPrompt,

--- a/tests/integration/langchain.integration.test.ts
+++ b/tests/integration/langchain.integration.test.ts
@@ -121,6 +121,20 @@ describe("LangChain callback handler integration tests", () => {
     );
   });
 
+  it("should treat undefined tools as absent", async () => {
+    await expect(
+      recordGeneration("generation-with-undefined-tools", {
+        tools: undefined,
+      }),
+    ).resolves.toEqual([{ content: "Find customer 123", role: "user" }]);
+  });
+
+  it("should treat an empty tools array as absent", async () => {
+    await expect(
+      recordGeneration("generation-with-empty-tools", { tools: [] }),
+    ).resolves.toEqual([{ content: "Find customer 123", role: "user" }]);
+  });
+
   it("should preserve tools in generation input", async () => {
     await expect(
       recordGeneration("generation-with-tools", { tools }),

--- a/tests/integration/langchain.integration.test.ts
+++ b/tests/integration/langchain.integration.test.ts
@@ -1,3 +1,4 @@
+import { HumanMessage } from "@langchain/core/messages";
 import { DynamicTool } from "@langchain/core/tools";
 import { CallbackHandler } from "@langfuse/langchain";
 import { LangfuseOtelSpanAttributes } from "@langfuse/tracing";
@@ -63,5 +64,93 @@ describe("LangChain callback handler integration tests", () => {
       LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT,
       "The result is: 100",
     );
+  });
+
+  const tools = [
+    {
+      type: "function",
+      function: {
+        name: "lookup_customer",
+        description: "Look up a customer by ID",
+        parameters: {
+          type: "object",
+          properties: { id: { type: "string" } },
+          required: ["id"],
+        },
+      },
+    },
+  ];
+
+  const recordGeneration = async (
+    runId: string,
+    invocationParams?: Record<string, unknown>,
+  ): Promise<unknown> => {
+    const handler = new CallbackHandler();
+
+    await handler.handleChatModelStart(
+      { id: ["langchain", "ChatOpenAI"] } as any,
+      [[new HumanMessage("Find customer 123")]],
+      runId,
+      undefined,
+      invocationParams
+        ? {
+            invocation_params: {
+              model: "gpt-4.1-mini",
+              ...invocationParams,
+            },
+          }
+        : undefined,
+    );
+    await handler.handleLLMEnd(
+      { generations: [[{ text: "Customer found" }]], llmOutput: {} } as any,
+      runId,
+    );
+
+    await waitForSpanExport(testEnv.mockExporter, 1);
+
+    return JSON.parse(
+      testEnv.mockExporter.getSpanByName("ChatOpenAI")?.attributes[
+        LangfuseOtelSpanAttributes.OBSERVATION_INPUT
+      ] as string,
+    );
+  };
+
+  it("should preserve the original messages input without tools", async () => {
+    await expect(recordGeneration("generation-without-tools")).resolves.toEqual(
+      [{ content: "Find customer 123", role: "user" }],
+    );
+  });
+
+  it("should preserve tools in generation input", async () => {
+    await expect(
+      recordGeneration("generation-with-tools", { tools }),
+    ).resolves.toEqual({
+      messages: [{ role: "user", content: "Find customer 123" }],
+      tools,
+    });
+  });
+
+  it("should preserve tool choice in generation input", async () => {
+    await expect(
+      recordGeneration("generation-with-tool-choice", {
+        tool_choice: "auto",
+      }),
+    ).resolves.toEqual({
+      messages: [{ role: "user", content: "Find customer 123" }],
+      tool_choice: "auto",
+    });
+  });
+
+  it("should preserve tools and tool choice in generation input", async () => {
+    await expect(
+      recordGeneration("generation-with-tools-and-choice", {
+        tools,
+        tool_choice: "auto",
+      }),
+    ).resolves.toEqual({
+      messages: [{ role: "user", content: "Find customer 123" }],
+      tools,
+      tool_choice: "auto",
+    });
   });
 });


### PR DESCRIPTION
## Problem

LangChain passes tool definitions and `tool_choice` through `invocation_params`, but `CallbackHandler` only retained the model parameter allowlist. As a result, Langfuse generations could not show the tools available to an agent or hydrate them in the Playground.

## Changes

- Preserve `tools` and `tool_choice` in generation input using the same structured shape as the OpenAI integration.
- Keep the existing messages-only input for generations without tool parameters.
- Add integration coverage for messages-only, tools-only, tool-choice-only, and combined inputs.

Closes #906

## Verification

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] Full integration suite via local Vitest with a temporary Windows-path alias config: 7 files, 318 tests passed
- [x] File-level ESLint for `CallbackHandler.ts` and `langchain.integration.test.ts`
- [x] File-level Prettier check
- [ ] Repository `pnpm lint` / `pnpm format:check`: blocked by existing CRLF findings across unchanged files on Windows
- [ ] Pre-commit hook: could not start because Git's shell could not resolve `pnpm`; the checks above were run independently

## Release info

### Bump level

- [x] Patch

### Libraries affected

- [x] @langfuse/langchain

### Changelog notes

- Preserve LangChain tool definitions and tool choice in generation input.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR preserves LangChain `tools` and `tool_choice` values in generation input while retaining the existing messages-array shape when neither parameter is present.
- Extends the invocation-parameter shape with tool-related fields.
- Emits OpenAI-compatible structured input for tool-enabled generations.
- Adds integration coverage for messages-only, tools-only, tool-choice-only, and combined inputs.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The new input shape passes through the existing tracing serialization path, preserves the prior messages-only behavior, and is covered by isolated integration tests for each supported parameter combination.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(langchain): preserve tool definition..."](https://github.com/langfuse/langfuse-js/commit/7ec0f4cff982268a9dc13dabbfb3db08567f3342) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52418000)</sub>

**Context used:**

- Knowledge Base — [LangChain CallbackHandler tracing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-js/-/docs/langchain.md)

<!-- /greptile_comment -->