### PR TITLE
perf(client): refill experiment concurrency slots

### DIFF
--- a/packages/client/src/experiment/ExperimentManager.ts
+++ b/packages/client/src/experiment/ExperimentManager.ts
@@ -186,7 +186,7 @@ export class ExperimentManager {
       runName: providedRunName,
       description,
       metadata,
-      maxConcurrency: batchSize = 50,
+      maxConcurrency = 50,
       runEvaluators,
     } = config;
 
@@ -202,49 +202,50 @@ export class ExperimentManager {
       );
     }
 
-    const itemResults: ExperimentItemResult<Input, ExpectedOutput, Metadata>[] =
-      [];
+    const itemResultsByIndex: Array<
+      ExperimentItemResult<Input, ExpectedOutput, Metadata> | undefined
+    > = new Array(data.length);
+    let nextIndex = 0;
 
-    for (let i = 0; i < data.length; i += batchSize) {
-      const batch = data.slice(i, i + batchSize);
+    const runNextItem = async () => {
+      while (nextIndex < data.length) {
+        const index = nextIndex++;
+        const item = data[index];
 
-      const promises: Promise<
-        ExperimentItemResult<Input, ExpectedOutput, Metadata>
-      >[] = batch.map(async (item) => {
-        return this.runItem({
-          item,
-          evaluators,
-          task,
-          experimentName: name,
-          experimentRunName: runName,
-          experimentDescription: description,
-          experimentMetadata: metadata,
-          fallbackExperimentId,
-          datasetVersion: config.datasetVersion,
-        });
-      });
+        try {
+          itemResultsByIndex[index] = await this.runItem({
+            item,
+            evaluators,
+            task,
+            experimentName: name,
+            experimentRunName: runName,
+            experimentDescription: description,
+            experimentMetadata: metadata,
+            fallbackExperimentId,
+            datasetVersion: config.datasetVersion,
+          });
+        } catch (reason) {
+          const errorMessage =
+            reason instanceof Error ? reason.message : String(reason);
+          this.logger.error(
+            `Task failed with error: ${errorMessage}. Skipping item.`,
+          );
+        }
+      }
+    };
 
-      const settledResults = await Promise.allSettled(promises);
-      const results = settledResults.reduce(
-        (acc, settledResult) => {
-          if (settledResult.status === "fulfilled") {
-            acc.push(settledResult.value);
-          } else {
-            const errorMessage =
-              settledResult.reason instanceof Error
-                ? settledResult.reason.message
-                : String(settledResult.reason);
-            this.logger.error(
-              `Task failed with error: ${errorMessage}. Skipping item.`,
-            );
-          }
-          return acc;
-        },
-        [] as ExperimentItemResult<Input, ExpectedOutput, Metadata>[],
-      );
+    const workers = Array.from(
+      { length: Math.min(maxConcurrency, data.length) },
+      runNextItem,
+    );
+    await Promise.all(workers);
 
-      itemResults.push(...results);
-    }
+    const itemResults = itemResultsByIndex.filter(
+      (
+        result,
+      ): result is ExperimentItemResult<Input, ExpectedOutput, Metadata> =>
+        result !== undefined,
+    );
 
     // Get dataset run URL
     const datasetRunId = itemResults.find(

--- a/tests/e2e/experiments.e2e.test.ts
+++ b/tests/e2e/experiments.e2e.test.ts
@@ -9,7 +9,7 @@ import { observeOpenAI } from "@langfuse/openai";
 import { Factuality, Levenshtein } from "autoevals";
 import { nanoid } from "nanoid";
 import OpenAI from "openai";
-import { describe, it, afterEach, beforeEach, expect } from "vitest";
+import { describe, it, afterEach, beforeEach, expect, vi } from "vitest";
 
 import {
   setupServerTestEnvironment,
@@ -436,6 +436,8 @@ describe("Langfuse Datasets E2E", () => {
         description: "Test mixed success/failure handling",
         data: dataset.slice(0, 2), // Germany and France
         task: mixedTask,
+        // This evaluator is unrelated to failure continuation, but preserves the
+        // existing AutoEvals/OpenAI coverage in this E2E test.
         evaluators: [createEvaluatorFromAutoevals(Factuality)],
       });
 
@@ -651,40 +653,81 @@ describe("Langfuse Datasets E2E", () => {
 
   // Concurrency and Performance Tests
   describe("Concurrency and Performance", () => {
-    it("should respect maxConcurrency parameter", async () => {
-      let concurrentCount = 0;
-      let maxConcurrentReached = 0;
-
-      const slowTask: ExperimentTask = async ({ input }) => {
-        concurrentCount++;
-        maxConcurrentReached = Math.max(maxConcurrentReached, concurrentCount);
-
-        // Simulate slow operation
-        await new Promise((resolve) => setTimeout(resolve, 100));
-
-        concurrentCount--;
-        return `Processed ${input}`;
-      };
-
-      const testData = Array.from({ length: 10 }, (_, i) => ({
-        input: `Item ${i}`,
-        expectedOutput: `Expected ${i}`,
+    it("refills concurrency slots before slower items complete", async () => {
+      const testData = ["first", "slow", "third", "fourth"].map((input) => ({
+        input,
       }));
+      const gates = new Map(
+        testData.map((item) => {
+          let resolve!: (value: string) => void;
+          const promise = new Promise<string>((resolvePromise) => {
+            resolve = resolvePromise;
+          });
 
-      const result = await langfuse.experiment.run({
-        name: "Concurrency test",
-        description: "Test maxConcurrency parameter",
+          return [item.input, { promise, resolve }] as const;
+        }),
+      );
+      const started: string[] = [];
+      let activeTasks = 0;
+      let maxActiveTasks = 0;
+
+      const runPromise = langfuse.experiment.run({
+        name: "Rolling concurrency test",
+        description: "Refills capacity after each completed item",
         data: testData,
-        task: slowTask,
-        maxConcurrency: 3,
+        maxConcurrency: 2,
+        task: async ({ input }) => {
+          started.push(input);
+          activeTasks += 1;
+          maxActiveTasks = Math.max(maxActiveTasks, activeTasks);
+
+          try {
+            return await gates.get(input)!.promise;
+          } finally {
+            activeTasks -= 1;
+          }
+        },
       });
 
-      await testEnv.spanProcessor.forceFlush();
-      await waitForServerIngestion(2000);
+      try {
+        await vi.waitFor(() => expect([...started]).toEqual(["first", "slow"]));
 
-      expect(result.itemResults).toHaveLength(10);
-      expect(maxConcurrentReached).toBeLessThanOrEqual(3);
-    }, 15000);
+        gates.get("first")!.resolve("first-output");
+        await vi.waitFor(() =>
+          expect([...started]).toEqual(["first", "slow", "third"]),
+        );
+        expect(activeTasks).toBe(2);
+
+        gates.get("third")!.resolve("third-output");
+        await vi.waitFor(() =>
+          expect([...started]).toEqual(["first", "slow", "third", "fourth"]),
+        );
+        expect(activeTasks).toBe(2);
+
+        gates.get("fourth")!.resolve("fourth-output");
+        gates.get("slow")!.resolve("slow-output");
+
+        const result = await runPromise;
+
+        expect(maxActiveTasks).toBe(2);
+        expect(result.itemResults.map(({ item }) => item.input)).toEqual([
+          "first",
+          "slow",
+          "third",
+          "fourth",
+        ]);
+
+        await testEnv.spanProcessor.forceFlush();
+        await waitForServerIngestion(2000);
+
+        const traceId = result.itemResults[0].traceId;
+        const trace = await langfuse.api.trace.get(traceId);
+        expect(trace.id).toBe(traceId);
+      } finally {
+        gates.forEach((gate, input) => gate.resolve(`${input}-output`));
+        await runPromise;
+      }
+    });
 
     it("should handle evaluators with different execution times", async () => {
       const fastEvaluator: Evaluator = async () => ({

--- a/tests/unit/ExperimentManager.test.ts
+++ b/tests/unit/ExperimentManager.test.ts
@@ -1,0 +1,96 @@
+import { ExperimentManager } from "@langfuse/client";
+import { getGlobalLogger } from "@langfuse/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+function createManager(): ExperimentManager {
+  return new ExperimentManager({
+    langfuseClient: {
+      score: {
+        create: vi.fn(),
+        flush: vi.fn().mockResolvedValue(undefined),
+      },
+    } as never,
+  });
+}
+
+describe("ExperimentManager concurrency", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starts the next item as soon as any in-flight item settles", async () => {
+    vi.spyOn(getGlobalLogger(), "warn").mockImplementation(() => {});
+
+    const gates = new Map(
+      ["first", "slow", "third", "fourth"].map((input) => [
+        input,
+        deferred<string>(),
+      ]),
+    );
+    const started: string[] = [];
+    let activeTasks = 0;
+    let maxActiveTasks = 0;
+
+    const runPromise = createManager().run({
+      name: "rolling-concurrency",
+      runName: "rolling-concurrency",
+      data: Array.from(gates.keys(), (input) => ({ input })),
+      maxConcurrency: 2,
+      task: async ({ input }) => {
+        started.push(input);
+        activeTasks += 1;
+        maxActiveTasks = Math.max(maxActiveTasks, activeTasks);
+
+        const output = await gates.get(input)!.promise;
+        activeTasks -= 1;
+        return output;
+      },
+    });
+
+    try {
+      await vi.waitFor(() => expect([...started]).toEqual(["first", "slow"]));
+
+      gates.get("first")!.resolve("first-output");
+      await vi.waitFor(() =>
+        expect([...started]).toEqual(["first", "slow", "third"]),
+      );
+      expect(activeTasks).toBe(2);
+
+      gates.get("third")!.resolve("third-output");
+      await vi.waitFor(() =>
+        expect([...started]).toEqual(["first", "slow", "third", "fourth"]),
+      );
+      expect(activeTasks).toBe(2);
+
+      gates.get("fourth")!.resolve("fourth-output");
+      gates.get("slow")!.resolve("slow-output");
+
+      const result = await runPromise;
+
+      expect(maxActiveTasks).toBe(2);
+      expect(result.itemResults.map(({ item }) => item.input)).toEqual([
+        "first",
+        "slow",
+        "third",
+        "fourth",
+      ]);
+    } finally {
+      gates.forEach((gate, input) => gate.resolve(`${input}-output`));
+      await runPromise;
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Experiment batches leave concurrency slots idle until the whole batch settles.

## Change

Use a rolling worker pool while preserving the cap, source ordering, per-item failures, evaluators, tracing, and API. Add deterministic unit and compiled-client/real-server E2E coverage.

## Verification

- ✅ `pnpm build`; unit 102/102; integration 316/316
- ✅ lint, typecheck, format, diff check, and commit hooks
- ✅ rolling-refill E2E, real trace readback, and restored OpenAI/AutoEvals failure E2E
- ✅ red/green proof: regression fails with fixed batching and passes with the worker pool
- ⚠️ experiments E2E 23/24: unchanged `<2s` timing test passed isolated at 1.882s
- ⚠️ full E2E 160/165: four unrelated v4 pricing assertions; one ingestion flake passed on retry
- ⚠️ `pnpm run ci` 578/583: the four pricing assertions plus the same timing test

Patch release: `@langfuse/client`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces fixed experiment batches with a rolling worker pool that refills each concurrency slot as soon as an item settles while retaining source-ordered results and per-item failure handling.

- Preallocates indexed result storage and filters failed items after all workers finish.
- Adds deterministic unit and real-server E2E coverage for slot refilling, concurrency limits, result ordering, and trace persistence.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The rolling workers preserve the configured cap, continue after individual failures, store successful results by source index, and wait for all workers before run-level evaluation and score flushing.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Initialize shared nextIndex and indexed results] --> B[Start up to maxConcurrency workers]
  B --> C{Unclaimed data remains?}
  C -->|Yes| D[Claim next index]
  D --> E[Run task and evaluators]
  E -->|Success| F[Store result at source index]
  E -->|Failure| G[Log and leave index empty]
  F --> C
  G --> C
  C -->|No| H[Worker completes]
  H --> I[Await all workers]
  I --> J[Filter empty entries while preserving source order]
  J --> K[Run run-level evaluators and flush scores]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["perf(client): refill experiment concurre..."](https://github.com/langfuse/langfuse-js/commit/a059734e07d962306e55bc903b0764dc9486bf5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52741553)</sub>

**Context used:**

- Knowledge Base — [LangfuseClient: prompts, datasets, experiments, scores, media](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-js/-/docs/client.md)

<!-- /greptile_comment -->