### PR TITLE
fix(langchain): preserve tool configuration in generation input

### DIFF
--- a/packages/langchain/src/CallbackHandler.ts
+++ b/packages/langchain/src/CallbackHandler.ts
@@ -290,6 +290,8 @@ export class CallbackHandler extends BaseCallbackHandler {
 
     const modelParameters: Record<string, any> = {};
     const invocationParams = extraParams?.["invocation_params"];
+    const tools = (invocationParams as any)?.tools;
+    const toolChoice = (invocationParams as any)?.tool_choice;
 
     for (const [key, value] of Object.entries({
       temperature: (invocationParams as any)?.temperature,
@@ -339,7 +341,16 @@ export class CallbackHandler extends BaseCallbackHandler {
       tags,
       runName,
       attributes: {
-        input: messages,
+        input:
+          tools !== undefined || toolChoice !== undefined
+            ? {
+                messages,
+                ...(tools !== undefined ? { tools } : {}),
+                ...(toolChoice !== undefined
+                  ? { tool_choice: toolChoice }
+                  : {}),
+              }
+            : messages,
         model: extractedModelName,
         modelParameters: modelParameters,
         prompt: registeredPrompt,

--- a/tests/integration/langchain.integration.test.ts
+++ b/tests/integration/langchain.integration.test.ts
@@ -64,4 +64,78 @@ describe("LangChain callback handler integration tests", () => {
       "The result is: 100",
     );
   });
+
+  it("should include tools and tool choice in generation input", async () => {
+    const handler = new CallbackHandler();
+    const runId = "generation-with-tools";
+    const tools = [
+      {
+        type: "function",
+        function: {
+          name: "validate_customer",
+          description: "Validates a customer",
+          parameters: {
+            type: "object",
+            properties: { id: { type: "string" } },
+          },
+        },
+      },
+    ];
+
+    await handler.handleGenerationStart(
+      { id: ["ChatOpenAI"] },
+      [{ role: "user", content: "hi" }],
+      runId,
+      undefined,
+      {
+        invocation_params: {
+          model: "gpt-4.1-mini",
+          temperature: 0.2,
+          tools,
+          tool_choice: "auto",
+        },
+      },
+    );
+    await handler.handleLLMEnd({ generations: [[{ text: "ok" }]] }, runId);
+
+    await waitForSpanExport(testEnv.mockExporter, 1);
+
+    assertions.expectSpanAttributeContains(
+      "ChatOpenAI",
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+      '"name":"validate_customer"',
+    );
+    assertions.expectSpanAttributeContains(
+      "ChatOpenAI",
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+      '"tool_choice":"auto"',
+    );
+    assertions.expectSpanAttributeContains(
+      "ChatOpenAI",
+      LangfuseOtelSpanAttributes.OBSERVATION_MODEL_PARAMETERS,
+      '"temperature":0.2',
+    );
+  });
+
+  it("should preserve message-array input without tool configuration", async () => {
+    const handler = new CallbackHandler();
+    const runId = "generation-without-tools";
+
+    await handler.handleGenerationStart(
+      { id: ["ChatOpenAI"] },
+      [{ role: "user", content: "hi" }],
+      runId,
+      undefined,
+      { invocation_params: { model: "gpt-4.1-mini" } },
+    );
+    await handler.handleLLMEnd({ generations: [[{ text: "ok" }]] }, runId);
+
+    await waitForSpanExport(testEnv.mockExporter, 1);
+
+    assertions.expectSpanAttribute(
+      "ChatOpenAI",
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+      '[{"role":"user","content":"hi"}]',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- preserve LangChain `tools` and `tool_choice` in generation input
- match the OpenAI-compatible `{ messages, tools, tool_choice }` shape used by Playground hydration
- keep the existing message-array input shape when no tool configuration is present
- add integration regression coverage for both paths

## Context

Fixes [LFE-14966](https://linear.app/clickhouse/issue/LFE-14966/langchain-callbackhandler-drops-toolstool-choice-from-invocation).

LangChain provides tool configuration through `invocation_params`, but `CallbackHandler` previously recorded only the messages and an allowlist of scalar model parameters. As a result, traced generations lost the tool contract and Playground could not hydrate it.

## Impacted packages

- `@langfuse/langchain`

## Validation

- `pnpm turbo run build --filter=@langfuse/langchain... --cache-dir=/tmp/lfe-14966-turbo-cache`
- `pnpm turbo run build --filter=@langfuse/otel... --cache-dir=/tmp/lfe-14966-turbo-cache`
- `pnpm exec vitest run tests/integration/langchain.integration.test.ts --reporter=verbose`
- `pnpm check:type`
- repository pre-commit checks: lint, typecheck, and format

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR preserves LangChain tool configuration in generation inputs while retaining the existing message-array shape for calls without tools.
- Captures `tools` and `tool_choice` from LangChain invocation parameters.
- Emits the OpenAI-compatible `{ messages, tools, tool_choice }` input shape when applicable.
- Adds integration coverage for tool-enabled and tool-free generation inputs.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified.

The tool configuration is conditionally included in the generation input, existing tool-free behavior is preserved, serialization accepts the new object shape, and regression tests cover both paths.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(langchain): preserve tool configurat..."](https://github.com/langfuse/langfuse-js/commit/450e21b9bacb7a9b1e13f54a19b1e7f42b96ca91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52513014)</sub>

**Context used:**

- Knowledge Base — [LangChain CallbackHandler tracing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-js/-/docs/langchain.md)

<!-- /greptile_comment -->