### PR TITLE
fix(langchain): serialize tool messages with role tool and preserve tool_call_id

### DIFF
--- a/packages/langchain/src/CallbackHandler.ts
+++ b/packages/langchain/src/CallbackHandler.ts
@@ -967,14 +967,20 @@ export class CallbackHandler extends BaseCallbackHandler {
       response = {
         content: message.content,
         additional_kwargs: message.additional_kwargs,
-        role: message.name,
+        role: "function",
       };
+      if (message.name) {
+        (response as any)["name"] = message.name;
+      }
     } else if (message.getType() === "tool") {
       response = {
         content: message.content,
         additional_kwargs: message.additional_kwargs,
-        role: message.name,
+        role: "tool",
       };
+      if ("tool_call_id" in message) {
+        (response as any)["tool_call_id"] = message["tool_call_id"];
+      }
     } else if (!message.name) {
       response = { content: message.content };
     } else {

--- a/tests/integration/langchain.integration.test.ts
+++ b/tests/integration/langchain.integration.test.ts
@@ -1,3 +1,4 @@
+import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages";
 import { DynamicTool } from "@langchain/core/tools";
 import { CallbackHandler } from "@langfuse/langchain";
 import { LangfuseOtelSpanAttributes } from "@langfuse/tracing";
@@ -114,6 +115,53 @@ describe("LangChain callback handler integration tests", () => {
       "ChatOpenAI",
       LangfuseOtelSpanAttributes.OBSERVATION_MODEL_PARAMETERS,
       '"temperature":0.2',
+    );
+  });
+
+  it("should serialize tool result messages with role tool and tool_call_id", async () => {
+    const handler = new CallbackHandler();
+    const runId = "generation-with-tool-result";
+
+    await handler.handleChatModelStart(
+      { id: ["ChatOpenAI"] } as never,
+      [
+        [
+          new HumanMessage("What is my updated debt?"),
+          new AIMessage({
+            content: "",
+            additional_kwargs: {
+              tool_calls: [
+                {
+                  id: "call_1",
+                  type: "function",
+                  function: { name: "get_debt", arguments: "{}" },
+                },
+              ],
+            },
+          }),
+          new ToolMessage({
+            content: '{"amount":1874.32}',
+            tool_call_id: "call_1",
+          }),
+        ],
+      ],
+      runId,
+      undefined,
+      { invocation_params: { model: "gpt-4.1-mini" } },
+    );
+    await handler.handleLLMEnd({ generations: [[{ text: "ok" }]] }, runId);
+
+    await waitForSpanExport(testEnv.mockExporter, 1);
+
+    assertions.expectSpanAttributeContains(
+      "ChatOpenAI",
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+      '"role":"tool"',
+    );
+    assertions.expectSpanAttributeContains(
+      "ChatOpenAI",
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+      '"tool_call_id":"call_1"',
     );
   });
 


### PR DESCRIPTION
## Problem

Fixes #930.

`extractChatMessageContent` serializes `ToolMessage`s with `role: message.name`. Since `name` is optional on `ToolMessage` (and idiomatic usage `new ToolMessage({ content, tool_call_id })` doesn't set it), the stored message ends up with no role at all — and when `name` IS set, the role becomes the tool's function name instead of a valid ChatML role. On top of that, `tool_call_id` is dropped entirely: it's a top-level field on `ToolMessage`, not part of `additional_kwargs`.

**Impact:** "Open in Playground" is broken for any generation whose history contains tool results. The web playground converter (`web/src/utils/chatml/playgroundConverter.ts`) only maps a message to `ToolResult` when it finds a `tool_call_id`, and otherwise falls back to `role || ChatMessageRole.Assistant` — so tool results render as plain assistant messages and re-running the completion fails (no tool linkage).

## Fix

- `ToolMessage` → `{ role: "tool", content, tool_call_id, additional_kwargs }`
- `FunctionMessage` (same pattern one branch above) → `{ role: "function", name, content, additional_kwargs }`

## Testing

Added an integration test in `tests/integration/langchain.integration.test.ts` following the pattern from #910: drives `handleChatModelStart` with a real `HumanMessage`/`AIMessage(tool_calls)`/`ToolMessage` history and asserts the exported `OBSERVATION_INPUT` contains `"role":"tool"` and `"tool_call_id":"call_1"`.

```
✓ tests/integration/langchain.integration.test.ts (4 tests)
```

`pnpm run lint`, `tsc -b --noEmit` and `prettier --check` all pass (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR corrects LangChain function and tool message serialization so each receives a valid ChatML role, while preserving function names and tool-call identifiers as separate fields.
- Serializes `FunctionMessage` with role `function` and its optional name.
- Serializes `ToolMessage` with role `tool` and preserves `tool_call_id`.
- Adds an integration test covering exported tool-result history.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The changed serializer now emits valid function and tool roles and preserves the tool-call linkage required by downstream consumers, with integration coverage for the primary regression.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(langchain): serialize tool messages ..."](https://github.com/langfuse/langfuse-js/commit/62c231490626745cb13afadce45df3573f9e0b9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59294151)</sub>

**Context used:**

- Knowledge Base — [LangChain callback integration](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-js/-/docs/langchain-integration.md)

<!-- /greptile_comment -->