### PR TITLE
fix(client): apply configured timeout to score ingestion requests

### DIFF
--- a/packages/client/src/LangfuseClient.ts
+++ b/packages/client/src/LangfuseClient.ts
@@ -314,7 +314,7 @@ export class LangfuseClient {
 
     this.prompt = new PromptManager({ apiClient: this.api });
     this.dataset = new DatasetManager({ langfuseClient: this });
-    this.score = new ScoreManager({ apiClient: this.api });
+    this.score = new ScoreManager({ apiClient: this.api, timeoutSeconds });
     this.media = new MediaManager({ apiClient: this.api });
     this.experiment = new ExperimentManager({ langfuseClient: this });
 

--- a/packages/client/src/score/index.ts
+++ b/packages/client/src/score/index.ts
@@ -30,15 +30,22 @@ export class ScoreManager {
   private flushTimer: any = null;
   private flushAtCount: number;
   private flushIntervalSeconds: number;
+  private timeoutSeconds?: number;
 
   /**
    * Creates a new ScoreManager instance.
    *
-   * @param params - Configuration object containing the API client
+   * @param params - Configuration object containing the API client and the
+   * request timeout in seconds. When no timeout is given, requests fall back
+   * to the API client's generated default.
    * @internal
    */
-  constructor(params: { apiClient: LangfuseAPIClient }) {
+  constructor(params: {
+    apiClient: LangfuseAPIClient;
+    timeoutSeconds?: number;
+  }) {
     this.apiClient = params.apiClient;
+    this.timeoutSeconds = params.timeoutSeconds;
 
     const envFlushAtCount = getEnv("LANGFUSE_FLUSH_AT");
     const envFlushIntervalSeconds = getEnv("LANGFUSE_FLUSH_INTERVAL");
@@ -283,7 +290,7 @@ export class ScoreManager {
 
         promises.push(
           this.apiClient.ingestion
-            .batch({ batch })
+            .batch({ batch }, { timeoutInSeconds: this.timeoutSeconds })
             .then((res) => {
               if (res.errors?.length > 0) {
                 this.logger.error("Error ingesting scores:", res.errors);

--- a/tests/unit/score-ingestion-timeout.test.ts
+++ b/tests/unit/score-ingestion-timeout.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { LangfuseAPIClient } from "@langfuse/core";
+import { LangfuseClient, ScoreManager } from "@langfuse/client";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const sampleScore = {
+  traceId: "trace-id",
+  name: "quality",
+  value: 0.9,
+};
+
+describe("ScoreManager ingestion timeout", () => {
+  it("forwards the configured timeout as request option", async () => {
+    const batch = vi.fn(async () => ({ responses: [], errors: [] }));
+    const apiClient = {
+      ingestion: { batch },
+    } as unknown as LangfuseAPIClient;
+
+    const manager = new ScoreManager({ apiClient, timeoutSeconds: 3 });
+    manager.create(sampleScore);
+    await manager.flush();
+
+    expect(batch).toHaveBeenCalledOnce();
+    const [, requestOptions] = batch.mock.calls[0];
+    expect(requestOptions).toMatchObject({ timeoutInSeconds: 3 });
+  });
+
+  it("keeps the generated fallback when no timeout is configured", async () => {
+    const batch = vi.fn(async () => ({ responses: [], errors: [] }));
+    const apiClient = {
+      ingestion: { batch },
+    } as unknown as LangfuseAPIClient;
+
+    const manager = new ScoreManager({ apiClient });
+    manager.create(sampleScore);
+    await manager.flush();
+
+    expect(batch).toHaveBeenCalledOnce();
+    const [, requestOptions] = batch.mock.calls[0];
+    expect(requestOptions?.timeoutInSeconds).toBeUndefined();
+  });
+
+  it("aborts a hanging ingestion request after the configured client timeout", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (_url, init) =>
+          new Promise((_resolve, reject) => {
+            capturedSignal = init?.signal;
+            capturedSignal?.addEventListener("abort", () =>
+              reject(capturedSignal?.reason),
+            );
+          }),
+      ),
+    );
+
+    const client = new LangfuseClient({
+      publicKey: "public-key",
+      secretKey: "secret-key",
+      baseUrl: "https://example.com",
+      timeout: 1,
+    });
+
+    client.score.create(sampleScore);
+
+    const startedAt = Date.now();
+    // The flush awaits the hung request; the abort is what lets it settle.
+    await client.score.flush();
+    const elapsed = Date.now() - startedAt;
+
+    expect(capturedSignal).toBeDefined();
+    expect(elapsed).toBeLessThan(5000);
+    expect(elapsed).toBeGreaterThanOrEqual(900);
+  });
+});


### PR DESCRIPTION
TL;DR: `LANGFUSE_TIMEOUT` (and `LangfuseClient({ timeout })`) now applies to ScoreManager ingestion requests instead of being silently ignored.

## Problem

#883 reported (and is still open): `LangfuseClient` computes `timeoutSeconds = params?.timeout ?? Number(getEnv("LANGFUSE_TIMEOUT") ?? 5)` but only uses it in a debug log. `ScoreManager` calls `this.apiClient.ingestion.batch({ batch })` without request options, so the Fern-generated client applies its 60s fallback. During a transient hang of a self-hosted `/api/public/ingestion`, a CLI process stayed alive far beyond the configured one-second timeout while flushing scores.

## Fix

- `ScoreManager` accepts `timeoutSeconds` and passes `{ timeoutInSeconds }` as request options to `ingestion.batch`. When unset, the generated 60s fallback is preserved (request option stays `undefined`).
- `LangfuseClient` forwards its configured `timeoutSeconds` to `ScoreManager`.

No generated file is touched: the timeout flows through the existing `RequestOptions.timeoutInSeconds` contract.

## Evidence

New test `tests/unit/score-ingestion-timeout.test.ts`:

**Before the fix** (test run against the bug):

```
FAIL  ... > forwards the configured timeout as request option
FAIL  ... > aborts a hanging ingestion request after the configured client timeout
Error: Test timed out in 5000ms.   <- the reported behavior: flush hangs past the configured timeout
Tests  2 failed | 1 passed (3)
```

**After the fix**:

```
✓ tests/unit/score-ingestion-timeout.test.ts (3 tests) 1008ms
     ✓ aborts a hanging ingestion request after the configured client timeout  1005ms
Test Files  1 passed (1)
     Tests  3 passed (3)
```

The abort test reproduces the issue scenario end to end: a real `LangfuseClient({ timeout: 1 })` with a hanging `fetch` now settles at the configured second instead of blocking.

Full unit suite: `Tests 105 passed (105)` (12 files). `pnpm lint` and `pnpm typecheck` clean (`typecheck` requires built `@langfuse/core` / `@langfuse/tracing` dists first).

CLA is signed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR applies the configured client timeout to buffered score-ingestion requests while retaining the generated timeout fallback for directly constructed managers without a timeout.
- Forwards `LangfuseClient`’s computed timeout to `ScoreManager`.
- Passes the timeout through the generated ingestion client’s existing request-options contract.
- Adds tests for propagation, fallback behavior, and aborting a hanging request.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The configured timeout is forwarded through the generated request-options contract, and an undefined value still selects the existing 60-second transport fallback.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(client): apply configured timeout to..."](https://github.com/langfuse/langfuse-js/commit/749d622a50ea0d58f3d60c037fa1161fe99d793e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59656893)</sub>

<!-- /greptile_comment -->