### PR TITLE
fix(core): support URL-safe Base64 media data URIs

### DIFF
--- a/packages/core/src/media.ts
+++ b/packages/core/src/media.ts
@@ -128,7 +128,8 @@ export class LangfuseMedia {
         throw new Error("Content type is empty");
       }
 
-      return [base64ToBytes(actualData), contentType as MediaContentType];
+      const normalizedData = actualData.replace(/-/g, "+").replace(/_/g, "/");
+      return [base64ToBytes(normalizedData), contentType as MediaContentType];
     } catch (error) {
       getGlobalLogger().error("Error parsing base64 data URI", error);
       return [undefined, undefined];

--- a/tests/unit/media.test.ts
+++ b/tests/unit/media.test.ts
@@ -1,0 +1,39 @@
+import { LangfuseMedia } from "@langfuse/client";
+import { describe, expect, it } from "vitest";
+
+describe("LangfuseMedia Base64 data URIs", () => {
+  it.each([
+    ["-w==", "+w==", [251]],
+    ["_w==", "/w==", [255]],
+    ["-_8=", "+/8=", [251, 255]],
+    ["+/8=", "+/8=", [251, 255]],
+  ])("decodes %s to the original bytes", async (encoded, standard, bytes) => {
+    const media = new LangfuseMedia({
+      source: "base64_data_uri",
+      base64DataUri: `data:image/png;base64,${encoded}`,
+    });
+    const expected = new LangfuseMedia({
+      source: "bytes",
+      contentType: "image/png",
+      contentBytes: new Uint8Array(bytes),
+    });
+
+    expect(media._contentBytes).toEqual(new Uint8Array(bytes));
+    expect(media.base64DataUri).toBe(`data:image/png;base64,${standard}`);
+    expect(await media.getId()).toBe(await expected.getId());
+  });
+
+  it.each(["!w==", "A", "-_8==="])(
+    "keeps invalid Base64 %s invalid",
+    async (encoded) => {
+      const media = new LangfuseMedia({
+        source: "base64_data_uri",
+        base64DataUri: `data:image/png;base64,${encoded}`,
+      });
+
+      expect(media._contentBytes).toBeUndefined();
+      expect(media.base64DataUri).toBeNull();
+      expect(await media.getId()).toBeNull();
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Fixes LFE-15471: https://linear.app/clickhouse/issue/LFE-15471/support-url-safe-base64-media-data-uris-in-the-js-sdk

`LangfuseMedia` currently rejects URL-safe Base64 data URIs such as `data:image/png;base64,-_8=`. Normalize `-` and `_` in the core media parser before the existing decoder, matching Python behavior and preserving standard Base64 and invalid-input handling. General Base64 utilities and OTel behavior are unchanged.

Impacted package: `@langfuse/core`, exposed through `@langfuse/client`. Regression coverage exercises the public client export, both alphabet characters independently and together, decoded bytes, canonical data URIs, content-derived IDs, standard input, and invalid characters/length/padding.

## Verification

- Reconfirmed JS main `d12f37bb6dfb75136122186fbdb2fc0e9da2a744` and Python main `8786515507c123e6e9ab40151d2e72f969149cef` and the Python alphabet normalization.
- Before fix: three URL-safe regression cases failed; standard and invalid cases passed.
- `pnpm exec vitest run tests/unit/media.test.ts tests/unit/mediaUpload.test.ts tests/unit/mediaReference.test.ts` — 19 passed.
- `pnpm test:unit` — 109 passed.
- `pnpm build`, `pnpm lint`, `pnpm typecheck` — passed (typecheck after building workspace packages).
- `pnpm exec prettier --check packages/core/src/media.ts tests/unit/media.test.ts` and `git diff --check` — passed.
- Local integration/E2E suites not run; this parser change requires no server. CI runs those suites.
